### PR TITLE
Improve mobile navigation and card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,15 +71,24 @@
       background: var(--primary);
       display: flex;
       align-items: center;
-      padding: 0 10px;
-      height: 60px;
+      gap: 8px;
+      padding: 8px 10px;
+      padding-top: calc(env(safe-area-inset-top, 0px) + 8px);
+      min-height: 60px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+    #navbar::-webkit-scrollbar {
+      display: none;
     }
     #navbar .logo {
       font-size: 1.4rem;
       font-weight: bold;
       letter-spacing: 1px;
-      margin-right: 20px;
+      margin-right: 12px;
+      flex-shrink: 0;
     }
     #navbar .nav-item {
       border: none;
@@ -93,6 +102,7 @@
       cursor: pointer;
       border-bottom: 3px solid transparent;
       transition: border-color 0.3s, color 0.3s;
+      flex: 0 0 auto;
     }
     #navbar .nav-item i {
       font-size: 1.1rem;
@@ -115,6 +125,7 @@
       cursor: pointer;
       padding: 10px;
       transition: color 0.3s;
+      flex: 0 0 auto;
     }
     .mode-btn:hover {
       color: var(--accent);
@@ -144,7 +155,7 @@
        ensure the content does not scroll underneath it. */
     #content {
       padding: 20px;
-      margin-top: 60px;
+      margin-top: 20px;
     }
     .page {
       display: none;
@@ -157,6 +168,72 @@
       justify-content: space-between;
       align-items: center;
       margin-bottom: 10px;
+    }
+
+    @media (max-width: 900px) {
+      #navbar .nav-item {
+        padding: 10px 12px;
+        font-size: 0.85rem;
+      }
+      .card-grid {
+        grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+      }
+    }
+
+    @media (max-width: 600px) {
+      #navbar {
+        gap: 6px;
+      }
+      #navbar .logo {
+        font-size: 1.1rem;
+        margin-right: 8px;
+      }
+      #content {
+        padding: 16px 12px 24px;
+      }
+      .page-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+      }
+      .search-bar {
+        max-width: none;
+      }
+      .card-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 14px;
+      }
+      body.kid-mode .card-grid {
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      }
+    }
+
+    @media (max-width: 480px) {
+      #navbar {
+        gap: 4px;
+      }
+      #navbar .nav-item {
+        padding: 8px 10px;
+        font-size: 0.8rem;
+      }
+      #navbar .nav-item i {
+        font-size: 1rem;
+      }
+      #content {
+        padding: 14px 10px 20px;
+      }
+      .card-grid {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 12px;
+      }
+      body.kid-mode .card-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      }
+      .pal-card img,
+      .item-card img {
+        width: 90px;
+        height: 90px;
+      }
     }
     .search-bar {
       width: 100%;


### PR DESCRIPTION
## Summary
- allow the top navigation bar to respect iPhone safe areas and become horizontally scrollable with touch momentum
- tighten spacing, typography, and grid sizing so cards, headers, and searches align cleanly on narrow screens
- add responsive breakpoints to keep kid mode and grown-up mode layouts readable on phones

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d8095c25a88331b353cffd774dcf56