### PR TITLE
Close modal when clicking outside

### DIFF
--- a/index.html
+++ b/index.html
@@ -1341,6 +1341,11 @@
     const modal = document.getElementById('modal');
     const modalBody = document.getElementById('modalBody');
     document.getElementById('modalClose').addEventListener('click', closeModal);
+    modal.addEventListener('click', event => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
     function openModal() {
       modal.classList.add('active');
       playSound(openSound);


### PR DESCRIPTION
## Summary
- close the modal when clicking on the backdrop so popups dismiss when clicking outside

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d837d50330833190456ed98ab76b2e