### PR TITLE
Refresh route guide with kid-friendly copy and tech data

### DIFF
--- a/data/palworld_complete_data_enhanced.json
+++ b/data/palworld_complete_data_enhanced.json
@@ -1,14385 +1,14784 @@
 {
-  "pals": {
-    "1": {
-      "id": 1,
-      "key": "1",
-      "name": "Lamball",
-      "wiki": "https://palworld.fandom.com/wiki/Lamball",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/01/Lamball_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1000,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "roly_poly",
-          "level": 1,
-          "power": 35,
-          "cooldown": 1.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "implode",
-          "level": 22,
-          "power": 180,
-          "cooldown": 55.0
-        },
-        {
-          "name": "electric_ball",
-          "level": 30,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wool",
-        "lamball_mutton"
-      ],
-      "breeding": {
-        "power": 1470,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/001_lamball.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Lamball"
-        ],
-        [
-          "Cattiva",
-          "Mau"
-        ],
-        [
-          "Chikipi",
-          "Mau Cryst"
-        ],
-        [
-          "Vixy",
-          "Teafant"
-        ],
-        [
-          "Teafant",
-          "Cremis"
-        ]
-      ]
-    },
-    "2": {
-      "id": 2,
-      "key": "2",
-      "name": "Cattiva",
-      "wiki": "https://palworld.fandom.com/wiki/Cattiva",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/51/Cattiva_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1000,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "gathering": 1,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "punch_flurry",
-          "level": 1,
-          "power": 40,
-          "cooldown": 1.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 30,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 40,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "red_berries"
-      ],
-      "breeding": {
-        "power": 1460,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/002_cattiva.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Vixy"
-        ],
-        [
-          "Cattiva",
-          "Cattiva"
-        ],
-        [
-          "Chikipi",
-          "Hangyu"
-        ],
-        [
-          "Lifmunk",
-          "Teafant"
-        ],
-        [
-          "Mau",
-          "Mau Cryst"
-        ]
-      ]
-    },
-    "3": {
-      "id": 3,
-      "key": "3",
-      "name": "Chikipi",
-      "wiki": "https://palworld.fandom.com/wiki/Chikipi",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/f4/Chikipi_menu.png/",
-      "genus": "bird",
-      "rarity": 1,
-      "price": 1000,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 70.0,
-        "defense": 60.0,
-        "speed": 375.0,
-        "stamina": 100.0,
-        "support": 70.0,
-        "food": 1.0
-      },
-      "work": {
-        "gathering": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "chicken_rush",
-          "level": 1,
-          "power": 30,
-          "cooldown": 1.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "implode",
-          "level": 22,
-          "power": 180,
-          "cooldown": 55.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 50,
-          "power": 80,
-          "cooldown": 18.0
-        }
-      ],
-      "drops": [
-        "egg",
-        "chikipi_poultry"
-      ],
-      "breeding": {
-        "power": 1500,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/003_chikipi.png",
-      "breedingCombos": [
-        [
-          "Chikipi",
-          "Chikipi"
-        ],
-        [
-          "Chikipi",
-          "Teafant"
-        ]
-      ]
-    },
-    "4": {
-      "id": 4,
-      "key": "4",
-      "name": "Lifmunk",
-      "wiki": "https://palworld.fandom.com/wiki/Lifmunk",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/dc/Lifmunk_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1010,
-      "size": "xs",
-      "stats": {
-        "hp": 75.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "lumbering": 1,
-        "medicine_production": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 22,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "berry_seeds",
-        "low_grade_medical_supplies"
-      ],
-      "breeding": {
-        "power": 1430,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/004_lifmunk.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Hoocrates"
-        ],
-        [
-          "Cattiva",
-          "Foxparks"
-        ],
-        [
-          "Chikipi",
-          "Jolthog Cryst"
-        ],
-        [
-          "Lifmunk",
-          "Lifmunk"
-        ],
-        [
-          "Sparkit",
-          "Vixy"
-        ]
-      ]
-    },
-    "5": {
-      "id": 5,
-      "key": "5",
-      "name": "Foxparks",
-      "wiki": "https://palworld.fandom.com/wiki/Foxparks",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d7/Foxparks_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1040,
-      "size": "xs",
-      "stats": {
-        "hp": 65.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "kindling": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 40,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 1400,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/005_foxparks.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Fuack"
-        ],
-        [
-          "Cattiva",
-          "Tocotoco"
-        ],
-        [
-          "Chikipi",
-          "Swee"
-        ],
-        [
-          "Lifmunk",
-          "Jolthog"
-        ],
-        [
-          "Foxparks",
-          "Foxparks"
-        ]
-      ]
-    },
-    "6": {
-      "id": 6,
-      "key": "6",
-      "name": "Fuack",
-      "wiki": "https://palworld.fandom.com/wiki/Fuack",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Fuack_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1120,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 80.0,
-        "defense": 60.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "watering": 1
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "hydro_jet",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 22,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 1330,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/006_fuack.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Woolipop"
-        ],
-        [
-          "Chikipi",
-          "Wixen"
-        ],
-        [
-          "Lifmunk",
-          "Daedream"
-        ],
-        [
-          "Foxparks",
-          "Kelpsea"
-        ],
-        [
-          "Fuack",
-          "Fuack"
-        ]
-      ]
-    },
-    "7": {
-      "id": 7,
-      "key": "7",
-      "name": "Sparkit",
-      "wiki": "https://palworld.fandom.com/wiki/Sparkit",
-      "image": "https://static.wikia.nocookie.net/palworld/images/c/ce/Sparkit_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1030,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 60.0,
-        "defense": 70.0,
-        "speed": 350.0,
-        "stamina": 100.0,
-        "support": 80.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "generating_electricity": 1
-      },
-      "skills": [
-        {
-          "name": "spark_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shockwave",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "electric_ball",
-          "level": 22,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 40,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 1410,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/007_sparkit.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Pengullet"
-        ],
-        [
-          "Cattiva",
-          "Jolthog Cryst"
-        ],
-        [
-          "Chikipi",
-          "Bristla"
-        ],
-        [
-          "Lifmunk",
-          "Hoocrates"
-        ],
-        [
-          "Foxparks",
-          "Hangyu"
-        ]
-      ]
-    },
-    "8": {
-      "id": 8,
-      "key": "8",
-      "name": "Tanzee",
-      "wiki": "https://palworld.fandom.com/wiki/Tanzee",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Tanzee_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1280,
-      "size": "xs",
-      "stats": {
-        "hp": 80.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "lumbering": 1,
-        "transporting": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 15,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "mushroom"
-      ],
-      "breeding": {
-        "power": 1250,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/008_tanzee.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Galeclaw"
-        ],
-        [
-          "Cattiva",
-          "Gorirat"
-        ],
-        [
-          "Chikipi",
-          "Robinquill Terra"
-        ],
-        [
-          "Lifmunk",
-          "Beegarde"
-        ],
-        [
-          "Foxparks",
-          "Gobfin Ignis"
-        ]
-      ]
-    },
-    "9": {
-      "id": 9,
-      "key": "9",
-      "name": "Rooby",
-      "wiki": "https://palworld.fandom.com/wiki/Rooby",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Rooby_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 2950,
-      "size": "s",
-      "stats": {
-        "hp": 75.0,
-        "attack": 100.0,
-        "defense": 75.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "kindling": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 1155,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/009_rooby.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Broncherry Aqua"
-        ],
-        [
-          "Cattiva",
-          "Digtoise"
-        ],
-        [
-          "Chikipi",
-          "Dinossom Lux"
-        ],
-        [
-          "Lifmunk",
-          "Reindrix"
-        ],
-        [
-          "Foxparks",
-          "Mozzarina"
-        ]
-      ]
-    },
-    "10": {
-      "id": 10,
-      "key": "10",
-      "name": "Pengullet",
-      "wiki": "https://palworld.fandom.com/wiki/Pengullet",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/38/Pengullet_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1080,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "watering": 1,
-        "cooling": 1
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "hydro_jet",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "ice_organ",
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 1350,
-        "type1": "Water",
-        "type2": "Ice"
-      },
-      "types": [
-        "Water",
-        "Ice"
-      ],
-      "localImage": "assets/pals/010_pengullet.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Daedream"
-        ],
-        [
-          "Cattiva",
-          "Gumoss"
-        ],
-        [
-          "Lifmunk",
-          "Kelpsea Ignis"
-        ],
-        [
-          "Foxparks",
-          "Swee"
-        ],
-        [
-          "Fuack",
-          "Jolthog"
-        ]
-      ]
-    },
-    "11": {
-      "id": 11,
-      "key": "11",
-      "name": "Penking",
-      "wiki": "https://palworld.fandom.com/wiki/Penking",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Penking_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 5410,
-      "size": "l",
-      "stats": {
-        "hp": 95.0,
-        "attack": 70.0,
-        "defense": 95.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "handiwork": 2,
-        "transporting": 2,
-        "watering": 2,
-        "mining": 2,
-        "cooling": 2
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "iceberg",
-          "level": 7,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "emperor_slide",
-          "level": 15,
-          "power": 70,
-          "cooldown": 10.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "ice_organ",
-        "penking_plume"
-      ],
-      "breeding": {
-        "power": 520,
-        "type1": "Water",
-        "type2": "Ice"
-      },
-      "types": [
-        "Water",
-        "Ice"
-      ],
-      "localImage": "assets/pals/011_penking.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Penking"
-        ],
-        [
-          "Mozzarina",
-          "Cryolinx"
-        ],
-        [
-          "Melpaca",
-          "Astegon"
-        ],
-        [
-          "Eikthyrdeer",
-          "Frostallion"
-        ],
-        [
-          "Nitewing",
-          "Vanwyrm Cryst"
-        ]
-      ]
-    },
-    "12": {
-      "id": 12,
-      "key": "12",
-      "name": "Jolthog",
-      "wiki": "https://palworld.fandom.com/wiki/Jolthog",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/52/Jolthog_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1060,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "generating_electricity": 1
-      },
-      "skills": [
-        {
-          "name": "shockwave",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "electric_ball",
-          "level": 15,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 40,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 1370,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/012_jolthog.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Kelpsea Ignis"
-        ],
-        [
-          "Cattiva",
-          "Flopie"
-        ],
-        [
-          "Chikipi",
-          "Gumoss"
-        ],
-        [
-          "Lifmunk",
-          "Ribbuny"
-        ],
-        [
-          "Foxparks",
-          "Tocotoco"
-        ]
-      ]
-    },
-    "13": {
-      "id": 13,
-      "key": "13",
-      "name": "Gumoss",
-      "wiki": "https://palworld.fandom.com/wiki/Gumoss",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/2e/Gumoss_menu.png/",
-      "genus": "other",
-      "rarity": 1,
-      "price": 1310,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "planting": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 22,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "berry_seeds",
-        "gumoss_leaf"
-      ],
-      "breeding": {
-        "power": 1240,
-        "type1": "Grass",
-        "type2": "Ground"
-      },
-      "types": [
-        "Grass",
-        "Ground"
-      ],
-      "localImage": "assets/pals/013_gumoss.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Felbat"
-        ],
-        [
-          "Cattiva",
-          "Robinquill"
-        ],
-        [
-          "Chikipi",
-          "Fenglope"
-        ],
-        [
-          "Lifmunk",
-          "Vaelet"
-        ],
-        [
-          "Foxparks",
-          "Cawgnito"
-        ]
-      ]
-    },
-    "14": {
-      "id": 14,
-      "key": "14",
-      "name": "Vixy",
-      "wiki": "https://palworld.fandom.com/wiki/Vixy",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/9e/Vixy_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 1000,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 350.0,
-        "stamina": 100.0,
-        "support": 140.0,
-        "food": 1.0
-      },
-      "work": {
-        "gathering": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 22,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 30,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "bone"
-      ],
-      "breeding": {
-        "power": 1450,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/014_vixy.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Lifmunk"
-        ],
-        [
-          "Cattiva",
-          "Mau Cryst"
-        ],
-        [
-          "Chikipi",
-          "Foxparks"
-        ],
-        [
-          "Sparkit",
-          "Teafant"
-        ],
-        [
-          "Vixy",
-          "Vixy"
-        ]
-      ]
-    },
-    "15": {
-      "id": 15,
-      "key": "15",
-      "name": "Hoocrates",
-      "wiki": "https://palworld.fandom.com/wiki/Hoocrates",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/ef/Hoocrates_menu.png/",
-      "genus": "bird",
-      "rarity": 1,
-      "price": 1050,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 80.0,
-        "speed": 380.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "fiber",
-        "high_grade_technical_manual"
-      ],
-      "breeding": {
-        "power": 1390,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/015_hoocrates.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Ribbuny"
-        ],
-        [
-          "Cattiva",
-          "Bristla"
-        ],
-        [
-          "Chikipi",
-          "Flopie"
-        ],
-        [
-          "Lifmunk",
-          "Pengullet"
-        ],
-        [
-          "Foxparks",
-          "Depresso"
-        ]
-      ]
-    },
-    "16": {
-      "id": 16,
-      "key": "16",
-      "name": "Teafant",
-      "wiki": "https://palworld.fandom.com/wiki/Teafant",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Teafant_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1000,
-      "size": "m",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "watering": 1
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "hydro_jet",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 1490,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/016_teafant.png",
-      "breedingCombos": [
-        [
-          "Chikipi",
-          "Mau"
-        ],
-        [
-          "Teafant",
-          "Teafant"
-        ],
-        [
-          "Lamball",
-          "Chikipi"
-        ],
-        [
-          "Teafant",
-          "Mau"
-        ]
-      ]
-    },
-    "17": {
-      "id": 17,
-      "key": "17",
-      "name": "Depresso",
-      "wiki": "https://palworld.fandom.com/wiki/Depresso",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d9/Depresso_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1050,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "poison_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 22,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "venom_gland"
-      ],
-      "breeding": {
-        "power": 1380,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/017_depresso.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Killamari"
-        ],
-        [
-          "Cattiva",
-          "Swee"
-        ],
-        [
-          "Chikipi",
-          "Kelpsea"
-        ],
-        [
-          "Lifmunk",
-          "Fuack"
-        ],
-        [
-          "Foxparks",
-          "Jolthog Cryst"
-        ]
-      ]
-    },
-    "18": {
-      "id": 18,
-      "key": "18",
-      "name": "Cremis",
-      "wiki": "https://palworld.fandom.com/wiki/Cremis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a1/Cremis_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1420,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 75.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "spark_blast",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shockwave",
-          "level": 30,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wool"
-      ],
-      "breeding": {
-        "power": 1455,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/018_cremis.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Mau Cryst"
-        ],
-        [
-          "Cattiva",
-          "Vixy"
-        ],
-        [
-          "Chikipi",
-          "Sparkit"
-        ],
-        [
-          "Lifmunk",
-          "Mau"
-        ],
-        [
-          "Teafant",
-          "Hangyu"
-        ]
-      ]
-    },
-    "19": {
-      "id": 19,
-      "key": "19",
-      "name": "Daedream",
-      "wiki": "https://palworld.fandom.com/wiki/Daedream",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/e6/Daedream_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1330,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 60.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "dark_ball",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "venom_gland",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 1230,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/019_daedream.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Verdash"
-        ],
-        [
-          "Cattiva",
-          "Robinquill Terra"
-        ],
-        [
-          "Lifmunk",
-          "Galeclaw"
-        ],
-        [
-          "Foxparks",
-          "Direhowl"
-        ],
-        [
-          "Fuack",
-          "Rushoar"
-        ]
-      ]
-    },
-    "20": {
-      "id": 20,
-      "key": "20",
-      "name": "Rushoar",
-      "wiki": "https://palworld.fandom.com/wiki/Rushoar",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d0/Rushoar_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1680,
-      "size": "s",
-      "stats": {
-        "hp": 80.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "reckless_charge",
-          "level": 1,
-          "power": 55,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "rushoar_pork",
-        "leather",
-        "bone"
-      ],
-      "breeding": {
-        "power": 1130,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/020_rushoar.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Arsox"
-        ],
-        [
-          "Cattiva",
-          "Chillet"
-        ],
-        [
-          "Chikipi",
-          "Foxcicle"
-        ],
-        [
-          "Lifmunk",
-          "Kitsun"
-        ],
-        [
-          "Foxparks",
-          "Broncherry"
-        ]
-      ]
-    },
-    "21": {
-      "id": 21,
-      "key": "21",
-      "name": "Nox",
-      "wiki": "https://palworld.fandom.com/wiki/Nox",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/55/Nox_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 1480,
-      "size": "xs",
-      "stats": {
-        "hp": 75.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 140.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 1180,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/021_nox.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Melpaca"
-        ],
-        [
-          "Cattiva",
-          "Eikthyrdeer Terra"
-        ],
-        [
-          "Chikipi",
-          "Broncherry"
-        ],
-        [
-          "Lifmunk",
-          "Caprity"
-        ],
-        [
-          "Fuack",
-          "Galeclaw"
-        ]
-      ]
-    },
-    "22": {
-      "id": 22,
-      "key": "22",
-      "name": "Fuddler",
-      "wiki": "https://palworld.fandom.com/wiki/Fuddler",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/64/Fuddler_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1360,
-      "size": "xs",
-      "stats": {
-        "hp": 65.0,
-        "attack": 100.0,
-        "defense": 50.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather"
-      ],
-      "breeding": {
-        "power": 1220,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/022_fuddler.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Fenglope"
-        ],
-        [
-          "Chikipi",
-          "Lovander"
-        ],
-        [
-          "Lifmunk",
-          "Felbat"
-        ],
-        [
-          "Foxparks",
-          "Gorirat"
-        ],
-        [
-          "Fuack",
-          "Lunaris"
-        ]
-      ]
-    },
-    "23": {
-      "id": 23,
-      "key": "23",
-      "name": "Killamari",
-      "wiki": "https://palworld.fandom.com/wiki/Killamari",
-      "image": "https://static.wikia.nocookie.net/palworld/images/8/80/Killamari_menu.png/",
-      "genus": "other",
-      "rarity": 1,
-      "price": 1200,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "transporting": 2,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "venom_gland"
-      ],
-      "breeding": {
-        "power": 1290,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/023_killamari.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Lunaris"
-        ],
-        [
-          "Cattiva",
-          "Leezpunk"
-        ],
-        [
-          "Chikipi",
-          "Cawgnito"
-        ],
-        [
-          "Lifmunk",
-          "Maraith"
-        ],
-        [
-          "Foxparks",
-          "Nox"
-        ]
-      ]
-    },
-    "24": {
-      "id": 24,
-      "key": "24",
-      "name": "Mau",
-      "wiki": "https://palworld.fandom.com/wiki/Mau",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/17/Mau_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 1,
-      "price": 1000,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 475.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "gold_coin"
-      ],
-      "breeding": {
-        "power": 1480,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/024_mau.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Teafant"
-        ],
-        [
-          "Cattiva",
-          "Chikipi"
-        ],
-        [
-          "Mau",
-          "Mau"
-        ],
-        [
-          "Chikipi",
-          "Cremis"
-        ]
-      ]
-    },
-    "25": {
-      "id": 25,
-      "key": "25",
-      "name": "Celaray",
-      "wiki": "https://palworld.fandom.com/wiki/Celaray",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/95/Celaray_menu.png/",
-      "genus": "other",
-      "rarity": 3,
-      "price": 2860,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "transporting": 1,
-        "watering": 1
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 30,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 870,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/025_celaray.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Cattiva",
-          "Relaxaurus"
-        ],
-        [
-          "Chikipi",
-          "Pyrin Noct"
-        ],
-        [
-          "Lifmunk",
-          "Jormuntide"
-        ],
-        [
-          "Foxparks",
-          "Warsect"
-        ]
-      ]
-    },
-    "26": {
-      "id": 26,
-      "key": "26",
-      "name": "Direhowl",
-      "wiki": "https://palworld.fandom.com/wiki/Direhowl",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/19/Direhowl_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 1920,
-      "size": "s",
-      "stats": {
-        "hp": 80.0,
-        "attack": 110.0,
-        "defense": 75.0,
-        "speed": 800.0,
-        "stamina": 70.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "fierce_fang",
-          "level": 1,
-          "power": 45,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 15,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ignis_blast",
-          "level": 30,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "ruby",
-        "gold_coin"
-      ],
-      "breeding": {
-        "power": 1060,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/026_direhowl.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Vanwyrm"
-        ],
-        [
-          "Chikipi",
-          "Vanwyrm Cryst"
-        ],
-        [
-          "Fuack",
-          "Arsox"
-        ],
-        [
-          "Sparkit",
-          "Blazehowl"
-        ],
-        [
-          "Tanzee",
-          "Celaray"
-        ]
-      ]
-    },
-    "27": {
-      "id": 27,
-      "key": "27",
-      "name": "Tocotoco",
-      "wiki": "https://palworld.fandom.com/wiki/Tocotoco",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Tocotoco_menu.png/",
-      "genus": "bird",
-      "rarity": 1,
-      "price": 1090,
-      "size": "s",
-      "stats": {
-        "hp": 60.0,
-        "attack": 80.0,
-        "defense": 70.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 70.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "implode",
-          "level": 1,
-          "power": 180,
-          "cooldown": 55.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "megaton_implode",
-          "level": 22,
-          "power": 250,
-          "cooldown": 55.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "gunpowder",
-        "tocotoco_feather"
-      ],
-      "breeding": {
-        "power": 1340,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/027_tocotoco.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Dazzi"
-        ],
-        [
-          "Cattiva",
-          "Fuddler"
-        ],
-        [
-          "Chikipi",
-          "Nox"
-        ],
-        [
-          "Lifmunk",
-          "Tanzee"
-        ],
-        [
-          "Foxparks",
-          "Flopie"
-        ]
-      ]
-    },
-    "28": {
-      "id": 28,
-      "key": "28",
-      "name": "Flopie",
-      "wiki": "https://palworld.fandom.com/wiki/Flopie",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Flopie_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1220,
-      "size": "xs",
-      "stats": {
-        "hp": 75.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "gathering": 1,
-        "medicine_production": 1,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "hydro_jet",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 22,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "low_grade_medical_supplies",
-        "wheat_seeds"
-      ],
-      "breeding": {
-        "power": 1280,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/028_flopie.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Gobfin"
-        ],
-        [
-          "Cattiva",
-          "Gobfin Ignis"
-        ],
-        [
-          "Chikipi",
-          "Direhowl"
-        ],
-        [
-          "Lifmunk",
-          "Rushoar"
-        ],
-        [
-          "Foxparks",
-          "Wixen"
-        ]
-      ]
-    },
-    "29": {
-      "id": 29,
-      "key": "29",
-      "name": "Mozzarina",
-      "wiki": "https://palworld.fandom.com/wiki/Mozzarina",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/3a/Mozzarina_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 2620,
-      "size": "s",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 580.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 15,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "mozzarina_meat",
-        "milk"
-      ],
-      "breeding": {
-        "power": 910,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/029_mozzarina.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Quivern"
-        ],
-        [
-          "Cattiva",
-          "Pyrin"
-        ],
-        [
-          "Chikipi",
-          "Reptyro"
-        ],
-        [
-          "Lifmunk",
-          "Mossanda Lux"
-        ],
-        [
-          "Foxparks",
-          "Nitewing"
-        ]
-      ]
-    },
-    "30": {
-      "id": 30,
-      "key": "30",
-      "name": "Bristla",
-      "wiki": "https://palworld.fandom.com/wiki/Bristla",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Bristla_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1140,
-      "size": "s",
-      "stats": {
-        "hp": 80.0,
-        "attack": 80.0,
-        "defense": 80.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "medicine_production": 2,
-        "transporting": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 15,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wheat_seeds",
-        "lettuce_seeds"
-      ],
-      "breeding": {
-        "power": 1320,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/030_bristla.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Nox"
-        ],
-        [
-          "Chikipi",
-          "Leezpunk Ignis"
-        ],
-        [
-          "Lifmunk",
-          "Dazzi"
-        ],
-        [
-          "Foxparks",
-          "Gumoss"
-        ],
-        [
-          "Fuack",
-          "Ribbuny"
-        ]
-      ]
-    },
-    "31": {
-      "id": 31,
-      "key": "31",
-      "name": "Gobfin",
-      "wiki": "https://palworld.fandom.com/wiki/Gobfin",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/ff/Gobfin_menu.png/",
-      "genus": "humanoid",
-      "rarity": 2,
-      "price": 1840,
-      "size": "s",
-      "stats": {
-        "hp": 90.0,
-        "attack": 90.0,
-        "defense": 75.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "watering": 2
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 1090,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/031_gobfin.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Blazehowl"
-        ],
-        [
-          "Chikipi",
-          "Univolt"
-        ],
-        [
-          "Lifmunk",
-          "Tombat"
-        ],
-        [
-          "Foxparks",
-          "Petallia"
-        ],
-        [
-          "Fuack",
-          "Digtoise"
-        ]
-      ]
-    },
-    "32": {
-      "id": 32,
-      "key": "32",
-      "name": "Hangyu",
-      "wiki": "https://palworld.fandom.com/wiki/Hangyu",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/08/Hangyu_menu.png/",
-      "genus": "other",
-      "rarity": 1,
-      "price": 1020,
-      "size": "xs",
-      "stats": {
-        "hp": 80.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 2,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "fiber"
-      ],
-      "breeding": {
-        "power": 1420,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/032_hangyu.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Jolthog"
-        ],
-        [
-          "Cattiva",
-          "Depresso"
-        ],
-        [
-          "Chikipi",
-          "Tocotoco"
-        ],
-        [
-          "Lifmunk",
-          "Sparkit"
-        ],
-        [
-          "Foxparks",
-          "Mau Cryst"
-        ]
-      ]
-    },
-    "33": {
-      "id": 33,
-      "key": "33",
-      "name": "Mossanda",
-      "wiki": "https://palworld.fandom.com/wiki/Mossanda",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Mossanda_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 6200,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "planting": 2,
-        "handiwork": 2,
-        "lumbering": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "crushing_punch",
-          "level": 22,
-          "power": 85,
-          "cooldown": 18.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "mushroom",
-        "leather",
-        "tomato_seeds"
-      ],
-      "breeding": {
-        "power": 430,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/033_mossanda.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Warsect"
-        ],
-        [
-          "Mossanda",
-          "Mossanda"
-        ],
-        [
-          "Nitewing",
-          "Ice Kingpaca"
-        ],
-        [
-          "Incineram",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Cinnamoth",
-          "Faleris"
-        ]
-      ]
-    },
-    "34": {
-      "id": 34,
-      "key": "34",
-      "name": "Woolipop",
-      "wiki": "https://palworld.fandom.com/wiki/Woolipop",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/fa/Woolipop_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 3,
-      "price": 1450,
-      "size": "s",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 90.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 22,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "cotton_candy",
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 1190,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/034_woolipop.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Mozzarina"
-        ],
-        [
-          "Cattiva",
-          "Eikthyrdeer"
-        ],
-        [
-          "Chikipi",
-          "Reindrix"
-        ],
-        [
-          "Lifmunk",
-          "Loupmoon"
-        ],
-        [
-          "Foxparks",
-          "Fenglope"
-        ]
-      ]
-    },
-    "35": {
-      "id": 35,
-      "key": "35",
-      "name": "Caprity",
-      "wiki": "https://palworld.fandom.com/wiki/Caprity",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Caprity_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 3,
-      "price": 2510,
-      "size": "s",
-      "stats": {
-        "hp": 100.0,
-        "attack": 70.0,
-        "defense": 90.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 120.0,
-        "food": 4.0
-      },
-      "work": {
-        "planting": 2,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "caprity_meat",
-        "red_berries",
-        "horn"
-      ],
-      "breeding": {
-        "power": 930,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/035_caprity.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Mossanda Lux"
-        ],
-        [
-          "Chikipi",
-          "Pyrin"
-        ],
-        [
-          "Lifmunk",
-          "Mossanda"
-        ],
-        [
-          "Foxparks",
-          "Wumpo"
-        ],
-        [
-          "Fuack",
-          "Elphidran Aqua"
-        ]
-      ]
-    },
-    "36": {
-      "id": 36,
-      "key": "36",
-      "name": "Melpaca",
-      "wiki": "https://palworld.fandom.com/wiki/Melpaca",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7f/Melpaca_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 3,
-      "price": 2740,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 90.0,
-        "defense": 90.0,
-        "speed": 460.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "fluffy_tackle",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 22,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shockwave",
-          "level": 30,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wool",
-        "leather"
-      ],
-      "breeding": {
-        "power": 890,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/036_melpaca.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Jormuntide"
-        ],
-        [
-          "Cattiva",
-          "Reptyro"
-        ],
-        [
-          "Chikipi",
-          "Relaxaurus"
-        ],
-        [
-          "Lifmunk",
-          "Quivern"
-        ],
-        [
-          "Foxparks",
-          "Ragnahawk"
-        ]
-      ]
-    },
-    "37": {
-      "id": 37,
-      "key": "37",
-      "name": "Eikthyrdeer",
-      "wiki": "https://palworld.fandom.com/wiki/Eikthyrdeer",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Eikthyrdeer_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 4,
-      "price": 2620,
-      "size": "l",
-      "stats": {
-        "hp": 95.0,
-        "attack": 70.0,
-        "defense": 80.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "antler_uppercut",
-          "level": 7,
-          "power": 50,
-          "cooldown": 5.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "eikthyrdeer_venison",
-        "leather",
-        "horn"
-      ],
-      "breeding": {
-        "power": 920,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/037_eikthyrdeer.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Faleris"
-        ],
-        [
-          "Cattiva",
-          "Ragnahawk"
-        ],
-        [
-          "Chikipi",
-          "Warsect"
-        ],
-        [
-          "Lifmunk",
-          "Sweepa"
-        ],
-        [
-          "Foxparks",
-          "Ice Kingpaca"
-        ]
-      ]
-    },
-    "38": {
-      "id": 38,
-      "key": "38",
-      "name": "Nitewing",
-      "wiki": "https://palworld.fandom.com/wiki/Nitewing",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/34/Nitewing_menu.png/",
-      "genus": "bird",
-      "rarity": 3,
-      "price": 6300,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "tornado_attack",
-          "level": 7,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather"
-      ],
-      "breeding": {
-        "power": 420,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/038_nitewing.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Reptyro"
-        ],
-        [
-          "Mossanda",
-          "Sweepa"
-        ],
-        [
-          "Nitewing",
-          "Nitewing"
-        ],
-        [
-          "Incineram",
-          "Lyleen"
-        ],
-        [
-          "Cinnamoth",
-          "Quivern"
-        ]
-      ]
-    },
-    "39": {
-      "id": 39,
-      "key": "39",
-      "name": "Ribbuny",
-      "wiki": "https://palworld.fandom.com/wiki/Ribbuny",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7e/Ribbuny_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 1160,
-      "size": "xs",
-      "stats": {
-        "hp": 75.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 245.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 15,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 22,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "iceberg",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "beautiful_flower"
-      ],
-      "breeding": {
-        "power": 1310,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/039_ribbuny.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Maraith"
-        ],
-        [
-          "Cattiva",
-          "Wixen"
-        ],
-        [
-          "Chikipi",
-          "Leezpunk"
-        ],
-        [
-          "Lifmunk",
-          "Woolipop"
-        ],
-        [
-          "Foxparks",
-          "Fuddler"
-        ]
-      ]
-    },
-    "40": {
-      "id": 40,
-      "key": "40",
-      "name": "Incineram",
-      "wiki": "https://palworld.fandom.com/wiki/Incineram",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Incineram_menu.png/",
-      "genus": "humanoid",
-      "rarity": 4,
-      "price": 4780,
-      "size": "m",
-      "stats": {
-        "hp": 95.0,
-        "attack": 150.0,
-        "defense": 85.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "kindling": 1,
-        "handiwork": 2,
-        "transporting": 2,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "hellfire_claw",
-          "level": 22,
-          "power": 70,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 50,
-          "power": 120,
-          "cooldown": 40.0
-        }
-      ],
-      "drops": [
-        "horn",
-        "leather"
-      ],
-      "breeding": {
-        "power": 590,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/040_incineram.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Vanwyrm"
-        ],
-        [
-          "Rushoar",
-          "Suzaku"
-        ],
-        [
-          "Celaray",
-          "Jormuntide"
-        ],
-        [
-          "Direhowl",
-          "Frostallion"
-        ],
-        [
-          "Mozzarina",
-          "Relaxaurus Lux"
-        ]
-      ]
-    },
-    "41": {
-      "id": 41,
-      "key": "41",
-      "name": "Cinnamoth",
-      "wiki": "https://palworld.fandom.com/wiki/Cinnamoth",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7e/Cinnamoth_menu.png/",
-      "genus": "bird",
-      "rarity": 4,
-      "price": 5700,
-      "size": "m",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "planting": 2,
-        "medicine_production": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_fog",
-          "level": 15,
-          "power": 0,
-          "cooldown": 30.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 30,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "honey",
-        "lettuce_seeds",
-        "wheat_seeds"
-      ],
-      "breeding": {
-        "power": 490,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/041_cinnamoth.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Wumpo"
-        ],
-        [
-          "Mozzarina",
-          "Necromus"
-        ],
-        [
-          "Mossanda",
-          "Surfent Terra"
-        ],
-        [
-          "Caprity",
-          "Suzaku"
-        ],
-        [
-          "Melpaca",
-          "Jetragon"
-        ]
-      ]
-    },
-    "42": {
-      "id": 42,
-      "key": "42",
-      "name": "Arsox",
-      "wiki": "https://palworld.fandom.com/wiki/Arsox",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/f5/Arsox_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 4,
-      "price": 3520,
-      "size": "m",
-      "stats": {
-        "hp": 85.0,
-        "attack": 100.0,
-        "defense": 95.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "kindling": 2,
-        "lumbering": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "blazing_horn",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "horn",
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 790,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/042_arsox.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Frostallion"
-        ],
-        [
-          "Chikipi",
-          "Paladius"
-        ],
-        [
-          "Lifmunk",
-          "Astegon"
-        ],
-        [
-          "Fuack",
-          "Lyleen"
-        ],
-        [
-          "Tanzee",
-          "Elizabee"
-        ]
-      ]
-    },
-    "43": {
-      "id": 43,
-      "key": "43",
-      "name": "Dumud",
-      "wiki": "https://palworld.fandom.com/wiki/Dumud",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Dumud_menu.png/",
-      "genus": "fish",
-      "rarity": 4,
-      "price": 4690,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 95.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "watering": 1,
-        "mining": 2,
-        "transporting": 1
-      },
-      "skills": [],
-      "drops": [
-        "raw_dumud",
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 895,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/043_dumud.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Reptyro"
-        ],
-        [
-          "Cattiva",
-          "Elizabee"
-        ],
-        [
-          "Chikipi",
-          "Mammorest Cryst"
-        ],
-        [
-          "Lifmunk",
-          "Pyrin"
-        ],
-        [
-          "Foxparks",
-          "Mossanda Lux"
-        ]
-      ]
-    },
-    "44": {
-      "id": 44,
-      "key": "44",
-      "name": "Cawgnito",
-      "wiki": "https://palworld.fandom.com/wiki/Cawgnito",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/f6/Cawgnito_menu.png/",
-      "genus": "bird",
-      "rarity": 3,
-      "price": 1840,
-      "size": "m",
-      "stats": {
-        "hp": 75.0,
-        "attack": 80.0,
-        "defense": 80.0,
-        "speed": 920.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "lumbering": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "phantom_peck",
-          "level": 15,
-          "power": 55,
-          "cooldown": 7.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "venom_gland",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 1080,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/044_cawgnito.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Katress"
-        ],
-        [
-          "Chikipi",
-          "Vanwyrm"
-        ],
-        [
-          "Foxparks",
-          "Foxcicle"
-        ],
-        [
-          "Fuack",
-          "Kitsun"
-        ],
-        [
-          "Sparkit",
-          "Tombat"
-        ]
-      ]
-    },
-    "45": {
-      "id": 45,
-      "key": "45",
-      "name": "Leezpunk",
-      "wiki": "https://palworld.fandom.com/wiki/Leezpunk",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/09/Leezpunk_menu.png/",
-      "genus": "humanoid",
-      "rarity": 2,
-      "price": 1720,
-      "size": "s",
-      "stats": {
-        "hp": 80.0,
-        "attack": 90.0,
-        "defense": 50.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "handiwork": 1,
-        "gathering": 1,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "poison_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "copper_key",
-        "silver_key"
-      ],
-      "breeding": {
-        "power": 1120,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/045_leezpunk.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Petallia"
-        ],
-        [
-          "Chikipi",
-          "Rayhound"
-        ],
-        [
-          "Lifmunk",
-          "Dinossom Lux"
-        ],
-        [
-          "Foxparks",
-          "Broncherry Aqua"
-        ],
-        [
-          "Fuack",
-          "Mozzarina"
-        ]
-      ]
-    },
-    "46": {
-      "id": 46,
-      "key": "46",
-      "name": "Loupmoon",
-      "wiki": "https://palworld.fandom.com/wiki/Loupmoon",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/00/Loupmoon_menu.png/",
-      "genus": "humanoid",
-      "rarity": 3,
-      "price": 2400,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 130.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "handiwork": 2
-      },
-      "skills": [
-        {
-          "name": "dark_ball",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "jumping_claw",
-          "level": 7,
-          "power": 55,
-          "cooldown": 7.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone"
-      ],
-      "breeding": {
-        "power": 950,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/046_loupmoon.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Mossanda"
-        ],
-        [
-          "Cattiva",
-          "Ice Kingpaca"
-        ],
-        [
-          "Lifmunk",
-          "Kingpaca"
-        ],
-        [
-          "Foxparks",
-          "Azurobe"
-        ],
-        [
-          "Fuack",
-          "Anubis"
-        ]
-      ]
-    },
-    "47": {
-      "id": 47,
-      "key": "47",
-      "name": "Galeclaw",
-      "wiki": "https://palworld.fandom.com/wiki/Galeclaw",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/08/Galeclaw_menu.png/",
-      "genus": "bird",
-      "rarity": 2,
-      "price": 2010,
-      "size": "m",
-      "stats": {
-        "hp": 75.0,
-        "attack": 120.0,
-        "defense": 60.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "gale_claw",
-          "level": 1,
-          "power": 60,
-          "cooldown": 8.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 22,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "galeclaw_poultry",
-        "leather"
-      ],
-      "breeding": {
-        "power": 1030,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/047_galeclaw.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Incineram"
-        ],
-        [
-          "Chikipi",
-          "Surfent"
-        ],
-        [
-          "Foxparks",
-          "Vanwyrm"
-        ],
-        [
-          "Tanzee",
-          "Dinossom Lux"
-        ],
-        [
-          "Pengullet",
-          "Blazehowl"
-        ]
-      ]
-    },
-    "48": {
-      "id": 48,
-      "key": "48",
-      "name": "Robinquill",
-      "wiki": "https://palworld.fandom.com/wiki/Robinquill",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/bb/Robinquill_menu.png/",
-      "genus": "humanoid",
-      "rarity": 5,
-      "price": 2050,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 2,
-        "lumbering": 1,
-        "medicine_production": 1,
-        "transporting": 2,
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "focus_shot",
-          "level": 15,
-          "power": 65,
-          "cooldown": 9.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wheat_seeds",
-        "arrow"
-      ],
-      "breeding": {
-        "power": 1020,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/048_robinquill.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Anubis"
-        ],
-        [
-          "Cattiva",
-          "Incineram Noct"
-        ],
-        [
-          "Chikipi",
-          "Elphidran"
-        ],
-        [
-          "Foxparks",
-          "Bushi"
-        ],
-        [
-          "Fuack",
-          "Blazehowl"
-        ]
-      ]
-    },
-    "49": {
-      "id": 49,
-      "key": "49",
-      "name": "Gorirat",
-      "wiki": "https://palworld.fandom.com/wiki/Gorirat",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Gorirat_menu.png/",
-      "genus": "humanoid",
-      "rarity": 5,
-      "price": 2010,
-      "size": "s",
-      "stats": {
-        "hp": 90.0,
-        "attack": 110.0,
-        "defense": 90.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "handiwork": 1,
-        "lumbering": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ground_pound",
-          "level": 15,
-          "power": 85,
-          "cooldown": 14.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 30,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "bone"
-      ],
-      "breeding": {
-        "power": 1040,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/049_gorirat.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Vanwyrm Cryst"
-        ],
-        [
-          "Chikipi",
-          "Incineram Noct"
-        ],
-        [
-          "Foxparks",
-          "Univolt"
-        ],
-        [
-          "Fuack",
-          "Tombat"
-        ],
-        [
-          "Sparkit",
-          "Blazehowl Noct"
-        ]
-      ]
-    },
-    "50": {
-      "id": 50,
-      "key": "50",
-      "name": "Beegarde",
-      "wiki": "https://palworld.fandom.com/wiki/Beegarde",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7b/Beegarde_menu.png/",
-      "genus": "humanoid",
-      "rarity": 4,
-      "price": 1880,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "lumbering": 1,
-        "medicine_production": 1,
-        "transporting": 2,
-        "gathering": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "bee_quiet",
-          "level": 15,
-          "power": 200,
-          "cooldown": 55.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 22,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "honey"
-      ],
-      "breeding": {
-        "power": 1070,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/050_beegarde.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Blazehowl Noct"
-        ],
-        [
-          "Cattiva",
-          "Univolt"
-        ],
-        [
-          "Chikipi",
-          "Bushi"
-        ],
-        [
-          "Lifmunk",
-          "Blazehowl"
-        ],
-        [
-          "Foxparks",
-          "Rayhound"
-        ]
-      ]
-    },
-    "51": {
-      "id": 51,
-      "key": "51",
-      "name": "Elizabee",
-      "wiki": "https://palworld.fandom.com/wiki/Elizabee",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Elizabee_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 6830,
-      "size": "l",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "planting": 2,
-        "handiwork": 2,
-        "lumbering": 1,
-        "medicine_production": 2,
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spinning_lance",
-          "level": 22,
-          "power": 70,
-          "cooldown": 9.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "honey",
-        "elizabee's_staff"
-      ],
-      "breeding": {
-        "power": 330,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/051_elizabee.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Orserk"
-        ],
-        [
-          "Mossanda",
-          "Ice Reptyro"
-        ],
-        [
-          "Nitewing",
-          "Pyrin Noct"
-        ],
-        [
-          "Incineram",
-          "Necromus"
-        ],
-        [
-          "Elizabee",
-          "Elizabee"
-        ]
-      ]
-    },
-    "52": {
-      "id": 52,
-      "key": "52",
-      "name": "Grintale",
-      "wiki": "https://palworld.fandom.com/wiki/Grintale",
-      "image": "https://static.wikia.nocookie.net/palworld/images/c/c3/Grintale_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 5510,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "cat_press",
-          "level": 15,
-          "power": 60,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 510,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/052_grintale.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Azurobe"
-        ],
-        [
-          "Celaray",
-          "Astegon"
-        ],
-        [
-          "Mossanda",
-          "Incineram"
-        ],
-        [
-          "Caprity",
-          "Jetragon"
-        ],
-        [
-          "Melpaca",
-          "Cryolinx"
-        ]
-      ]
-    },
-    "53": {
-      "id": 53,
-      "key": "53",
-      "name": "Swee",
-      "wiki": "https://palworld.fandom.com/wiki/Swee",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Swee_menu.png/",
-      "genus": "other",
-      "rarity": 1,
-      "price": 1180,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 100.0,
-        "defense": 60.0,
-        "speed": 250.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1,
-        "cooling": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "wool"
-      ],
-      "breeding": {
-        "power": 1300,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/053_swee.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Rushoar"
-        ],
-        [
-          "Cattiva",
-          "Leezpunk Ignis"
-        ],
-        [
-          "Chikipi",
-          "Gobfin Ignis"
-        ],
-        [
-          "Fuack",
-          "Kelpsea Ignis"
-        ],
-        [
-          "Sparkit",
-          "Woolipop"
-        ]
-      ]
-    },
-    "54": {
-      "id": 54,
-      "key": "54",
-      "name": "Sweepa",
-      "wiki": "https://palworld.fandom.com/wiki/Sweepa",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/f3/Sweepa_menu.png/",
-      "genus": "other",
-      "rarity": 6,
-      "price": 6400,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 2,
-        "cooling": 2
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "wool"
-      ],
-      "breeding": {
-        "power": 410,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/054_sweepa.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Mammorest"
-        ],
-        [
-          "Mossanda",
-          "Mossanda Lux"
-        ],
-        [
-          "Incineram",
-          "Ice Reptyro"
-        ],
-        [
-          "Cinnamoth",
-          "Elizabee"
-        ],
-        [
-          "Arsox",
-          "Suzaku Aqua"
-        ]
-      ]
-    },
-    "55": {
-      "id": 55,
-      "key": "55",
-      "name": "Chillet",
-      "wiki": "https://palworld.fandom.com/wiki/Chillet",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/49/Chillet_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 4,
-      "price": 3450,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 1,
-        "cooling": 1
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather"
-      ],
-      "breeding": {
-        "power": 800,
-        "type1": "Ice",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Ice",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/055_chillet.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Cryolinx"
-        ],
-        [
-          "Cattiva",
-          "Orserk"
-        ],
-        [
-          "Chikipi",
-          "Frostallion Noct"
-        ],
-        [
-          "Foxparks",
-          "Grizzbolt"
-        ],
-        [
-          "Fuack",
-          "Relaxaurus Lux"
-        ]
-      ]
-    },
-    "56": {
-      "id": 56,
-      "key": "56",
-      "name": "Univolt",
-      "wiki": "https://palworld.fandom.com/wiki/Univolt",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/0e/Univolt_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 5,
-      "price": 4280,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 110.0,
-        "defense": 105.0,
-        "speed": 720.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "generating_electricity": 2,
-        "lumbering": 1
-      },
-      "skills": [
-        {
-          "name": "spark_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "lock-on_laser",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "electric_organ",
-        "horn"
-      ],
-      "breeding": {
-        "power": 680,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/056_univolt.png",
-      "breedingCombos": [
-        [
-          "Fuack",
-          "Suzaku Aqua"
-        ],
-        [
-          "Pengullet",
-          "Blazamut"
-        ],
-        [
-          "Penking",
-          "Broncherry Aqua"
-        ],
-        [
-          "Gumoss",
-          "Frostallion"
-        ],
-        [
-          "Daedream",
-          "Cryolinx"
-        ]
-      ]
-    },
-    "57": {
-      "id": 57,
-      "key": "57",
-      "name": "Foxcicle",
-      "wiki": "https://palworld.fandom.com/wiki/Foxcicle",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Foxcicle_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 5,
-      "price": 3730,
-      "size": "s",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 105.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "cooling": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 760,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/057_foxcicle.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Suzaku"
-        ],
-        [
-          "Cattiva",
-          "Shadowbeak"
-        ],
-        [
-          "Lifmunk",
-          "Jetragon"
-        ],
-        [
-          "Foxparks",
-          "Frostallion"
-        ],
-        [
-          "Fuack",
-          "Helzephyr"
-        ]
-      ]
-    },
-    "58": {
-      "id": 58,
-      "key": "58",
-      "name": "Pyrin",
-      "wiki": "https://palworld.fandom.com/wiki/Pyrin",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/e6/Pyrin_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 6720,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 110.0,
-        "defense": 90.0,
-        "speed": 850.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "kindling": 2,
-        "lumbering": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ignis_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_slam",
-          "level": 30,
-          "power": 85,
-          "cooldown": 14.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 360,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/058_pyrin.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Grizzbolt"
-        ],
-        [
-          "Mossanda",
-          "Mammorest Cryst"
-        ],
-        [
-          "Nitewing",
-          "Mammorest"
-        ],
-        [
-          "Incineram",
-          "Cryolinx"
-        ],
-        [
-          "Cinnamoth",
-          "Ice Reptyro"
-        ]
-      ]
-    },
-    "59": {
-      "id": 59,
-      "key": "59",
-      "name": "Reindrix",
-      "wiki": "https://palworld.fandom.com/wiki/Reindrix",
-      "image": "https://static.wikia.nocookie.net/palworld/images/c/c1/Reindrix_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 4,
-      "price": 2800,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 80.0,
-        "defense": 110.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "lumbering": 2,
-        "cooling": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "freezing_charge",
-          "level": 22,
-          "power": 65,
-          "cooldown": 9.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "reindrix_venison",
-        "leather",
-        "horn",
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 880,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/059_reindrix.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Mammorest Cryst"
-        ],
-        [
-          "Cattiva",
-          "Mammorest"
-        ],
-        [
-          "Chikipi",
-          "Menasting"
-        ],
-        [
-          "Lifmunk",
-          "Elizabee"
-        ],
-        [
-          "Foxparks",
-          "Pyrin"
-        ]
-      ]
-    },
-    "60": {
-      "id": 60,
-      "key": "60",
-      "name": "Rayhound",
-      "wiki": "https://palworld.fandom.com/wiki/Rayhound",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/3f/Rayhound_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 5,
-      "price": 3880,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "generating_electricity": 2
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shockwave",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "spark_blast",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "electric_ball",
-          "level": 30,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 40,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 740,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/060_rayhound.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Blazamut"
-        ],
-        [
-          "Lifmunk",
-          "Suzaku"
-        ],
-        [
-          "Foxparks",
-          "Paladius"
-        ],
-        [
-          "Fuack",
-          "Astegon"
-        ],
-        [
-          "Sparkit",
-          "Necromus"
-        ]
-      ]
-    },
-    "61": {
-      "id": 61,
-      "key": "61",
-      "name": "Kitsun",
-      "wiki": "https://palworld.fandom.com/wiki/Kitsun",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/6b/Kitsun_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 3170,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 70.0,
-        "defense": 100.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 110.0,
-        "food": 4.0
-      },
-      "work": {
-        "kindling": 2
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 15,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "daring_flames",
-          "level": 22,
-          "power": 75,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 830,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/061_kitsun.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Helzephyr"
-        ],
-        [
-          "Cattiva",
-          "Grizzbolt"
-        ],
-        [
-          "Lifmunk",
-          "Ice Reptyro"
-        ],
-        [
-          "Foxparks",
-          "Menasting"
-        ],
-        [
-          "Fuack",
-          "Elizabee"
-        ]
-      ]
-    },
-    "62": {
-      "id": 62,
-      "key": "62",
-      "name": "Dazzi",
-      "wiki": "https://palworld.fandom.com/wiki/Dazzi",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b0/Dazzi_menu.png/",
-      "genus": "humanoid",
-      "rarity": 2,
-      "price": 1390,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 110.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "generating_electricity": 1,
-        "handiwork": 1,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 15,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 1210,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/062_dazzi.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Loupmoon"
-        ],
-        [
-          "Chikipi",
-          "Eikthyrdeer"
-        ],
-        [
-          "Lifmunk",
-          "Verdash"
-        ],
-        [
-          "Foxparks",
-          "Robinquill"
-        ],
-        [
-          "Fuack",
-          "Gobfin"
-        ]
-      ]
-    },
-    "63": {
-      "id": 63,
-      "key": "63",
-      "name": "Lunaris",
-      "wiki": "https://palworld.fandom.com/wiki/Lunaris",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/38/Lunaris_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 1760,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 80.0,
-        "defense": 90.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1,
-        "transporting": 1,
-        "handiwork": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "plasma_tornado",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "paldium_fragment"
-      ],
-      "breeding": {
-        "power": 1110,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/063_lunaris.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Tombat"
-        ],
-        [
-          "Cattiva",
-          "Foxcicle"
-        ],
-        [
-          "Lifmunk",
-          "Arsox"
-        ],
-        [
-          "Foxparks",
-          "Dinossom"
-        ],
-        [
-          "Fuack",
-          "Melpaca"
-        ]
-      ]
-    },
-    "64": {
-      "id": 64,
-      "key": "64",
-      "name": "Dinossom",
-      "wiki": "https://palworld.fandom.com/wiki/Dinossom",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b7/Dinossom_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 3240,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 90.0,
-        "defense": 90.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 150.0,
-        "food": 6.0
-      },
-      "work": {
-        "planting": 2,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "botanical_smash",
-          "level": 7,
-          "power": 60,
-          "cooldown": 8.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wheat_seeds"
-      ],
-      "breeding": {
-        "power": 820,
-        "type1": "Grass",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Grass",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/064_dinossom.png",
-      "breedingCombos": [
-        [
-          "Chikipi",
-          "Orserk"
-        ],
-        [
-          "Lifmunk",
-          "Lyleen Noct"
-        ],
-        [
-          "Foxparks",
-          "Pyrin Noct"
-        ],
-        [
-          "Fuack",
-          "Jormuntide"
-        ],
-        [
-          "Sparkit",
-          "Ice Reptyro"
-        ]
-      ]
-    },
-    "65": {
-      "id": 65,
-      "key": "65",
-      "name": "Surfent",
-      "wiki": "https://palworld.fandom.com/wiki/Surfent",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/1d/Surfent_menu.png/",
-      "genus": "fish",
-      "rarity": 4,
-      "price": 5050,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 70.0,
-        "defense": 80.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "watering": 2
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 560,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/065_surfent.png",
-      "breedingCombos": [
-        [
-          "Celaray",
-          "Lyleen"
-        ],
-        [
-          "Direhowl",
-          "Shadowbeak"
-        ],
-        [
-          "Mozzarina",
-          "Lyleen Noct"
-        ],
-        [
-          "Gobfin",
-          "Suzaku Aqua"
-        ],
-        [
-          "Caprity",
-          "Helzephyr"
-        ]
-      ]
-    },
-    "66": {
-      "id": 66,
-      "key": "66",
-      "name": "Maraith",
-      "wiki": "https://palworld.fandom.com/wiki/Maraith",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Maraith_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 1570,
-      "size": "m",
-      "stats": {
-        "hp": 75.0,
-        "attack": 50.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 2,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 1150,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/066_maraith.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Kitsun"
-        ],
-        [
-          "Cattiva",
-          "Broncherry Aqua"
-        ],
-        [
-          "Chikipi",
-          "Chillet"
-        ],
-        [
-          "Lifmunk",
-          "Celaray"
-        ],
-        [
-          "Foxparks",
-          "Eikthyrdeer Terra"
-        ]
-      ]
-    },
-    "67": {
-      "id": 67,
-      "key": "67",
-      "name": "Digtoise",
-      "wiki": "https://palworld.fandom.com/wiki/Digtoise",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Digtoise_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 5,
-      "price": 2980,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 80.0,
-        "defense": 120.0,
-        "speed": 300.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "mining": 3
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shell_spin",
-          "level": 15,
-          "power": 65,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "ore",
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 850,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/067_digtoise.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Ice Reptyro"
-        ],
-        [
-          "Cattiva",
-          "Pyrin Noct"
-        ],
-        [
-          "Chikipi",
-          "Grizzbolt"
-        ],
-        [
-          "Lifmunk",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Foxparks",
-          "Mammorest"
-        ]
-      ]
-    },
-    "68": {
-      "id": 68,
-      "key": "68",
-      "name": "Tombat",
-      "wiki": "https://palworld.fandom.com/wiki/Tombat",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/f2/Tombat_menu.png/",
-      "genus": "humanoid",
-      "rarity": 5,
-      "price": 3810,
-      "size": "m",
-      "stats": {
-        "hp": 95.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "gathering": 2,
-        "mining": 2,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 750,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/068_tombat.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Suzaku Aqua"
-        ],
-        [
-          "Lifmunk",
-          "Necromus"
-        ],
-        [
-          "Foxparks",
-          "Frostallion Noct"
-        ],
-        [
-          "Sparkit",
-          "Jetragon"
-        ],
-        [
-          "Tanzee",
-          "Lyleen"
-        ]
-      ]
-    },
-    "69": {
-      "id": 69,
-      "key": "69",
-      "name": "Lovander",
-      "wiki": "https://palworld.fandom.com/wiki/Lovander",
-      "image": "https://static.wikia.nocookie.net/palworld/images/c/c8/Lovander_menu.png/",
-      "genus": "humanoid",
-      "rarity": 5,
-      "price": 2450,
-      "size": "l",
-      "stats": {
-        "hp": 120.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 750.0,
-        "stamina": 100.0,
-        "support": 140.0,
-        "food": 5.0
-      },
-      "work": {
-        "handiwork": 2,
-        "medicine_production": 2,
-        "transporting": 2,
-        "mining": 1
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "implode",
-          "level": 40,
-          "power": 180,
-          "cooldown": 55.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "mushroom",
-        "cake",
-        "suspicious_juice",
-        "strange_juice"
-      ],
-      "breeding": {
-        "power": 940,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/069_lovander.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Sweepa"
-        ],
-        [
-          "Cattiva",
-          "Nitewing"
-        ],
-        [
-          "Chikipi",
-          "Ragnahawk"
-        ],
-        [
-          "Lifmunk",
-          "Sibelyx"
-        ],
-        [
-          "Foxparks",
-          "Wumpo Botan"
-        ]
-      ]
-    },
-    "70": {
-      "id": 70,
-      "key": "70",
-      "name": "Flambelle",
-      "wiki": "https://palworld.fandom.com/wiki/Flambelle",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/20/Flambelle_menu.png/",
-      "genus": "humanoid",
-      "rarity": 1,
-      "price": 2500,
-      "size": "xs",
-      "stats": {
-        "hp": 60.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 250.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "kindling": 1,
-        "handiwork": 1,
-        "transporting": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 1405,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/070_flambelle.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Tocotoco"
-        ],
-        [
-          "Cattiva",
-          "Pengullet"
-        ],
-        [
-          "Chikipi",
-          "Ribbuny"
-        ],
-        [
-          "Lifmunk",
-          "Depresso"
-        ],
-        [
-          "Foxparks",
-          "Sparkit"
-        ]
-      ]
-    },
-    "71": {
-      "id": 71,
-      "key": "71",
-      "name": "Vanwyrm",
-      "wiki": "https://palworld.fandom.com/wiki/Vanwyrm",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/ea/Vanwyrm_menu.png/",
-      "genus": "bird",
-      "rarity": 4,
-      "price": 4360,
-      "size": "l",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 700.0,
-        "stamina": 150.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "kindling": 1,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ignis_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "ruby",
-        "gold_coin"
-      ],
-      "breeding": {
-        "power": 660,
-        "type1": "Fire",
-        "type2": "Dark"
-      },
-      "types": [
-        "Fire",
-        "Dark"
-      ],
-      "localImage": "assets/pals/071_vanwyrm.png",
-      "breedingCombos": [
-        [
-          "Tanzee",
-          "Necromus"
-        ],
-        [
-          "Penking",
-          "Chillet"
-        ],
-        [
-          "Gumoss",
-          "Paladius"
-        ],
-        [
-          "Daedream",
-          "Jetragon"
-        ],
-        [
-          "Rushoar",
-          "Helzephyr"
-        ]
-      ]
-    },
-    "72": {
-      "id": 72,
-      "key": "72",
-      "name": "Bushi",
-      "wiki": "https://palworld.fandom.com/wiki/Bushi",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/73/Bushi_menu.png/",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 4520,
-      "size": "m",
-      "stats": {
-        "hp": 80.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "kindling": 2,
-        "handiwork": 1,
-        "transporting": 2,
-        "lumbering": 3,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iaigiri",
-          "level": 22,
-          "power": 65,
-          "cooldown": 9.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 50,
-          "power": 120,
-          "cooldown": 40.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "ingot"
-      ],
-      "breeding": {
-        "power": 640,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/072_bushi.png",
-      "breedingCombos": [
-        [
-          "Tanzee",
-          "Suzaku Aqua"
-        ],
-        [
-          "Penking",
-          "Foxcicle"
-        ],
-        [
-          "Daedream",
-          "Suzaku"
-        ],
-        [
-          "Rushoar",
-          "Astegon"
-        ],
-        [
-          "Nox",
-          "Frostallion Noct"
-        ]
-      ]
-    },
-    "73": {
-      "id": 73,
-      "key": "73",
-      "name": "Beakon",
-      "wiki": "https://palworld.fandom.com/wiki/Beakon",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Beakon_menu.png/",
-      "genus": "bird",
-      "rarity": 6,
-      "price": 7490,
-      "size": "l",
-      "stats": {
-        "hp": 105.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 750.0,
-        "stamina": 160.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "gathering": 1,
-        "generating_electricity": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spark_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 220,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/073_beakon.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Blazamut"
-        ],
-        [
-          "Sweepa",
-          "Suzaku Aqua"
-        ],
-        [
-          "Pyrin",
-          "Paladius"
-        ],
-        [
-          "Beakon",
-          "Beakon"
-        ],
-        [
-          "Ragnahawk",
-          "Shadowbeak"
-        ]
-      ]
-    },
-    "74": {
-      "id": 74,
-      "key": "74",
-      "name": "Ragnahawk",
-      "wiki": "https://palworld.fandom.com/wiki/Ragnahawk",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/dd/Ragnahawk_menu.png/",
-      "genus": "bird",
-      "rarity": 7,
-      "price": 6720,
-      "size": "l",
-      "stats": {
-        "hp": 95.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 800.0,
-        "stamina": 150.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "kindling": 3,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 380,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/074_ragnahawk.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Pyrin Noct"
-        ],
-        [
-          "Mossanda",
-          "Elizabee"
-        ],
-        [
-          "Nitewing",
-          "Warsect"
-        ],
-        [
-          "Cinnamoth",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Grintale",
-          "Lyleen"
-        ]
-      ]
-    },
-    "75": {
-      "id": 75,
-      "key": "75",
-      "name": "Katress",
-      "wiki": "https://palworld.fandom.com/wiki/Katress",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/9e/Katress_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 4120,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 440.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "medicine_production": 2,
-        "handiwork": 2,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "katress_hair",
-        "high_grade_technical_manual"
-      ],
-      "breeding": {
-        "power": 700,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/075_katress.png",
-      "breedingCombos": [
-        [
-          "Fuack",
-          "Necromus"
-        ],
-        [
-          "Tanzee",
-          "Astegon"
-        ],
-        [
-          "Pengullet",
-          "Suzaku"
-        ],
-        [
-          "Penking",
-          "Reindrix"
-        ],
-        [
-          "Jolthog",
-          "Suzaku Aqua"
-        ]
-      ]
-    },
-    "76": {
-      "id": 76,
-      "key": "76",
-      "name": "Wixen",
-      "wiki": "https://palworld.fandom.com/wiki/Wixen",
-      "image": "https://static.wikia.nocookie.net/palworld/images/8/85/Wixen_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 1540,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 50.0,
-        "defense": 80.0,
-        "speed": 440.0,
-        "stamina": 100.0,
-        "support": 120.0,
-        "food": 5.0
-      },
-      "work": {
-        "kindling": 2,
-        "handiwork": 3,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "high_grade_technical_manual"
-      ],
-      "breeding": {
-        "power": 1160,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/076_wixen.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Digtoise"
-        ],
-        [
-          "Cattiva",
-          "Broncherry"
-        ],
-        [
-          "Chikipi",
-          "Dinossom"
-        ],
-        [
-          "Lifmunk",
-          "Melpaca"
-        ],
-        [
-          "Foxparks",
-          "Eikthyrdeer"
-        ]
-      ]
-    },
-    "77": {
-      "id": 77,
-      "key": "77",
-      "name": "Verdash",
-      "wiki": "https://palworld.fandom.com/wiki/Verdash",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/43/Verdash_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 2200,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 3,
-        "lumbering": 2,
-        "handiwork": 3,
-        "planting": 2,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 7,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 15,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "bone"
-      ],
-      "breeding": {
-        "power": 990,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/077_verdash.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Grintale"
-        ],
-        [
-          "Cattiva",
-          "Penking"
-        ],
-        [
-          "Chikipi",
-          "Wumpo Botan"
-        ],
-        [
-          "Lifmunk",
-          "Surfent Terra"
-        ],
-        [
-          "Foxparks",
-          "Incineram Noct"
-        ]
-      ]
-    },
-    "78": {
-      "id": 78,
-      "key": "78",
-      "name": "Vaelet",
-      "wiki": "https://palworld.fandom.com/wiki/Vaelet",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/24/Vaelet_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 1960,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 2,
-        "handiwork": 2,
-        "medicine_production": 3,
-        "planting": 2,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "poison_fog",
-          "level": 1,
-          "power": 0,
-          "cooldown": 30.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "low_grade_medical_supplies",
-        "tomato_seeds"
-      ],
-      "breeding": {
-        "power": 1050,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/078_vaelet.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Bushi"
-        ],
-        [
-          "Lifmunk",
-          "Blazehowl Noct"
-        ],
-        [
-          "Foxparks",
-          "Katress"
-        ],
-        [
-          "Tanzee",
-          "Digtoise"
-        ],
-        [
-          "Pengullet",
-          "Tombat"
-        ]
-      ]
-    },
-    "79": {
-      "id": 79,
-      "key": "79",
-      "name": "Sibelyx",
-      "wiki": "https://palworld.fandom.com/wiki/Sibelyx",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/66/Sibelyx_menu.png/",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 5900,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 90.0,
-        "defense": 100.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 90.0,
-        "food": 5.0
-      },
-      "work": {
-        "medicine_production": 2,
-        "cooling": 2,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "high_quality_cloth",
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 450,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/079_sibelyx.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Ragnahawk"
-        ],
-        [
-          "Celaray",
-          "Suzaku Aqua"
-        ],
-        [
-          "Mossanda",
-          "Kingpaca"
-        ],
-        [
-          "Melpaca",
-          "Blazamut"
-        ],
-        [
-          "Nitewing",
-          "Wumpo Botan"
-        ]
-      ]
-    },
-    "80": {
-      "id": 80,
-      "key": "80",
-      "name": "Elphidran",
-      "wiki": "https://palworld.fandom.com/wiki/Elphidran",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a6/Elphidran_menu.png/",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 5230,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 80.0,
-        "defense": 90.0,
-        "speed": 630.0,
-        "stamina": 130.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "dragon_cannon",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "mystic_whirlwind",
-          "level": 22,
-          "power": 70,
-          "cooldown": 10.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 540,
-        "type1": "Dragon",
-        "type2": null
-      },
-      "types": [
-        "Dragon"
-      ],
-      "localImage": "assets/pals/080_elphidran.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Surfent"
-        ],
-        [
-          "Celaray",
-          "Lyleen Noct"
-        ],
-        [
-          "Caprity",
-          "Astegon"
-        ],
-        [
-          "Melpaca",
-          "Helzephyr"
-        ],
-        [
-          "Nitewing",
-          "Vanwyrm"
-        ]
-      ]
-    },
-    "81": {
-      "id": 81,
-      "key": "81",
-      "name": "Kelpsea",
-      "wiki": "https://palworld.fandom.com/wiki/Kelpsea",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/1b/Kelpsea_menu.png/",
-      "genus": "dragon",
-      "rarity": 1,
-      "price": 1260,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "watering": 1
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "raw_kelpsea",
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 1260,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/081_kelpsea.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Vaelet"
-        ],
-        [
-          "Cattiva",
-          "Direhowl"
-        ],
-        [
-          "Chikipi",
-          "Robinquill"
-        ],
-        [
-          "Lifmunk",
-          "Gobfin"
-        ],
-        [
-          "Foxparks",
-          "Leezpunk"
-        ]
-      ]
-    },
-    "82": {
-      "id": 82,
-      "key": "82",
-      "name": "Azurobe",
-      "wiki": "https://palworld.fandom.com/wiki/Azurobe",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Azurobe_menu.png/",
-      "genus": "fish",
-      "rarity": 7,
-      "price": 5600,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 70.0,
-        "defense": 100.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "watering": 3
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 15,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "cloth",
-        "precious_dragon_stone"
-      ],
-      "breeding": {
-        "power": 500,
-        "type1": "Water",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Water",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/082_azurobe.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Wumpo Botan"
-        ],
-        [
-          "Celaray",
-          "Cryolinx"
-        ],
-        [
-          "Mozzarina",
-          "Jetragon"
-        ],
-        [
-          "Mossanda",
-          "Anubis"
-        ],
-        [
-          "Caprity",
-          "Necromus"
-        ]
-      ]
-    },
-    "83": {
-      "id": 83,
-      "key": "83",
-      "name": "Cryolinx",
-      "wiki": "https://palworld.fandom.com/wiki/Cryolinx",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/9d/Cryolinx_menu.png/",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 8440,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 140.0,
-        "defense": 110.0,
-        "speed": 720.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "handiwork": 1,
-        "lumbering": 2,
-        "cooling": 3
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 130,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/083_cryolinx.png",
-      "breedingCombos": [
-        [
-          "Cryolinx",
-          "Cryolinx"
-        ],
-        [
-          "Blazamut",
-          "Lyleen"
-        ],
-        [
-          "Helzephyr",
-          "Necromus"
-        ],
-        [
-          "Suzaku",
-          "Lyleen Noct"
-        ],
-        [
-          "Grizzbolt",
-          "Shadowbeak"
-        ]
-      ]
-    },
-    "84": {
-      "id": 84,
-      "key": "84",
-      "name": "Blazehowl",
-      "wiki": "https://palworld.fandom.com/wiki/Blazehowl",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/33/Blazehowl_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 7,
-      "price": 4040,
-      "size": "l",
-      "stats": {
-        "hp": 105.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 750.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "kindling": 3,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 30,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 710,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/084_blazehowl.png",
-      "breedingCombos": [
-        [
-          "Fuack",
-          "Jetragon"
-        ],
-        [
-          "Sparkit",
-          "Blazamut"
-        ],
-        [
-          "Pengullet",
-          "Necromus"
-        ],
-        [
-          "Penking",
-          "Eikthyrdeer Terra"
-        ],
-        [
-          "Jolthog",
-          "Suzaku"
-        ]
-      ]
-    },
-    "85": {
-      "id": 85,
-      "key": "85",
-      "name": "Relaxaurus",
-      "wiki": "https://palworld.fandom.com/wiki/Relaxaurus",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/01/Relaxaurus_menu.png/",
-      "genus": "monster",
-      "rarity": 8,
-      "price": 10240,
-      "size": "xl",
-      "stats": {
-        "hp": 110.0,
-        "attack": 110.0,
-        "defense": 70.0,
-        "speed": 650.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "watering": 2,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "dragon_cannon",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil",
-        "ruby"
-      ],
-      "breeding": {
-        "power": 280,
-        "type1": "Dragon",
-        "type2": "Water"
-      },
-      "types": [
-        "Dragon",
-        "Water"
-      ],
-      "localImage": "assets/pals/085_relaxaurus.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Cryolinx"
-        ],
-        [
-          "Nitewing",
-          "Orserk"
-        ],
-        [
-          "Cinnamoth",
-          "Necromus"
-        ],
-        [
-          "Elizabee",
-          "Ice Reptyro"
-        ],
-        [
-          "Grintale",
-          "Suzaku"
-        ]
-      ]
-    },
-    "86": {
-      "id": 86,
-      "key": "86",
-      "name": "Broncherry",
-      "wiki": "https://palworld.fandom.com/wiki/Broncherry",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/bd/Broncherry_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 7,
-      "price": 2920,
-      "size": "xl",
-      "stats": {
-        "hp": 120.0,
-        "attack": 80.0,
-        "defense": 100.0,
-        "speed": 350.0,
-        "stamina": 100.0,
-        "support": 120.0,
-        "food": 7.0
-      },
-      "work": {
-        "planting": 3
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "muscle_slam",
-          "level": 15,
-          "power": 80,
-          "cooldown": 12.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "broncherry_meat",
-        "tomato_seeds"
-      ],
-      "breeding": {
-        "power": 860,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/086_broncherry.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Lyleen"
-        ],
-        [
-          "Cattiva",
-          "Menasting"
-        ],
-        [
-          "Chikipi",
-          "Beakon"
-        ],
-        [
-          "Lifmunk",
-          "Mammorest Cryst"
-        ],
-        [
-          "Foxparks",
-          "Reptyro"
-        ]
-      ]
-    },
-    "87": {
-      "id": 87,
-      "key": "87",
-      "name": "Petallia",
-      "wiki": "https://palworld.fandom.com/wiki/Petallia",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/28/Petallia_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 3590,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "planting": 3,
-        "handiwork": 2,
-        "gathering": 2,
-        "medicine_production": 2,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 15,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "beautiful_flower"
-      ],
-      "breeding": {
-        "power": 780,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/087_petallia.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Jetragon"
-        ],
-        [
-          "Cattiva",
-          "Frostallion Noct"
-        ],
-        [
-          "Chikipi",
-          "Shadowbeak"
-        ],
-        [
-          "Lifmunk",
-          "Cryolinx"
-        ],
-        [
-          "Fuack",
-          "Ice Reptyro"
-        ]
-      ]
-    },
-    "88": {
-      "id": 88,
-      "key": "88",
-      "name": "Reptyro",
-      "wiki": "https://palworld.fandom.com/wiki/Reptyro",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d0/Reptyro_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 6940,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 390.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "kindling": 3,
-        "mining": 3
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "volcanic_burst",
-          "level": 30,
-          "power": 100,
-          "cooldown": 45.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 320,
-        "type1": "Ground",
-        "type2": "Fire"
-      },
-      "types": [
-        "Ground",
-        "Fire"
-      ],
-      "localImage": "assets/pals/088_reptyro.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Frostallion"
-        ],
-        [
-          "Mossanda",
-          "Lyleen Noct"
-        ],
-        [
-          "Nitewing",
-          "Beakon"
-        ],
-        [
-          "Incineram",
-          "Suzaku"
-        ],
-        [
-          "Cinnamoth",
-          "Astegon"
-        ]
-      ]
-    },
-    "89": {
-      "id": 89,
-      "key": "89",
-      "name": "Kingpaca",
-      "wiki": "https://palworld.fandom.com/wiki/Kingpaca",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/9d/Kingpaca_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 8,
-      "price": 5800,
-      "size": "xl",
-      "stats": {
-        "hp": 120.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "kingly_slam",
-          "level": 22,
-          "power": 100,
-          "cooldown": 21.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wool"
-      ],
-      "breeding": {
-        "power": 470,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/089_kingpaca.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Nitewing"
-        ],
-        [
-          "Celaray",
-          "Necromus"
-        ],
-        [
-          "Mozzarina",
-          "Suzaku Aqua"
-        ],
-        [
-          "Mossanda",
-          "Grintale"
-        ],
-        [
-          "Caprity",
-          "Blazamut"
-        ]
-      ]
-    },
-    "90": {
-      "id": 90,
-      "key": "90",
-      "name": "Mammorest",
-      "wiki": "https://palworld.fandom.com/wiki/Mammorest",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Mammorest_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 8,
-      "price": 9450,
-      "size": "xl",
-      "stats": {
-        "hp": 150.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 430.0,
-        "stamina": 100.0,
-        "support": 30.0,
-        "food": 8.0
-      },
-      "work": {
-        "planting": 2,
-        "lumbering": 2,
-        "mining": 2
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "earth_impact",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil",
-        "leather",
-        "mammorest_meat"
-      ],
-      "breeding": {
-        "power": 300,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/090_mammorest.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Paladius"
-        ],
-        [
-          "Incineram",
-          "Blazamut"
-        ],
-        [
-          "Elizabee",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Grintale",
-          "Jetragon"
-        ],
-        [
-          "Sweepa",
-          "Helzephyr"
-        ]
-      ]
-    },
-    "91": {
-      "id": 91,
-      "key": "91",
-      "name": "Wumpo",
-      "wiki": "https://palworld.fandom.com/wiki/Wumpo",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/0e/Wumpo_menu.png/",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 5900,
-      "size": "l",
-      "stats": {
-        "hp": 140.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 365.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "handiwork": 2,
-        "lumbering": 3,
-        "cooling": 2,
-        "transporting": 4
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "ice_organ",
-        "beautiful_flower"
-      ],
-      "breeding": {
-        "power": 460,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/091_wumpo.png",
-      "breedingCombos": [
-        [
-          "Celaray",
-          "Suzaku"
-        ],
-        [
-          "Mozzarina",
-          "Blazamut"
-        ],
-        [
-          "Mossanda",
-          "Cinnamoth"
-        ],
-        [
-          "Melpaca",
-          "Suzaku Aqua"
-        ],
-        [
-          "Nitewing",
-          "Azurobe"
-        ]
-      ]
-    },
-    "92": {
-      "id": 92,
-      "key": "92",
-      "name": "Warsect",
-      "wiki": "https://palworld.fandom.com/wiki/Warsect",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Warsect_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 6830,
-      "size": "l",
-      "stats": {
-        "hp": 120.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 1,
-        "lumbering": 3,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "giga_horn",
-          "level": 30,
-          "power": 75,
-          "cooldown": 11.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "honey"
-      ],
-      "breeding": {
-        "power": 340,
-        "type1": "Grass",
-        "type2": "Ground"
-      },
-      "types": [
-        "Grass",
-        "Ground"
-      ],
-      "localImage": "assets/pals/092_warsect.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Lyleen"
-        ],
-        [
-          "Nitewing",
-          "Menasting"
-        ],
-        [
-          "Incineram",
-          "Jetragon"
-        ],
-        [
-          "Cinnamoth",
-          "Helzephyr"
-        ],
-        [
-          "Elizabee",
-          "Quivern"
-        ]
-      ]
-    },
-    "93": {
-      "id": 93,
-      "key": "93",
-      "name": "Fenglope",
-      "wiki": "https://palworld.fandom.com/wiki/Fenglope",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/68/Fenglope_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 3,
-      "price": 2250,
-      "size": "s",
-      "stats": {
-        "hp": 110.0,
-        "attack": 110.0,
-        "defense": 90.0,
-        "speed": 750.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "cloud_tempest",
-          "level": 15,
-          "power": 90,
-          "cooldown": 15.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "leather",
-        "horn"
-      ],
-      "breeding": {
-        "power": 980,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/093_fenglope.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Cinnamoth"
-        ],
-        [
-          "Cattiva",
-          "Azurobe"
-        ],
-        [
-          "Chikipi",
-          "Wumpo"
-        ],
-        [
-          "Lifmunk",
-          "Elphidran Aqua"
-        ],
-        [
-          "Foxparks",
-          "Surfent"
-        ]
-      ]
-    },
-    "94": {
-      "id": 94,
-      "key": "94",
-      "name": "Felbat",
-      "wiki": "https://palworld.fandom.com/wiki/Felbat",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7d/Felbat_menu.png/",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 2100,
-      "size": "m",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 110.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 110.0,
-        "food": 5.0
-      },
-      "work": {
-        "medicine_production": 3
-      },
-      "skills": [
-        {
-          "name": "poison_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "cloth",
-        "small_pal_soul"
-      ],
-      "breeding": {
-        "power": 1010,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/094_felbat.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Surfent Terra"
-        ],
-        [
-          "Cattiva",
-          "Surfent"
-        ],
-        [
-          "Chikipi",
-          "Penking"
-        ],
-        [
-          "Lifmunk",
-          "Incineram"
-        ],
-        [
-          "Foxparks",
-          "Vanwyrm Cryst"
-        ]
-      ]
-    },
-    "95": {
-      "id": 95,
-      "key": "95",
-      "name": "Quivern",
-      "wiki": "https://palworld.fandom.com/wiki/Quivern",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d9/Quivern_menu.png/",
-      "genus": "dragon",
-      "rarity": 7,
-      "price": 6830,
-      "size": "l",
-      "stats": {
-        "hp": 105.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 800.0,
-        "stamina": 220.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "handiwork": 1,
-        "transporting": 3,
-        "gathering": 2,
-        "mining": 2
-      },
-      "skills": [
-        {
-          "name": "dragon_cannon",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 15,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 350,
-        "type1": "Dragon",
-        "type2": null
-      },
-      "types": [
-        "Dragon"
-      ],
-      "localImage": "assets/pals/095_quivern.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Nitewing",
-          "Relaxaurus"
-        ],
-        [
-          "Cinnamoth",
-          "Lyleen Noct"
-        ],
-        [
-          "Elizabee",
-          "Faleris"
-        ],
-        [
-          "Grintale",
-          "Helzephyr"
-        ]
-      ]
-    },
-    "96": {
-      "id": 96,
-      "key": "96",
-      "name": "Blazamut",
-      "wiki": "https://palworld.fandom.com/wiki/Blazamut",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/ee/Blazamut_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 9,
-      "price": 10520,
-      "size": "xl",
-      "stats": {
-        "hp": 100.0,
-        "attack": 150.0,
-        "defense": 120.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 50.0,
-        "food": 8.0
-      },
-      "work": {
-        "kindling": 3,
-        "mining": 4
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ignis_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 30,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "coal",
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 10,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/096_blazamut.png",
-      "breedingCombos": [
-        [
-          "Blazamut",
-          "Blazamut"
-        ],
-        [
-          "Blazamut",
-          "Suzaku Aqua"
-        ]
-      ]
-    },
-    "97": {
-      "id": 97,
-      "key": "97",
-      "name": "Helzephyr",
-      "wiki": "https://palworld.fandom.com/wiki/Helzephyr",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/3c/Helzephyr_menu.png/",
-      "genus": "bird",
-      "rarity": 7,
-      "price": 7840,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 700.0,
-        "stamina": 170.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "spirit_fire",
-          "level": 1,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "venom_gland",
-        "medium_pal_soul"
-      ],
-      "breeding": {
-        "power": 190,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/097_helzephyr.png",
-      "breedingCombos": [
-        [
-          "Elizabee",
-          "Suzaku"
-        ],
-        [
-          "Cryolinx",
-          "Lyleen"
-        ],
-        [
-          "Relaxaurus",
-          "Frostallion Noct"
-        ],
-        [
-          "Reptyro",
-          "Shadowbeak"
-        ],
-        [
-          "Mammorest",
-          "Paladius"
-        ]
-      ]
-    },
-    "98": {
-      "id": 98,
-      "key": "98",
-      "name": "Astegon",
-      "wiki": "https://palworld.fandom.com/wiki/Astegon",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/d4/Astegon_menu.png/",
-      "genus": "monster",
-      "rarity": 9,
-      "price": 8200,
-      "size": "xl",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 125.0,
-        "speed": 600.0,
-        "stamina": 300.0,
-        "support": 100.0,
-        "food": 9.0
-      },
-      "work": {
-        "handiwork": 1,
-        "mining": 4
-      },
-      "skills": [
-        {
-          "name": "dragon_cannon",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 7,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 22,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_metal_ingot",
-        "pure_quartz"
-      ],
-      "breeding": {
-        "power": 150,
-        "type1": "Dark",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Dark",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/098_astegon.png",
-      "breedingCombos": [
-        [
-          "Beakon",
-          "Paladius"
-        ],
-        [
-          "Blazamut",
-          "Mammorest Cryst"
-        ],
-        [
-          "Astegon",
-          "Astegon"
-        ],
-        [
-          "Suzaku",
-          "Lyleen"
-        ],
-        [
-          "Grizzbolt",
-          "Frostallion Noct"
-        ]
-      ]
-    },
-    "99": {
-      "id": 99,
-      "key": "99",
-      "name": "Menasting",
-      "wiki": "https://palworld.fandom.com/wiki/Menasting",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/57/Menasting_menu.png/",
-      "genus": "other",
-      "rarity": 9,
-      "price": 7050,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 130.0,
-        "speed": 1000.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "lumbering": 2,
-        "mining": 3
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "coal",
-        "venom_gland"
-      ],
-      "breeding": {
-        "power": 260,
-        "type1": "Dark",
-        "type2": "Ground"
-      },
-      "types": [
-        "Dark",
-        "Ground"
-      ],
-      "localImage": "assets/pals/099_menasting.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Jetragon"
-        ],
-        [
-          "Nitewing",
-          "Frostallion Noct"
-        ],
-        [
-          "Cinnamoth",
-          "Suzaku Aqua"
-        ],
-        [
-          "Elizabee",
-          "Helzephyr"
-        ],
-        [
-          "Grintale",
-          "Blazamut"
-        ]
-      ]
-    },
-    "100": {
-      "id": 100,
-      "key": "100",
-      "name": "Anubis",
-      "wiki": "https://palworld.fandom.com/wiki/Anubis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Anubis_menu.png/",
-      "genus": "humanoid",
-      "rarity": 10,
-      "price": 4960,
-      "size": "m",
-      "stats": {
-        "hp": 120.0,
-        "attack": 130.0,
-        "defense": 100.0,
-        "speed": 800.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "handiwork": 4,
-        "mining": 3,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "stone_blast",
-          "level": 1,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 7,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 15,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spinning_roundhouse",
-          "level": 22,
-          "power": 100,
-          "cooldown": 21.0
-        },
-        {
-          "name": "forceful_charge",
-          "level": 30,
-          "power": 120,
-          "cooldown": 28.0
-        },
-        {
-          "name": "ground_smash",
-          "level": 40,
-          "power": 140,
-          "cooldown": 35.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "large_pal_soul",
-        "innovative_technical_manual"
-      ],
-      "breeding": {
-        "power": 570,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/100_anubis.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Vanwyrm Cryst"
-        ],
-        [
-          "Rushoar",
-          "Blazamut"
-        ],
-        [
-          "Celaray",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Direhowl",
-          "Paladius"
-        ],
-        [
-          "Mozzarina",
-          "Ice Reptyro"
-        ]
-      ]
-    },
-    "101": {
-      "id": 101,
-      "key": "101",
-      "name": "Jormuntide",
-      "wiki": "https://palworld.fandom.com/wiki/Jormuntide",
-      "image": "https://static.wikia.nocookie.net/palworld/images/8/8e/Jormuntide_menu.png/",
-      "genus": "fish",
-      "rarity": 8,
-      "price": 9320,
-      "size": "xl",
-      "stats": {
-        "hp": 130.0,
-        "attack": 150.0,
-        "defense": 100.0,
-        "speed": 525.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "watering": 4
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 22,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 310,
-        "type1": "Dragon",
-        "type2": "Water"
-      },
-      "types": [
-        "Dragon",
-        "Water"
-      ],
-      "localImage": "assets/pals/101_jormuntide.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Frostallion Noct"
-        ],
-        [
-          "Mossanda",
-          "Helzephyr"
-        ],
-        [
-          "Nitewing",
-          "Grizzbolt"
-        ],
-        [
-          "Incineram",
-          "Suzaku Aqua"
-        ],
-        [
-          "Cinnamoth",
-          "Cryolinx"
-        ]
-      ]
-    },
-    "102": {
-      "id": 102,
-      "key": "102",
-      "name": "Suzaku",
-      "wiki": "https://palworld.fandom.com/wiki/Suzaku",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/b4/Suzaku_menu.png/",
-      "genus": "bird",
-      "rarity": 8,
-      "price": 9840,
-      "size": "xl",
-      "stats": {
-        "hp": 120.0,
-        "attack": 100.0,
-        "defense": 105.0,
-        "speed": 850.0,
-        "stamina": 350.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "kindling": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ignis_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 50,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/102_suzaku.png",
-      "breedingCombos": [
-        [
-          "Blazamut",
-          "Jetragon"
-        ],
-        [
-          "Suzaku",
-          "Suzaku"
-        ],
-        [
-          "Necromus",
-          "Suzaku Aqua"
-        ],
-        [
-          "Blazamut",
-          "Paladius"
-        ],
-        [
-          "Blazamut",
-          "Frostallion Noct"
-        ]
-      ]
-    },
-    "103": {
-      "id": 103,
-      "key": "103",
-      "name": "Grizzbolt",
-      "wiki": "https://palworld.fandom.com/wiki/Grizzbolt",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Grizzbolt_menu.png/",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 7720,
-      "size": "l",
-      "stats": {
-        "hp": 105.0,
-        "attack": 120.0,
-        "defense": 100.0,
-        "speed": 470.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "generating_electricity": 3,
-        "handiwork": 2,
-        "transporting": 3,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "spark_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "lightning_claw",
-          "level": 15,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 200,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/103_grizzbolt.png",
-      "breedingCombos": [
-        [
-          "Elizabee",
-          "Necromus"
-        ],
-        [
-          "Cryolinx",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Relaxaurus",
-          "Frostallion"
-        ],
-        [
-          "Reptyro",
-          "Paladius"
-        ],
-        [
-          "Mammorest",
-          "Frostallion Noct"
-        ]
-      ]
-    },
-    "104": {
-      "id": 104,
-      "key": "104",
-      "name": "Lyleen",
-      "wiki": "https://palworld.fandom.com/wiki/Lyleen",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Lyleen_menu.png/",
-      "genus": "humanoid",
-      "rarity": 9,
-      "price": 7160,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 105.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "planting": 4,
-        "handiwork": 3,
-        "medicine_production": 3,
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "seed_machine_gun",
-          "level": 7,
-          "power": 50,
-          "cooldown": 9.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 15,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 22,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 40,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "low_grade_medical_supplies",
-        "beautiful_flower",
-        "innovative_technical_manual"
-      ],
-      "breeding": {
-        "power": 250,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/104_lyleen.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Necromus"
-        ],
-        [
-          "Nitewing",
-          "Paladius"
-        ],
-        [
-          "Cinnamoth",
-          "Blazamut"
-        ],
-        [
-          "Sweepa",
-          "Jetragon"
-        ],
-        [
-          "Pyrin",
-          "Orserk"
-        ]
-      ]
-    },
-    "105": {
-      "id": 105,
-      "key": "105",
-      "name": "Faleris",
-      "wiki": "https://palworld.fandom.com/wiki/Faleris",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/99/Faleris_menu.png/",
-      "genus": "bird",
-      "rarity": 9,
-      "price": 6720,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 110.0,
-        "speed": 1000.0,
-        "stamina": 230.0,
-        "support": 90.0,
-        "food": 8.0
-      },
-      "work": {
-        "kindling": 3,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "phoenix_flare",
-          "level": 30,
-          "power": 135,
-          "cooldown": 28.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 370,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/105_faleris.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Beakon"
-        ],
-        [
-          "Mossanda",
-          "Jormuntide"
-        ],
-        [
-          "Nitewing",
-          "Reptyro"
-        ],
-        [
-          "Incineram",
-          "Astegon"
-        ],
-        [
-          "Cinnamoth",
-          "Lyleen"
-        ]
-      ]
-    },
-    "106": {
-      "id": 106,
-      "key": "106",
-      "name": "Orserk",
-      "wiki": "https://palworld.fandom.com/wiki/Orserk",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/6e/Orserk_menu.png/",
-      "genus": "humanoid",
-      "rarity": 9,
-      "price": 8320,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 900.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "generating_electricity": 4,
-        "handiwork": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "kerauno",
-          "level": 1,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 7,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "spark_blast",
-          "level": 15,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "electric_organ"
-      ],
-      "breeding": {
-        "power": 140,
-        "type1": "Dragon",
-        "type2": "Electric"
-      },
-      "types": [
-        "Dragon",
-        "Electric"
-      ],
-      "localImage": "assets/pals/106_orserk.png",
-      "breedingCombos": [
-        [
-          "Beakon",
-          "Shadowbeak"
-        ],
-        [
-          "Cryolinx",
-          "Astegon"
-        ],
-        [
-          "Blazamut",
-          "Relaxaurus Lux"
-        ],
-        [
-          "Helzephyr",
-          "Jetragon"
-        ],
-        [
-          "Suzaku",
-          "Ice Reptyro"
-        ]
-      ]
-    },
-    "107": {
-      "id": 107,
-      "key": "107",
-      "name": "Shadowbeak",
-      "wiki": "https://palworld.fandom.com/wiki/Shadowbeak",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/0c/Shadowbeak_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 10,
-      "price": 9060,
-      "size": "l",
-      "stats": {
-        "hp": 120.0,
-        "attack": 130.0,
-        "defense": 140.0,
-        "speed": 850.0,
-        "stamina": 250.0,
-        "support": 90.0,
-        "food": 8.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "divine_disaster",
-          "level": 40,
-          "power": 160,
-          "cooldown": 45.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_metal_ingot",
-        "carbon_fiber",
-        "innovative_technical_manual"
-      ],
-      "breeding": {
-        "power": 60,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/107_shadowbeak.png",
-      "breedingCombos": [
-        [
-          "Suzaku",
-          "Necromus"
-        ],
-        [
-          "Shadowbeak",
-          "Shadowbeak"
-        ],
-        [
-          "Jetragon",
-          "Suzaku Aqua"
-        ],
-        [
-          "Blazamut",
-          "Frostallion"
-        ],
-        [
-          "Suzaku",
-          "Paladius"
-        ]
-      ]
-    },
-    "108": {
-      "id": 108,
-      "key": "108",
-      "name": "Paladius",
-      "wiki": "https://palworld.fandom.com/wiki/Paladius",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/09/Paladius_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 20,
-      "price": 8810,
-      "size": "l",
-      "stats": {
-        "hp": 130.0,
-        "attack": 110.0,
-        "defense": 145.0,
-        "speed": 800.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 9.0
-      },
-      "work": {
-        "mining": 2,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "iceberg",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 30,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "spear_thrust",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "pal_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_metal_ingot",
-        "diamond"
-      ],
-      "breeding": {
-        "power": 80,
-        "type1": "Neutral",
-        "type2": null
-      },
-      "types": [
-        "Neutral"
-      ],
-      "localImage": "assets/pals/108_paladius.png",
-      "breedingCombos": [
-        [
-          "Cryolinx",
-          "Suzaku Aqua"
-        ],
-        [
-          "Blazamut",
-          "Astegon"
-        ],
-        [
-          "Shadowbeak",
-          "Frostallion Noct"
-        ],
-        [
-          "Paladius",
-          "Paladius"
-        ],
-        [
-          "Necromus",
-          "Jetragon"
-        ]
-      ]
-    },
-    "109": {
-      "id": 109,
-      "key": "109",
-      "name": "Necromus",
-      "wiki": "https://palworld.fandom.com/wiki/Necromus",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Necromus_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 20,
-      "price": 8930,
-      "size": "l",
-      "stats": {
-        "hp": 130.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 900.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 9.0
-      },
-      "work": {
-        "mining": 2,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "shadow_burst",
-          "level": 1,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 15,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 22,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 30,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "twin_spears",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_metal_ingot",
-        "large_pal_soul"
-      ],
-      "breeding": {
-        "power": 70,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/109_necromus.png",
-      "breedingCombos": [
-        [
-          "Cryolinx",
-          "Blazamut"
-        ],
-        [
-          "Suzaku",
-          "Jetragon"
-        ],
-        [
-          "Shadowbeak",
-          "Paladius"
-        ],
-        [
-          "Necromus",
-          "Necromus"
-        ]
-      ]
-    },
-    "110": {
-      "id": 110,
-      "key": "110",
-      "name": "Frostallion",
-      "wiki": "https://palworld.fandom.com/wiki/Frostallion",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/00/Frostallion_menu.png/",
-      "genus": "fourlegged",
-      "rarity": 20,
-      "price": 8440,
-      "size": "l",
-      "stats": {
-        "hp": 140.0,
-        "attack": 100.0,
-        "defense": 120.0,
-        "speed": 1000.0,
-        "stamina": 300.0,
-        "support": 70.0,
-        "food": 7.0
-      },
-      "work": {
-        "cooling": 4
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "crystal_wing",
-          "level": 30,
-          "power": 110,
-          "cooldown": 24.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "ice_organ",
-        "diamond"
-      ],
-      "breeding": {
-        "power": 120,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/110_frostallion.png",
-      "breedingCombos": [
-        [
-          "Blazamut",
-          "Ice Reptyro"
-        ],
-        [
-          "Helzephyr",
-          "Suzaku"
-        ],
-        [
-          "Astegon",
-          "Jetragon"
-        ],
-        [
-          "Orserk",
-          "Frostallion Noct"
-        ],
-        [
-          "Frostallion",
-          "Frostallion"
-        ]
-      ]
-    },
-    "111": {
-      "id": 111,
-      "key": "111",
-      "name": "Jetragon",
-      "wiki": "https://palworld.fandom.com/wiki/Jetragon",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/e5/Jetragon_menu.png/",
-      "genus": "dragon",
-      "rarity": 20,
-      "price": 8680,
-      "size": "xl",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 110.0,
-        "speed": 1700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 9.0
-      },
-      "work": {
-        "gathering": 3
-      },
-      "skills": [
-        {
-          "name": "spirit_fire",
-          "level": 1,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 15,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "beam_comet",
-          "level": 30,
-          "power": 140,
-          "cooldown": 50.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pure_quartz",
-        "polymer",
-        "carbon_fiber",
-        "diamond"
-      ],
-      "breeding": {
-        "power": 90,
-        "type1": "Dragon",
-        "type2": null
-      },
-      "types": [
-        "Dragon"
-      ],
-      "localImage": "assets/pals/111_jetragon.png",
-      "breedingCombos": [
-        [
-          "Cryolinx",
-          "Suzaku"
-        ],
-        [
-          "Astegon",
-          "Suzaku Aqua"
-        ],
-        [
-          "Shadowbeak",
-          "Frostallion"
-        ],
-        [
-          "Paladius",
-          "Frostallion Noct"
-        ],
-        [
-          "Jetragon",
-          "Jetragon"
-        ]
-      ]
-    },
-    "112": {
-      "id": 112,
-      "key": "012B",
-      "name": "Jolthog Cryst",
-      "wiki": "https://palworld.fandom.com/wiki/Jolthog_Cryst",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/72/Jolthog_Cryst_menu.png",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 1070,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 80.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "cooling": 1
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "iceberg",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 1360,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/112_jolthog_cryst.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Tanzee"
-        ],
-        [
-          "Cattiva",
-          "Kelpsea"
-        ],
-        [
-          "Chikipi",
-          "Fuddler"
-        ],
-        [
-          "Lifmunk",
-          "Killamari"
-        ],
-        [
-          "Foxparks",
-          "Bristla"
-        ]
-      ]
-    },
-    "113": {
-      "id": 113,
-      "key": "024B",
-      "name": "Mau Cryst",
-      "wiki": "https://palworld.fandom.com/wiki/Mau_Cryst",
-      "image": "https://static.wikia.nocookie.net/palworld/images/7/7a/Mau_Cryst_menu.png",
-      "genus": "fourlegged",
-      "rarity": 2,
-      "price": 1010,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 475.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "cooling": 1,
-        "farming": 1
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "air_cannon",
-          "level": 7,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "sand_blast",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "ice_organ",
-        "sapphire"
-      ],
-      "breeding": {
-        "power": 1440,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/113_mau_cryst.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Sparkit"
-        ],
-        [
-          "Cattiva",
-          "Hangyu"
-        ],
-        [
-          "Chikipi",
-          "Depresso"
-        ],
-        [
-          "Lifmunk",
-          "Vixy"
-        ],
-        [
-          "Foxparks",
-          "Mau"
-        ]
-      ]
-    },
-    "114": {
-      "id": 114,
-      "key": "031B",
-      "name": "Gobfin Ignis",
-      "wiki": "https://palworld.fandom.com/wiki/Gobfin_Ignis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/9/9c/Gobfin_Ignis_menu.png",
-      "genus": "humanoid",
-      "rarity": 3,
-      "price": 1800,
-      "size": "s",
-      "stats": {
-        "hp": 90.0,
-        "attack": 90.0,
-        "defense": 75.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "kindling": 2,
-        "handiwork": 1,
-        "transporting": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "power_shot",
-          "level": 7,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 30,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 50,
-          "power": 120,
-          "cooldown": 40.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 1100,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/114_gobfin_ignis.png",
-      "breedingCombos": [
-        [
-          "Cattiva",
-          "Rayhound"
-        ],
-        [
-          "Chikipi",
-          "Katress"
-        ],
-        [
-          "Foxparks",
-          "Chillet"
-        ],
-        [
-          "Fuack",
-          "Celaray"
-        ],
-        [
-          "Sparkit",
-          "Arsox"
-        ]
-      ]
-    },
-    "115": {
-      "id": 115,
-      "key": "032B",
-      "name": "Hangyu Cryst",
-      "wiki": "https://palworld.fandom.com/wiki/Hangyu_Cryst",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/49/Hangyu_Cryst_menu.png",
-      "genus": "other",
-      "rarity": 2,
-      "price": 1020,
-      "size": "xs",
-      "stats": {
-        "hp": 80.0,
-        "attack": 70.0,
-        "defense": 70.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 2.0
-      },
-      "work": {
-        "gathering": 1,
-        "cooling": 1,
-        "handiwork": 1,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "power_shot",
-          "level": 15,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "fiber",
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 1422,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/115_hangyu_cryst.png",
-      "breedingCombos": [
-        [
-          "Hangyu Cryst",
-          "Hangyu Cryst"
-        ],
-        [
-          "Hoocrates",
-          "Cremis"
-        ],
-        [
-          "Flambelle",
-          "Mau Cryst"
-        ],
-        [
-          "Lamball",
-          "Depresso"
-        ],
-        [
-          "Cattiva",
-          "Hoocrates"
-        ]
-      ]
-    },
-    "116": {
-      "id": 116,
-      "key": "033B",
-      "name": "Mossanda Lux",
-      "wiki": "https://palworld.fandom.com/wiki/Mossanda_Lux",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/05/Mossanda_Lux_menu.png",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 6610,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 100.0,
-        "defense": 100.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "generating_electricity": 2,
-        "handiwork": 2,
-        "lumbering": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "spark_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 15,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "blast_punch",
-          "level": 22,
-          "power": 85,
-          "cooldown": 14.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "mushroom",
-        "electric_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 390,
-        "type1": "Electric",
-        "type2": null
-      },
-      "types": [
-        "Electric"
-      ],
-      "localImage": "assets/pals/116_mossanda_lux.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Menasting"
-        ],
-        [
-          "Mossanda",
-          "Quivern"
-        ],
-        [
-          "Nitewing",
-          "Pyrin"
-        ],
-        [
-          "Incineram",
-          "Helzephyr"
-        ],
-        [
-          "Cinnamoth",
-          "Mammorest Cryst"
-        ]
-      ]
-    },
-    "117": {
-      "id": 117,
-      "key": "037B",
-      "name": "Eikthyrdeer Terra",
-      "wiki": "https://palworld.fandom.com/wiki/Eikthyrdeer_Terra",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Eikthyrdeer_Terra_menu.png",
-      "genus": "fourlegged",
-      "rarity": 6,
-      "price": 2680,
-      "size": "l",
-      "stats": {
-        "hp": 95.0,
-        "attack": 70.0,
-        "defense": 80.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "power_shot",
-          "level": 1,
-          "power": 35,
-          "cooldown": 4.0
-        },
-        {
-          "name": "antler_uppercut",
-          "level": 7,
-          "power": 50,
-          "cooldown": 5.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 40,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "eikthyrdeer_venison",
-        "leather",
-        "horn"
-      ],
-      "breeding": {
-        "power": 900,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/117_eikthyrdeer_terra.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Elizabee"
-        ],
-        [
-          "Cattiva",
-          "Warsect"
-        ],
-        [
-          "Chikipi",
-          "Mammorest"
-        ],
-        [
-          "Lifmunk",
-          "Faleris"
-        ],
-        [
-          "Fuack",
-          "Kingpaca"
-        ]
-      ]
-    },
-    "118": {
-      "id": 118,
-      "key": "040B",
-      "name": "Incineram Noct",
-      "wiki": "https://palworld.fandom.com/wiki/Incineram_Noct",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Incineram_Noct_menu.png",
-      "genus": "humanoid",
-      "rarity": 5,
-      "price": 4870,
-      "size": "m",
-      "stats": {
-        "hp": 95.0,
-        "attack": 150.0,
-        "defense": 85.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 4.0
-      },
-      "work": {
-        "handiwork": 2,
-        "mining": 1,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 7,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "hellfire_claw",
-          "level": 22,
-          "power": 70,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 50,
-          "power": 120,
-          "cooldown": 40.0
-        }
-      ],
-      "drops": [
-        "horn",
-        "leather"
-      ],
-      "breeding": {
-        "power": 580,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/118_incineram_noct.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Bushi"
-        ],
-        [
-          "Rushoar",
-          "Suzaku Aqua"
-        ],
-        [
-          "Celaray",
-          "Mammorest Cryst"
-        ],
-        [
-          "Direhowl",
-          "Frostallion Noct"
-        ],
-        [
-          "Mozzarina",
-          "Lyleen"
-        ]
-      ]
-    },
-    "119": {
-      "id": 119,
-      "key": "045B",
-      "name": "Leezpunk Ignis",
-      "wiki": "https://palworld.fandom.com/wiki/Leezpunk_Ignis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/e/ea/Leezpunk_Ignis_menu.png",
-      "genus": "humanoid",
-      "rarity": 3,
-      "price": 1640,
-      "size": "s",
-      "stats": {
-        "hp": 80.0,
-        "attack": 90.0,
-        "defense": 50.0,
-        "speed": 400.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "kindling": 1,
-        "handiwork": 1,
-        "transporting": 1,
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "poison_blast",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "silver_key"
-      ],
-      "breeding": {
-        "power": 1140,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/119_leezpunk_ignis.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Dinossom Lux"
-        ],
-        [
-          "Cattiva",
-          "Dinossom"
-        ],
-        [
-          "Chikipi",
-          "Petallia"
-        ],
-        [
-          "Lifmunk",
-          "Digtoise"
-        ],
-        [
-          "Foxparks",
-          "Reindrix"
-        ]
-      ]
-    },
-    "120": {
-      "id": 120,
-      "key": "048B",
-      "name": "Robinquill Terra",
-      "wiki": "https://palworld.fandom.com/wiki/Robinquill_Terra",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/45/Robinquill_Terra_menu.png",
-      "genus": "humanoid",
-      "rarity": 6,
-      "price": 2150,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 600.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 3.0
-      },
-      "work": {
-        "gathering": 2,
-        "lumbering": 1,
-        "handiwork": 2,
-        "medicine_production": 1,
-        "transporting": 2
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "wind_cutter",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "focus_shot",
-          "level": 15,
-          "power": 65,
-          "cooldown": 9.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "wheat_seeds",
-        "arrow"
-      ],
-      "breeding": {
-        "power": 1000,
-        "type1": "Grass",
-        "type2": "Ground"
-      },
-      "types": [
-        "Grass",
-        "Ground"
-      ],
-      "localImage": "assets/pals/120_robinquill_terra.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Elphidran Aqua"
-        ],
-        [
-          "Cattiva",
-          "Elphidran"
-        ],
-        [
-          "Chikipi",
-          "Azurobe"
-        ],
-        [
-          "Lifmunk",
-          "Anubis"
-        ],
-        [
-          "Fuack",
-          "Blazehowl Noct"
-        ]
-      ]
-    },
-    "121": {
-      "id": 121,
-      "key": "058B",
-      "name": "Pyrin Noct",
-      "wiki": "https://palworld.fandom.com/wiki/Pyrin_Noct",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/2b/Pyrin_Noct_menu.png",
-      "genus": "fourlegged",
-      "rarity": 7,
-      "price": 7270,
-      "size": "l",
-      "stats": {
-        "hp": 100.0,
-        "attack": 110.0,
-        "defense": 90.0,
-        "speed": 850.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "kindling": 2,
-        "lumbering": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "dark_charge",
-          "level": 30,
-          "power": 85,
-          "cooldown": 14.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ",
-        "leather"
-      ],
-      "breeding": {
-        "power": 240,
-        "type1": "Fire",
-        "type2": "Dark"
-      },
-      "types": [
-        "Fire",
-        "Dark"
-      ],
-      "localImage": "assets/pals/121_pyrin_noct.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Suzaku"
-        ],
-        [
-          "Nitewing",
-          "Shadowbeak"
-        ],
-        [
-          "Elizabee",
-          "Astegon"
-        ],
-        [
-          "Sweepa",
-          "Necromus"
-        ],
-        [
-          "Pyrin",
-          "Frostallion"
-        ]
-      ]
-    },
-    "122": {
-      "id": 122,
-      "key": "064B",
-      "name": "Dinossom Lux",
-      "wiki": "https://palworld.fandom.com/wiki/Dinossom_Lux",
-      "image": "https://static.wikia.nocookie.net/palworld/images/c/c7/Dinossom_Lux_menu.png",
-      "genus": "humanoid",
-      "rarity": 7,
-      "price": 3380,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 90.0,
-        "defense": 90.0,
-        "speed": 550.0,
-        "stamina": 100.0,
-        "support": 150.0,
-        "food": 6.0
-      },
-      "work": {
-        "generating_electricity": 2,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "shockwave",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "plasma_tornado",
-          "level": 7,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "botanical_smash",
-          "level": 15,
-          "power": 60,
-          "cooldown": 8.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "tomato_seeds"
-      ],
-      "breeding": {
-        "power": 810,
-        "type1": "Electric",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Electric",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/122_dinossom_lux.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Astegon"
-        ],
-        [
-          "Chikipi",
-          "Frostallion"
-        ],
-        [
-          "Lifmunk",
-          "Helzephyr"
-        ],
-        [
-          "Foxparks",
-          "Beakon"
-        ],
-        [
-          "Fuack",
-          "Mammorest Cryst"
-        ]
-      ]
-    },
-    "123": {
-      "id": 123,
-      "key": "065B",
-      "name": "Surfent Terra",
-      "wiki": "https://palworld.fandom.com/wiki/Surfent_Terra",
-      "image": "https://static.wikia.nocookie.net/palworld/images/f/ff/Surfent_Terra_menu.png",
-      "genus": "fish",
-      "rarity": 5,
-      "price": 5140,
-      "size": "m",
-      "stats": {
-        "hp": 90.0,
-        "attack": 70.0,
-        "defense": 100.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "gathering": 1
-      },
-      "skills": [
-        {
-          "name": "sand_blast",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "stone_cannon",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "sand_tornado",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 550,
-        "type1": "Ground",
-        "type2": null
-      },
-      "types": [
-        "Ground"
-      ],
-      "localImage": "assets/pals/123_surfent_terra.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Incineram Noct"
-        ],
-        [
-          "Celaray",
-          "Ice Reptyro"
-        ],
-        [
-          "Mozzarina",
-          "Helzephyr"
-        ],
-        [
-          "Gobfin",
-          "Blazamut"
-        ],
-        [
-          "Mossanda",
-          "Blazehowl Noct"
-        ]
-      ]
-    },
-    "124": {
-      "id": 124,
-      "key": "071B",
-      "name": "Vanwyrm Cryst",
-      "wiki": "https://palworld.fandom.com/wiki/Vanwyrm_Cryst",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/19/Vanwyrm_Cryst_menu.png",
-      "genus": "bird",
-      "rarity": 5,
-      "price": 4610,
-      "size": "l",
-      "stats": {
-        "hp": 90.0,
-        "attack": 100.0,
-        "defense": 95.0,
-        "speed": 700.0,
-        "stamina": 150.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "cooling": 2,
-        "transporting": 3
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "bone",
-        "ice_organ",
-        "sapphire"
-      ],
-      "breeding": {
-        "power": 620,
-        "type1": "Ice",
-        "type2": "Dark"
-      },
-      "types": [
-        "Ice",
-        "Dark"
-      ],
-      "localImage": "assets/pals/124_vanwyrm_cryst.png",
-      "breedingCombos": [
-        [
-          "Daedream",
-          "Blazamut"
-        ],
-        [
-          "Nox",
-          "Shadowbeak"
-        ],
-        [
-          "Celaray",
-          "Faleris"
-        ],
-        [
-          "Mozzarina",
-          "Elizabee"
-        ],
-        [
-          "Gobfin",
-          "Astegon"
-        ]
-      ]
-    },
-    "125": {
-      "id": 125,
-      "key": "080B",
-      "name": "Elphidran Aqua",
-      "wiki": "https://palworld.fandom.com/wiki/Elphidran_Aqua",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Elphidran_Aqua_menu.png",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 5320,
-      "size": "l",
-      "stats": {
-        "hp": 115.0,
-        "attack": 80.0,
-        "defense": 95.0,
-        "speed": 630.0,
-        "stamina": 130.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "watering": 3,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "mystic_whirlwind",
-          "level": 22,
-          "power": 70,
-          "cooldown": 10.0
-        },
-        {
-          "name": "acid_rain",
-          "level": 30,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil"
-      ],
-      "breeding": {
-        "power": 530,
-        "type1": "Water",
-        "type2": "Dragon"
-      },
-      "types": [
-        "Water",
-        "Dragon"
-      ],
-      "localImage": "assets/pals/125_elphidran_aqua.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Elphidran"
-        ],
-        [
-          "Celaray",
-          "Helzephyr"
-        ],
-        [
-          "Mozzarina",
-          "Astegon"
-        ],
-        [
-          "Caprity",
-          "Cryolinx"
-        ],
-        [
-          "Eikthyrdeer",
-          "Orserk"
-        ]
-      ]
-    },
-    "126": {
-      "id": 126,
-      "key": "081B",
-      "name": "Kelpsea Ignis",
-      "wiki": "https://palworld.fandom.com/wiki/Kelpsea_Ignis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/b/ba/Kelpsea_Ignis_menu.png",
-      "genus": "dragon",
-      "rarity": 2,
-      "price": 1240,
-      "size": "xs",
-      "stats": {
-        "hp": 70.0,
-        "attack": 100.0,
-        "defense": 70.0,
-        "speed": 700.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 1.0
-      },
-      "work": {
-        "kindling": 1
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "spirit_fire",
-          "level": 15,
-          "power": 45,
-          "cooldown": 7.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 22,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "dragon_burst",
-          "level": 30,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 40,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "raw_kelpsea",
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 1270,
-        "type1": "Fire",
-        "type2": null
-      },
-      "types": [
-        "Fire"
-      ],
-      "localImage": "assets/pals/126_kelpsea_ignis.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Beegarde"
-        ],
-        [
-          "Cattiva",
-          "Cawgnito"
-        ],
-        [
-          "Chikipi",
-          "Gorirat"
-        ],
-        [
-          "Lifmunk",
-          "Lunaris"
-        ],
-        [
-          "Foxparks",
-          "Leezpunk Ignis"
-        ]
-      ]
-    },
-    "127": {
-      "id": 127,
-      "key": "084B",
-      "name": "Blazehowl Noct",
-      "wiki": "https://palworld.fandom.com/wiki/Blazehowl_Noct",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5d/Blazehowl_Noct_menu.png",
-      "genus": "fourlegged",
-      "rarity": 8,
-      "price": 4360,
-      "size": "l",
-      "stats": {
-        "hp": 105.0,
-        "attack": 100.0,
-        "defense": 80.0,
-        "speed": 750.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "kindling": 3,
-        "lumbering": 2
-      },
-      "skills": [
-        {
-          "name": "shadow_burst",
-          "level": 1,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "flare_arrow",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "ignis_rage",
-          "level": 30,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 670,
-        "type1": "Fire",
-        "type2": "Dark"
-      },
-      "types": [
-        "Fire",
-        "Dark"
-      ],
-      "localImage": "assets/pals/127_blazehowl_noct.png",
-      "breedingCombos": [
-        [
-          "Fuack",
-          "Blazamut"
-        ],
-        [
-          "Tanzee",
-          "Jetragon"
-        ],
-        [
-          "Penking",
-          "Dinossom"
-        ],
-        [
-          "Gumoss",
-          "Frostallion Noct"
-        ],
-        [
-          "Rushoar",
-          "Lyleen Noct"
-        ]
-      ]
-    },
-    "128": {
-      "id": 128,
-      "key": "085B",
-      "name": "Relaxaurus Lux",
-      "wiki": "https://palworld.fandom.com/wiki/Relaxaurus_Lux",
-      "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Relaxaurus_Lux_menu.png",
-      "genus": "monster",
-      "rarity": 9,
-      "price": 10380,
-      "size": "xl",
-      "stats": {
-        "hp": 110.0,
-        "attack": 110.0,
-        "defense": 75.0,
-        "speed": 650.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "transporting": 1,
-        "generating_electricity": 3
-      },
-      "skills": [
-        {
-          "name": "spark_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "shockwave",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "lightning_streak",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "draconic_breath",
-          "level": 30,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "lightning_strike",
-          "level": 40,
-          "power": 120,
-          "cooldown": 40.0
-        },
-        {
-          "name": "lightning_bolt",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil",
-        "electric_organ",
-        "sapphire"
-      ],
-      "breeding": {
-        "power": 270,
-        "type1": "Dragon",
-        "type2": "Electric"
-      },
-      "types": [
-        "Dragon",
-        "Electric"
-      ],
-      "localImage": "assets/pals/128_relaxaurus_lux.png",
-      "breedingCombos": [
-        [
-          "Nitewing",
-          "Frostallion"
-        ],
-        [
-          "Cinnamoth",
-          "Suzaku"
-        ],
-        [
-          "Elizabee",
-          "Lyleen Noct"
-        ],
-        [
-          "Grintale",
-          "Suzaku Aqua"
-        ],
-        [
-          "Sweepa",
-          "Cryolinx"
-        ]
-      ]
-    },
-    "129": {
-      "id": 129,
-      "key": "086B",
-      "name": "Broncherry Aqua",
-      "wiki": "https://palworld.fandom.com/wiki/Broncherry_Aqua",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Broncherry_Aqua_menu.png",
-      "genus": "fourlegged",
-      "rarity": 8,
-      "price": 3110,
-      "size": "xl",
-      "stats": {
-        "hp": 120.0,
-        "attack": 80.0,
-        "defense": 100.0,
-        "speed": 350.0,
-        "stamina": 100.0,
-        "support": 120.0,
-        "food": 7.0
-      },
-      "work": {
-        "watering": 3
-      },
-      "skills": [
-        {
-          "name": "aqua_gun",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "bubble_blast",
-          "level": 7,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "muscle_slam",
-          "level": 15,
-          "power": 80,
-          "cooldown": 12.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 22,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 30,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "broncherry_meat",
-        "lettuce_seeds"
-      ],
-      "breeding": {
-        "power": 840,
-        "type1": "Grass",
-        "type2": "Water"
-      },
-      "types": [
-        "Grass",
-        "Water"
-      ],
-      "localImage": "assets/pals/129_broncherry_aqua.png",
-      "breedingCombos": [
-        [
-          "Lamball",
-          "Lyleen Noct"
-        ],
-        [
-          "Cattiva",
-          "Beakon"
-        ],
-        [
-          "Lifmunk",
-          "Lyleen"
-        ],
-        [
-          "Foxparks",
-          "Relaxaurus"
-        ],
-        [
-          "Fuack",
-          "Quivern"
-        ]
-      ]
-    },
-    "130": {
-      "id": 130,
-      "key": "088B",
-      "name": "Ice Reptyro",
-      "wiki": "https://palworld.fandom.com/wiki/Ice_Reptyro",
-      "image": "https://static.wikia.nocookie.net/palworld/images/2/2c/Ice_Reptyro_menu.png",
-      "genus": "fourlegged",
-      "rarity": 7,
-      "price": 7380,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 130.0,
-        "speed": 390.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 5.0
-      },
-      "work": {
-        "mining": 3,
-        "cooling": 3
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "stone_blast",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "frost_burst",
-          "level": 30,
-          "power": 100,
-          "cooldown": 45.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "rock_lance",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 230,
-        "type1": "Ground",
-        "type2": "Ice"
-      },
-      "types": [
-        "Ground",
-        "Ice"
-      ],
-      "localImage": "assets/pals/130_ice_reptyro.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Suzaku Aqua"
-        ],
-        [
-          "Elizabee",
-          "Cryolinx"
-        ],
-        [
-          "Sweepa",
-          "Suzaku"
-        ],
-        [
-          "Pyrin",
-          "Frostallion Noct"
-        ],
-        [
-          "Beakon",
-          "Pyrin Noct"
-        ]
-      ]
-    },
-    "131": {
-      "id": 131,
-      "key": "089B",
-      "name": "Ice Kingpaca",
-      "wiki": "https://palworld.fandom.com/wiki/Ice_Kingpaca",
-      "image": "https://static.wikia.nocookie.net/palworld/images/5/5a/Ice_Kingpaca_menu.png",
-      "genus": "fourlegged",
-      "rarity": 9,
-      "price": 6100,
-      "size": "xl",
-      "stats": {
-        "hp": 120.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 500.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "gathering": 1,
-        "cooling": 3
-      },
-      "skills": [
-        {
-          "name": "ice_missile",
-          "level": 1,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "iceberg",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "kingly_slam",
-          "level": 22,
-          "power": 100,
-          "cooldown": 21.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "wool",
-        "ice_organ"
-      ],
-      "breeding": {
-        "power": 440,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/131_ice_kingpaca.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Pyrin"
-        ],
-        [
-          "Celaray",
-          "Blazamut"
-        ],
-        [
-          "Mossanda",
-          "Sibelyx"
-        ],
-        [
-          "Nitewing",
-          "Wumpo"
-        ],
-        [
-          "Incineram",
-          "Mammorest Cryst"
-        ]
-      ]
-    },
-    "132": {
-      "id": 132,
-      "key": "090B",
-      "name": "Mammorest Cryst",
-      "wiki": "https://palworld.fandom.com/wiki/Mammorest_Cryst",
-      "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Mammorest_Cryst_menu.png",
-      "genus": "fourlegged",
-      "rarity": 9,
-      "price": 9580,
-      "size": "xl",
-      "stats": {
-        "hp": 150.0,
-        "attack": 100.0,
-        "defense": 90.0,
-        "speed": 430.0,
-        "stamina": 100.0,
-        "support": 30.0,
-        "food": 8.0
-      },
-      "work": {
-        "lumbering": 2,
-        "mining": 2,
-        "cooling": 2
-      },
-      "skills": [
-        {
-          "name": "stone_cannon",
-          "level": 1,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "power_bomb",
-          "level": 15,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "iceberg",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "earth_impact",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 40,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 50,
-          "power": 130,
-          "cooldown": 45.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil",
-        "leather",
-        "mammorest_meat"
-      ],
-      "breeding": {
-        "power": 290,
-        "type1": "Ice",
-        "type2": null
-      },
-      "types": [
-        "Ice"
-      ],
-      "localImage": "assets/pals/132_mammorest_cryst.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Shadowbeak"
-        ],
-        [
-          "Mossanda",
-          "Astegon"
-        ],
-        [
-          "Cinnamoth",
-          "Jetragon"
-        ],
-        [
-          "Elizabee",
-          "Lyleen"
-        ],
-        [
-          "Grintale",
-          "Necromus"
-        ]
-      ]
-    },
-    "133": {
-      "id": 133,
-      "key": "091B",
-      "name": "Wumpo Botan",
-      "wiki": "https://palworld.fandom.com/wiki/Wumpo_Botan",
-      "image": "https://static.wikia.nocookie.net/palworld/images/6/68/Wumpo_Botan_menu.png",
-      "genus": "humanoid",
-      "rarity": 8,
-      "price": 5700,
-      "size": "l",
-      "stats": {
-        "hp": 140.0,
-        "attack": 100.0,
-        "defense": 110.0,
-        "speed": 365.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "planting": 1,
-        "handiwork": 2,
-        "lumbering": 3,
-        "transporting": 4
-      },
-      "skills": [
-        {
-          "name": "wind_cutter",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "seed_mine",
-          "level": 15,
-          "power": 65,
-          "cooldown": 13.0
-        },
-        {
-          "name": "grass_tornado",
-          "level": 22,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "spine_vine",
-          "level": 30,
-          "power": 95,
-          "cooldown": 25.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "solar_blast",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "lettuce_seeds",
-        "tomato_seeds",
-        "beautiful_flower"
-      ],
-      "breeding": {
-        "power": 480,
-        "type1": "Grass",
-        "type2": null
-      },
-      "types": [
-        "Grass"
-      ],
-      "localImage": "assets/pals/133_wumpo_botan.png",
-      "breedingCombos": [
-        [
-          "Penking",
-          "Ice Kingpaca"
-        ],
-        [
-          "Celaray",
-          "Jetragon"
-        ],
-        [
-          "Mozzarina",
-          "Suzaku"
-        ],
-        [
-          "Mossanda",
-          "Elphidran Aqua"
-        ],
-        [
-          "Caprity",
-          "Suzaku Aqua"
-        ]
-      ]
-    },
-    "134": {
-      "id": 134,
-      "key": "101B",
-      "name": "Jormuntide Ignis",
-      "wiki": "https://palworld.fandom.com/wiki/Jormuntide_Ignis",
-      "image": "https://static.wikia.nocookie.net/palworld/images/0/0d/Jormuntide_Ignis_menu.png",
-      "genus": "fish",
-      "rarity": 9,
-      "price": 9500,
-      "size": "xl",
-      "stats": {
-        "hp": 130.0,
-        "attack": 150.0,
-        "defense": 100.0,
-        "speed": 525.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 7.0
-      },
-      "work": {
-        "kindling": 4
-      },
-      "skills": [
-        {
-          "name": "ignis_blast",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dragon_cannon",
-          "level": 7,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "flare_storm",
-          "level": 15,
-          "power": 80,
-          "cooldown": 18.0
-        },
-        {
-          "name": "ignis_breath",
-          "level": 22,
-          "power": 70,
-          "cooldown": 15.0
-        },
-        {
-          "name": "tri-lightning",
-          "level": 30,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "fire_ball",
-          "level": 40,
-          "power": 150,
-          "cooldown": 55.0
-        },
-        {
-          "name": "dragon_meteor",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "high_quality_pal_oil",
-        "flame_organ"
-      ],
-      "breeding": {
-        "power": 315,
-        "type1": "Dragon",
-        "type2": "Fire"
-      },
-      "types": [
-        "Dragon",
-        "Fire"
-      ],
-      "localImage": "assets/pals/134_jormuntide_ignis.png",
-      "breedingCombos": [
-        [
-          "Mossanda",
-          "Grizzbolt"
-        ],
-        [
-          "Nitewing",
-          "Lyleen Noct"
-        ],
-        [
-          "Cinnamoth",
-          "Orserk"
-        ],
-        [
-          "Elizabee",
-          "Mammorest"
-        ],
-        [
-          "Grintale",
-          "Frostallion"
-        ]
-      ]
-    },
-    "135": {
-      "id": 135,
-      "key": "102B",
-      "name": "Suzaku Aqua",
-      "wiki": "https://palworld.fandom.com/wiki/Suzaku_Aqua",
-      "image": "https://static.wikia.nocookie.net/palworld/images/a/a1/Suzaku_Aqua_menu.png",
-      "genus": "bird",
-      "rarity": 9,
-      "price": 10110,
-      "size": "xl",
-      "stats": {
-        "hp": 125.0,
-        "attack": 100.0,
-        "defense": 105.0,
-        "speed": 850.0,
-        "stamina": 350.0,
-        "support": 100.0,
-        "food": 8.0
-      },
-      "work": {
-        "watering": 3
-      },
-      "skills": [
-        {
-          "name": "hydro_jet",
-          "level": 1,
-          "power": 30,
-          "cooldown": 2.0
-        },
-        {
-          "name": "ice_missile",
-          "level": 7,
-          "power": 30,
-          "cooldown": 3.0
-        },
-        {
-          "name": "aqua_gun",
-          "level": 15,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "aqua_burst",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "hydro_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pal_fluids"
-      ],
-      "breeding": {
-        "power": 30,
-        "type1": "Water",
-        "type2": null
-      },
-      "types": [
-        "Water"
-      ],
-      "localImage": "assets/pals/135_suzaku_aqua.png",
-      "breedingCombos": [
-        [
-          "Blazamut",
-          "Suzaku"
-        ],
-        [
-          "Suzaku Aqua",
-          "Suzaku Aqua"
-        ],
-        [
-          "Blazamut",
-          "Shadowbeak"
-        ]
-      ]
-    },
-    "136": {
-      "id": 136,
-      "key": "104B",
-      "name": "Lyleen Noct",
-      "wiki": "https://palworld.fandom.com/wiki/Lyleen_Noct",
-      "image": "https://static.wikia.nocookie.net/palworld/images/3/30/Lyleen_Noct_menu.png",
-      "genus": "humanoid",
-      "rarity": 10,
-      "price": 7610,
-      "size": "l",
-      "stats": {
-        "hp": 110.0,
-        "attack": 100.0,
-        "defense": 115.0,
-        "speed": 450.0,
-        "stamina": 100.0,
-        "support": 100.0,
-        "food": 6.0
-      },
-      "work": {
-        "handiwork": 3,
-        "medicine_production": 3,
-        "gathering": 2
-      },
-      "skills": [
-        {
-          "name": "dark_ball",
-          "level": 1,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "icicle_cutter",
-          "level": 7,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "cryst_breath",
-          "level": 22,
-          "power": 90,
-          "cooldown": 22.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 30,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "blizzard_spike",
-          "level": 40,
-          "power": 130,
-          "cooldown": 45.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "low_grade_medical_supplies",
-        "beautiful_flower",
-        "innovative_technical_manual"
-      ],
-      "breeding": {
-        "power": 210,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/136_lyleen_noct.png",
-      "breedingCombos": [
-        [
-          "Elizabee",
-          "Jetragon"
-        ],
-        [
-          "Sweepa",
-          "Blazamut"
-        ],
-        [
-          "Pyrin",
-          "Shadowbeak"
-        ],
-        [
-          "Beakon",
-          "Grizzbolt"
-        ],
-        [
-          "Cryolinx",
-          "Mammorest Cryst"
-        ]
-      ]
-    },
-    "137": {
-      "id": 137,
-      "key": "110B",
-      "name": "Frostallion Noct",
-      "wiki": "https://palworld.fandom.com/wiki/Frostallion_Noct",
-      "image": "https://static.wikia.nocookie.net/palworld/images/1/14/Frostallion_Noct_menu.png",
-      "genus": "fourlegged",
-      "rarity": 20,
-      "price": 8560,
-      "size": "l",
-      "stats": {
-        "hp": 140.0,
-        "attack": 100.0,
-        "defense": 135.0,
-        "speed": 1000.0,
-        "stamina": 300.0,
-        "support": 70.0,
-        "food": 7.0
-      },
-      "work": {
-        "gathering": 4
-      },
-      "skills": [
-        {
-          "name": "air_cannon",
-          "level": 1,
-          "power": 25,
-          "cooldown": 2.0
-        },
-        {
-          "name": "dark_ball",
-          "level": 7,
-          "power": 40,
-          "cooldown": 4.0
-        },
-        {
-          "name": "shadow_burst",
-          "level": 15,
-          "power": 55,
-          "cooldown": 10.0
-        },
-        {
-          "name": "spirit_flame",
-          "level": 22,
-          "power": 75,
-          "cooldown": 16.0
-        },
-        {
-          "name": "crystal_wing",
-          "level": 30,
-          "power": 110,
-          "cooldown": 24.0
-        },
-        {
-          "name": "nightmare_ball",
-          "level": 40,
-          "power": 100,
-          "cooldown": 30.0
-        },
-        {
-          "name": "dark_laser",
-          "level": 50,
-          "power": 150,
-          "cooldown": 55.0
-        }
-      ],
-      "drops": [
-        "pure_quartz",
-        "large_pal_soul"
-      ],
-      "breeding": {
-        "power": 100,
-        "type1": "Dark",
-        "type2": null
-      },
-      "types": [
-        "Dark"
-      ],
-      "localImage": "assets/pals/137_frostallion_noct.png",
-      "breedingCombos": [
-        [
-          "Cryolinx",
-          "Necromus"
-        ],
-        [
-          "Blazamut",
-          "Helzephyr"
-        ],
-        [
-          "Astegon",
-          "Suzaku"
-        ],
-        [
-          "Orserk",
-          "Shadowbeak"
-        ],
-        [
-          "Paladius",
-          "Frostallion"
-        ]
-      ]
-    }
-  },
-  "items": {
-    "wool": {
-      "category": "Misc"
-    },
-    "lamball_mutton": {
-      "category": "Food"
-    },
-    "red_berries": {
-      "category": "Food"
-    },
-    "egg": {
-      "category": "Food"
-    },
-    "chikipi_poultry": {
-      "category": "Food"
-    },
-    "berry_seeds": {
-      "category": "Food"
-    },
-    "low_grade_medical_supplies": {
-      "category": "Misc"
-    },
-    "leather": {
-      "category": "Material"
-    },
-    "flame_organ": {
-      "category": "Misc"
-    },
-    "pal_fluids": {
-      "category": "Misc"
-    },
-    "electric_organ": {
-      "category": "Misc"
-    },
-    "mushroom": {
-      "category": "Material"
-    },
-    "ice_organ": {
-      "category": "Misc"
-    },
-    "penking_plume": {
-      "category": "Misc"
-    },
-    "gumoss_leaf": {
-      "category": "Misc"
-    },
-    "bone": {
-      "category": "Misc"
-    },
-    "fiber": {
-      "category": "Material"
-    },
-    "high_grade_technical_manual": {
-      "category": "Misc"
-    },
-    "venom_gland": {
-      "category": "Material"
-    },
-    "small_pal_soul": {
-      "category": "Misc"
-    },
-    "rushoar_pork": {
-      "category": "Misc"
-    },
-    "gold_coin": {
-      "category": "Misc"
-    },
-    "ruby": {
-      "category": "Misc"
-    },
-    "gunpowder": {
-      "category": "Equipment"
-    },
-    "tocotoco_feather": {
-      "category": "Misc"
-    },
-    "wheat_seeds": {
-      "category": "Misc"
-    },
-    "mozzarina_meat": {
-      "category": "Food"
-    },
-    "milk": {
-      "category": "Food"
-    },
-    "lettuce_seeds": {
-      "category": "Misc"
-    },
-    "tomato_seeds": {
-      "category": "Misc"
-    },
-    "cotton_candy": {
-      "category": "Misc"
-    },
-    "high_quality_pal_oil": {
-      "category": "Material"
-    },
-    "caprity_meat": {
-      "category": "Food"
-    },
-    "horn": {
-      "category": "Misc"
-    },
-    "eikthyrdeer_venison": {
-      "category": "Misc"
-    },
-    "beautiful_flower": {
-      "category": "Misc"
-    },
-    "honey": {
-      "category": "Food"
-    },
-    "raw_dumud": {
-      "category": "Misc"
-    },
-    "copper_key": {
-      "category": "Misc"
-    },
-    "silver_key": {
-      "category": "Misc"
-    },
-    "galeclaw_poultry": {
-      "category": "Food"
-    },
-    "arrow": {
-      "category": "Misc"
-    },
-    "elizabee's_staff": {
-      "category": "Misc"
-    },
-    "reindrix_venison": {
-      "category": "Misc"
-    },
-    "paldium_fragment": {
-      "category": "Material"
-    },
-    "ore": {
-      "category": "Material"
-    },
-    "cake": {
-      "category": "Food"
-    },
-    "suspicious_juice": {
-      "category": "Misc"
-    },
-    "strange_juice": {
-      "category": "Misc"
-    },
-    "ingot": {
-      "category": "Material"
-    },
-    "katress_hair": {
-      "category": "Misc"
-    },
-    "high_quality_cloth": {
-      "category": "Material"
-    },
-    "raw_kelpsea": {
-      "category": "Misc"
-    },
-    "cloth": {
-      "category": "Material"
-    },
-    "precious_dragon_stone": {
-      "category": "Material"
-    },
-    "broncherry_meat": {
-      "category": "Food"
-    },
-    "mammorest_meat": {
-      "category": "Food"
-    },
-    "coal": {
-      "category": "Material"
-    },
-    "medium_pal_soul": {
-      "category": "Misc"
-    },
-    "pal_metal_ingot": {
-      "category": "Material"
-    },
-    "pure_quartz": {
-      "category": "Misc"
-    },
-    "large_pal_soul": {
-      "category": "Misc"
-    },
-    "innovative_technical_manual": {
-      "category": "Misc"
-    },
-    "carbon_fiber": {
-      "category": "Material"
-    },
-    "diamond": {
-      "category": "Misc"
-    },
-    "polymer": {
-      "category": "Material"
-    },
-    "sapphire": {
-      "category": "Misc"
-    }
-  },
-  "tech": [
-    {
-      "level": 2,
-      "items": [
-        {
-          "name": "Pal Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 1,
-            "Wood": 3,
-            "Stone": 3
-          },
-          "description": "Craft Pal Sphere with materials and capture high-level pals."
-        }
-      ]
-    },
-    {
-      "level": 14,
-      "items": [
-        {
-          "name": "Mega Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 1,
-            "Ingot": 1,
-            "Wood": 5,
-            "Stone": 5
-          },
-          "description": "Craft Mega Sphere with materials and capture high-level pals."
-        }
-      ]
-    },
-    {
-      "level": 20,
-      "items": [
-        {
-          "name": "Giga Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 2,
-            "Ingot": 2,
-            "Wood": 7,
-            "Stone": 7
-          },
-          "description": "Craft Giga Sphere with materials and capture high-level pals."
-        }
-      ]
-    },
-    {
-      "level": 27,
-      "items": [
-        {
-          "name": "Hyper Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 3,
-            "Ingot": 3,
-            "Wood": 10,
-            "Cement": 2
-          },
-          "description": "Craft Hyper Sphere with materials and capture high-level pals."
-        }
-      ]
-    },
-    {
-      "level": 35,
-      "items": [
-        {
-          "name": "Ultra Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 5,
-            "Refined Ingot": 5,
-            "Carbon Fiber": 2,
-            "Cement": 3
-          },
-          "description": "Craft Ultra Sphere with materials and capture high-level pals."
-        }
-      ]
-    },
-    {
-      "level": 40,
-      "items": [
-        {
-          "name": "Legendary Sphere",
-          "category": "Equipment",
-          "materials": {
-            "Paladium Fragment": 10,
-            "Carbon Fiber": 5,
-            "Circuit Board": 5,
-            "Polymer": 5
-          },
-          "description": "Craft Legendary Sphere with materials and capture high-level pals."
-        }
-      ]
-    }
-  ]
+    "pals": {
+        "1": {
+            "id": 1,
+            "key": "1",
+            "name": "Lamball",
+            "wiki": "https://palworld.fandom.com/wiki/Lamball",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/01/Lamball_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1000,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "roly_poly",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 1.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "implode",
+                    "level": 22,
+                    "power": 180,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "electric_ball",
+                    "level": 30,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wool",
+                "lamball_mutton"
+            ],
+            "breeding": {
+                "power": 1470,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/001_lamball.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Lamball"
+                ],
+                [
+                    "Cattiva",
+                    "Mau"
+                ],
+                [
+                    "Chikipi",
+                    "Mau Cryst"
+                ],
+                [
+                    "Vixy",
+                    "Teafant"
+                ],
+                [
+                    "Teafant",
+                    "Cremis"
+                ]
+            ]
+        },
+        "2": {
+            "id": 2,
+            "key": "2",
+            "name": "Cattiva",
+            "wiki": "https://palworld.fandom.com/wiki/Cattiva",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/51/Cattiva_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1000,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "gathering": 1,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "punch_flurry",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 1.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 30,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 40,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "red_berries"
+            ],
+            "breeding": {
+                "power": 1460,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/002_cattiva.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Vixy"
+                ],
+                [
+                    "Cattiva",
+                    "Cattiva"
+                ],
+                [
+                    "Chikipi",
+                    "Hangyu"
+                ],
+                [
+                    "Lifmunk",
+                    "Teafant"
+                ],
+                [
+                    "Mau",
+                    "Mau Cryst"
+                ]
+            ]
+        },
+        "3": {
+            "id": 3,
+            "key": "3",
+            "name": "Chikipi",
+            "wiki": "https://palworld.fandom.com/wiki/Chikipi",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/f4/Chikipi_menu.png/",
+            "genus": "bird",
+            "rarity": 1,
+            "price": 1000,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 70.0,
+                "defense": 60.0,
+                "speed": 375.0,
+                "stamina": 100.0,
+                "support": 70.0,
+                "food": 1.0
+            },
+            "work": {
+                "gathering": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "chicken_rush",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 1.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "implode",
+                    "level": 22,
+                    "power": 180,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 50,
+                    "power": 80,
+                    "cooldown": 18.0
+                }
+            ],
+            "drops": [
+                "egg",
+                "chikipi_poultry"
+            ],
+            "breeding": {
+                "power": 1500,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/003_chikipi.png",
+            "breedingCombos": [
+                [
+                    "Chikipi",
+                    "Chikipi"
+                ],
+                [
+                    "Chikipi",
+                    "Teafant"
+                ]
+            ]
+        },
+        "4": {
+            "id": 4,
+            "key": "4",
+            "name": "Lifmunk",
+            "wiki": "https://palworld.fandom.com/wiki/Lifmunk",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/dc/Lifmunk_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1010,
+            "size": "xs",
+            "stats": {
+                "hp": 75.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "lumbering": 1,
+                "medicine_production": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 22,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "berry_seeds",
+                "low_grade_medical_supplies"
+            ],
+            "breeding": {
+                "power": 1430,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/004_lifmunk.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Hoocrates"
+                ],
+                [
+                    "Cattiva",
+                    "Foxparks"
+                ],
+                [
+                    "Chikipi",
+                    "Jolthog Cryst"
+                ],
+                [
+                    "Lifmunk",
+                    "Lifmunk"
+                ],
+                [
+                    "Sparkit",
+                    "Vixy"
+                ]
+            ]
+        },
+        "5": {
+            "id": 5,
+            "key": "5",
+            "name": "Foxparks",
+            "wiki": "https://palworld.fandom.com/wiki/Foxparks",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d7/Foxparks_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1040,
+            "size": "xs",
+            "stats": {
+                "hp": 65.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "kindling": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 40,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 1400,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/005_foxparks.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Fuack"
+                ],
+                [
+                    "Cattiva",
+                    "Tocotoco"
+                ],
+                [
+                    "Chikipi",
+                    "Swee"
+                ],
+                [
+                    "Lifmunk",
+                    "Jolthog"
+                ],
+                [
+                    "Foxparks",
+                    "Foxparks"
+                ]
+            ]
+        },
+        "6": {
+            "id": 6,
+            "key": "6",
+            "name": "Fuack",
+            "wiki": "https://palworld.fandom.com/wiki/Fuack",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Fuack_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1120,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 80.0,
+                "defense": 60.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "watering": 1
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "hydro_jet",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 1330,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/006_fuack.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Woolipop"
+                ],
+                [
+                    "Chikipi",
+                    "Wixen"
+                ],
+                [
+                    "Lifmunk",
+                    "Daedream"
+                ],
+                [
+                    "Foxparks",
+                    "Kelpsea"
+                ],
+                [
+                    "Fuack",
+                    "Fuack"
+                ]
+            ]
+        },
+        "7": {
+            "id": 7,
+            "key": "7",
+            "name": "Sparkit",
+            "wiki": "https://palworld.fandom.com/wiki/Sparkit",
+            "image": "https://static.wikia.nocookie.net/palworld/images/c/ce/Sparkit_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1030,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 60.0,
+                "defense": 70.0,
+                "speed": 350.0,
+                "stamina": 100.0,
+                "support": 80.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "generating_electricity": 1
+            },
+            "skills": [
+                {
+                    "name": "spark_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "electric_ball",
+                    "level": 22,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 40,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 1410,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/007_sparkit.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Pengullet"
+                ],
+                [
+                    "Cattiva",
+                    "Jolthog Cryst"
+                ],
+                [
+                    "Chikipi",
+                    "Bristla"
+                ],
+                [
+                    "Lifmunk",
+                    "Hoocrates"
+                ],
+                [
+                    "Foxparks",
+                    "Hangyu"
+                ]
+            ]
+        },
+        "8": {
+            "id": 8,
+            "key": "8",
+            "name": "Tanzee",
+            "wiki": "https://palworld.fandom.com/wiki/Tanzee",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Tanzee_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1280,
+            "size": "xs",
+            "stats": {
+                "hp": 80.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "lumbering": 1,
+                "transporting": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 15,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "mushroom"
+            ],
+            "breeding": {
+                "power": 1250,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/008_tanzee.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Galeclaw"
+                ],
+                [
+                    "Cattiva",
+                    "Gorirat"
+                ],
+                [
+                    "Chikipi",
+                    "Robinquill Terra"
+                ],
+                [
+                    "Lifmunk",
+                    "Beegarde"
+                ],
+                [
+                    "Foxparks",
+                    "Gobfin Ignis"
+                ]
+            ]
+        },
+        "9": {
+            "id": 9,
+            "key": "9",
+            "name": "Rooby",
+            "wiki": "https://palworld.fandom.com/wiki/Rooby",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Rooby_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 2950,
+            "size": "s",
+            "stats": {
+                "hp": 75.0,
+                "attack": 100.0,
+                "defense": 75.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "kindling": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 1155,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/009_rooby.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Broncherry Aqua"
+                ],
+                [
+                    "Cattiva",
+                    "Digtoise"
+                ],
+                [
+                    "Chikipi",
+                    "Dinossom Lux"
+                ],
+                [
+                    "Lifmunk",
+                    "Reindrix"
+                ],
+                [
+                    "Foxparks",
+                    "Mozzarina"
+                ]
+            ]
+        },
+        "10": {
+            "id": 10,
+            "key": "10",
+            "name": "Pengullet",
+            "wiki": "https://palworld.fandom.com/wiki/Pengullet",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/38/Pengullet_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1080,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "watering": 1,
+                "cooling": 1
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "hydro_jet",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "ice_organ",
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 1350,
+                "type1": "Water",
+                "type2": "Ice"
+            },
+            "types": [
+                "Water",
+                "Ice"
+            ],
+            "localImage": "assets/pals/010_pengullet.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Daedream"
+                ],
+                [
+                    "Cattiva",
+                    "Gumoss"
+                ],
+                [
+                    "Lifmunk",
+                    "Kelpsea Ignis"
+                ],
+                [
+                    "Foxparks",
+                    "Swee"
+                ],
+                [
+                    "Fuack",
+                    "Jolthog"
+                ]
+            ]
+        },
+        "11": {
+            "id": 11,
+            "key": "11",
+            "name": "Penking",
+            "wiki": "https://palworld.fandom.com/wiki/Penking",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Penking_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 5410,
+            "size": "l",
+            "stats": {
+                "hp": 95.0,
+                "attack": 70.0,
+                "defense": 95.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "handiwork": 2,
+                "transporting": 2,
+                "watering": 2,
+                "mining": 2,
+                "cooling": 2
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 7,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "emperor_slide",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "ice_organ",
+                "penking_plume"
+            ],
+            "breeding": {
+                "power": 520,
+                "type1": "Water",
+                "type2": "Ice"
+            },
+            "types": [
+                "Water",
+                "Ice"
+            ],
+            "localImage": "assets/pals/011_penking.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Penking"
+                ],
+                [
+                    "Mozzarina",
+                    "Cryolinx"
+                ],
+                [
+                    "Melpaca",
+                    "Astegon"
+                ],
+                [
+                    "Eikthyrdeer",
+                    "Frostallion"
+                ],
+                [
+                    "Nitewing",
+                    "Vanwyrm Cryst"
+                ]
+            ]
+        },
+        "12": {
+            "id": 12,
+            "key": "12",
+            "name": "Jolthog",
+            "wiki": "https://palworld.fandom.com/wiki/Jolthog",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/52/Jolthog_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1060,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "generating_electricity": 1
+            },
+            "skills": [
+                {
+                    "name": "shockwave",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "electric_ball",
+                    "level": 15,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 40,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 1370,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/012_jolthog.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Kelpsea Ignis"
+                ],
+                [
+                    "Cattiva",
+                    "Flopie"
+                ],
+                [
+                    "Chikipi",
+                    "Gumoss"
+                ],
+                [
+                    "Lifmunk",
+                    "Ribbuny"
+                ],
+                [
+                    "Foxparks",
+                    "Tocotoco"
+                ]
+            ]
+        },
+        "13": {
+            "id": 13,
+            "key": "13",
+            "name": "Gumoss",
+            "wiki": "https://palworld.fandom.com/wiki/Gumoss",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/2e/Gumoss_menu.png/",
+            "genus": "other",
+            "rarity": 1,
+            "price": 1310,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "planting": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 22,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "berry_seeds",
+                "gumoss_leaf"
+            ],
+            "breeding": {
+                "power": 1240,
+                "type1": "Grass",
+                "type2": "Ground"
+            },
+            "types": [
+                "Grass",
+                "Ground"
+            ],
+            "localImage": "assets/pals/013_gumoss.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Felbat"
+                ],
+                [
+                    "Cattiva",
+                    "Robinquill"
+                ],
+                [
+                    "Chikipi",
+                    "Fenglope"
+                ],
+                [
+                    "Lifmunk",
+                    "Vaelet"
+                ],
+                [
+                    "Foxparks",
+                    "Cawgnito"
+                ]
+            ]
+        },
+        "14": {
+            "id": 14,
+            "key": "14",
+            "name": "Vixy",
+            "wiki": "https://palworld.fandom.com/wiki/Vixy",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/9e/Vixy_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 1000,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 350.0,
+                "stamina": 100.0,
+                "support": 140.0,
+                "food": 1.0
+            },
+            "work": {
+                "gathering": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 30,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "bone"
+            ],
+            "breeding": {
+                "power": 1450,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/014_vixy.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Lifmunk"
+                ],
+                [
+                    "Cattiva",
+                    "Mau Cryst"
+                ],
+                [
+                    "Chikipi",
+                    "Foxparks"
+                ],
+                [
+                    "Sparkit",
+                    "Teafant"
+                ],
+                [
+                    "Vixy",
+                    "Vixy"
+                ]
+            ]
+        },
+        "15": {
+            "id": 15,
+            "key": "15",
+            "name": "Hoocrates",
+            "wiki": "https://palworld.fandom.com/wiki/Hoocrates",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/ef/Hoocrates_menu.png/",
+            "genus": "bird",
+            "rarity": 1,
+            "price": 1050,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 80.0,
+                "speed": 380.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "fiber",
+                "high_grade_technical_manual"
+            ],
+            "breeding": {
+                "power": 1390,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/015_hoocrates.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Ribbuny"
+                ],
+                [
+                    "Cattiva",
+                    "Bristla"
+                ],
+                [
+                    "Chikipi",
+                    "Flopie"
+                ],
+                [
+                    "Lifmunk",
+                    "Pengullet"
+                ],
+                [
+                    "Foxparks",
+                    "Depresso"
+                ]
+            ]
+        },
+        "16": {
+            "id": 16,
+            "key": "16",
+            "name": "Teafant",
+            "wiki": "https://palworld.fandom.com/wiki/Teafant",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Teafant_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1000,
+            "size": "m",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "watering": 1
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "hydro_jet",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 1490,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/016_teafant.png",
+            "breedingCombos": [
+                [
+                    "Chikipi",
+                    "Mau"
+                ],
+                [
+                    "Teafant",
+                    "Teafant"
+                ],
+                [
+                    "Lamball",
+                    "Chikipi"
+                ],
+                [
+                    "Teafant",
+                    "Mau"
+                ]
+            ]
+        },
+        "17": {
+            "id": 17,
+            "key": "17",
+            "name": "Depresso",
+            "wiki": "https://palworld.fandom.com/wiki/Depresso",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d9/Depresso_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1050,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "poison_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "venom_gland"
+            ],
+            "breeding": {
+                "power": 1380,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/017_depresso.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Killamari"
+                ],
+                [
+                    "Cattiva",
+                    "Swee"
+                ],
+                [
+                    "Chikipi",
+                    "Kelpsea"
+                ],
+                [
+                    "Lifmunk",
+                    "Fuack"
+                ],
+                [
+                    "Foxparks",
+                    "Jolthog Cryst"
+                ]
+            ]
+        },
+        "18": {
+            "id": 18,
+            "key": "18",
+            "name": "Cremis",
+            "wiki": "https://palworld.fandom.com/wiki/Cremis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a1/Cremis_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1420,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 75.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "spark_blast",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 30,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wool"
+            ],
+            "breeding": {
+                "power": 1455,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/018_cremis.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Mau Cryst"
+                ],
+                [
+                    "Cattiva",
+                    "Vixy"
+                ],
+                [
+                    "Chikipi",
+                    "Sparkit"
+                ],
+                [
+                    "Lifmunk",
+                    "Mau"
+                ],
+                [
+                    "Teafant",
+                    "Hangyu"
+                ]
+            ]
+        },
+        "19": {
+            "id": 19,
+            "key": "19",
+            "name": "Daedream",
+            "wiki": "https://palworld.fandom.com/wiki/Daedream",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/e6/Daedream_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1330,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 60.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "dark_ball",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "venom_gland",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 1230,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/019_daedream.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Verdash"
+                ],
+                [
+                    "Cattiva",
+                    "Robinquill Terra"
+                ],
+                [
+                    "Lifmunk",
+                    "Galeclaw"
+                ],
+                [
+                    "Foxparks",
+                    "Direhowl"
+                ],
+                [
+                    "Fuack",
+                    "Rushoar"
+                ]
+            ]
+        },
+        "20": {
+            "id": 20,
+            "key": "20",
+            "name": "Rushoar",
+            "wiki": "https://palworld.fandom.com/wiki/Rushoar",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d0/Rushoar_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1680,
+            "size": "s",
+            "stats": {
+                "hp": 80.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "reckless_charge",
+                    "level": 1,
+                    "power": 55,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "rushoar_pork",
+                "leather",
+                "bone"
+            ],
+            "breeding": {
+                "power": 1130,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/020_rushoar.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Arsox"
+                ],
+                [
+                    "Cattiva",
+                    "Chillet"
+                ],
+                [
+                    "Chikipi",
+                    "Foxcicle"
+                ],
+                [
+                    "Lifmunk",
+                    "Kitsun"
+                ],
+                [
+                    "Foxparks",
+                    "Broncherry"
+                ]
+            ]
+        },
+        "21": {
+            "id": 21,
+            "key": "21",
+            "name": "Nox",
+            "wiki": "https://palworld.fandom.com/wiki/Nox",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/55/Nox_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 1480,
+            "size": "xs",
+            "stats": {
+                "hp": 75.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 140.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 1180,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/021_nox.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Melpaca"
+                ],
+                [
+                    "Cattiva",
+                    "Eikthyrdeer Terra"
+                ],
+                [
+                    "Chikipi",
+                    "Broncherry"
+                ],
+                [
+                    "Lifmunk",
+                    "Caprity"
+                ],
+                [
+                    "Fuack",
+                    "Galeclaw"
+                ]
+            ]
+        },
+        "22": {
+            "id": 22,
+            "key": "22",
+            "name": "Fuddler",
+            "wiki": "https://palworld.fandom.com/wiki/Fuddler",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/64/Fuddler_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1360,
+            "size": "xs",
+            "stats": {
+                "hp": 65.0,
+                "attack": 100.0,
+                "defense": 50.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather"
+            ],
+            "breeding": {
+                "power": 1220,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/022_fuddler.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Fenglope"
+                ],
+                [
+                    "Chikipi",
+                    "Lovander"
+                ],
+                [
+                    "Lifmunk",
+                    "Felbat"
+                ],
+                [
+                    "Foxparks",
+                    "Gorirat"
+                ],
+                [
+                    "Fuack",
+                    "Lunaris"
+                ]
+            ]
+        },
+        "23": {
+            "id": 23,
+            "key": "23",
+            "name": "Killamari",
+            "wiki": "https://palworld.fandom.com/wiki/Killamari",
+            "image": "https://static.wikia.nocookie.net/palworld/images/8/80/Killamari_menu.png/",
+            "genus": "other",
+            "rarity": 1,
+            "price": 1200,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "transporting": 2,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "venom_gland"
+            ],
+            "breeding": {
+                "power": 1290,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/023_killamari.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Lunaris"
+                ],
+                [
+                    "Cattiva",
+                    "Leezpunk"
+                ],
+                [
+                    "Chikipi",
+                    "Cawgnito"
+                ],
+                [
+                    "Lifmunk",
+                    "Maraith"
+                ],
+                [
+                    "Foxparks",
+                    "Nox"
+                ]
+            ]
+        },
+        "24": {
+            "id": 24,
+            "key": "24",
+            "name": "Mau",
+            "wiki": "https://palworld.fandom.com/wiki/Mau",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/17/Mau_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 1,
+            "price": 1000,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 475.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "gold_coin"
+            ],
+            "breeding": {
+                "power": 1480,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/024_mau.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Teafant"
+                ],
+                [
+                    "Cattiva",
+                    "Chikipi"
+                ],
+                [
+                    "Mau",
+                    "Mau"
+                ],
+                [
+                    "Chikipi",
+                    "Cremis"
+                ]
+            ]
+        },
+        "25": {
+            "id": 25,
+            "key": "25",
+            "name": "Celaray",
+            "wiki": "https://palworld.fandom.com/wiki/Celaray",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/95/Celaray_menu.png/",
+            "genus": "other",
+            "rarity": 3,
+            "price": 2860,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "transporting": 1,
+                "watering": 1
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 30,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 870,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/025_celaray.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Cattiva",
+                    "Relaxaurus"
+                ],
+                [
+                    "Chikipi",
+                    "Pyrin Noct"
+                ],
+                [
+                    "Lifmunk",
+                    "Jormuntide"
+                ],
+                [
+                    "Foxparks",
+                    "Warsect"
+                ]
+            ]
+        },
+        "26": {
+            "id": 26,
+            "key": "26",
+            "name": "Direhowl",
+            "wiki": "https://palworld.fandom.com/wiki/Direhowl",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/19/Direhowl_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 1920,
+            "size": "s",
+            "stats": {
+                "hp": 80.0,
+                "attack": 110.0,
+                "defense": 75.0,
+                "speed": 800.0,
+                "stamina": 70.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "fierce_fang",
+                    "level": 1,
+                    "power": 45,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 15,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ignis_blast",
+                    "level": 30,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "ruby",
+                "gold_coin"
+            ],
+            "breeding": {
+                "power": 1060,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/026_direhowl.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Vanwyrm"
+                ],
+                [
+                    "Chikipi",
+                    "Vanwyrm Cryst"
+                ],
+                [
+                    "Fuack",
+                    "Arsox"
+                ],
+                [
+                    "Sparkit",
+                    "Blazehowl"
+                ],
+                [
+                    "Tanzee",
+                    "Celaray"
+                ]
+            ]
+        },
+        "27": {
+            "id": 27,
+            "key": "27",
+            "name": "Tocotoco",
+            "wiki": "https://palworld.fandom.com/wiki/Tocotoco",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Tocotoco_menu.png/",
+            "genus": "bird",
+            "rarity": 1,
+            "price": 1090,
+            "size": "s",
+            "stats": {
+                "hp": 60.0,
+                "attack": 80.0,
+                "defense": 70.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 70.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "implode",
+                    "level": 1,
+                    "power": 180,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "megaton_implode",
+                    "level": 22,
+                    "power": 250,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "gunpowder",
+                "tocotoco_feather"
+            ],
+            "breeding": {
+                "power": 1340,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/027_tocotoco.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Dazzi"
+                ],
+                [
+                    "Cattiva",
+                    "Fuddler"
+                ],
+                [
+                    "Chikipi",
+                    "Nox"
+                ],
+                [
+                    "Lifmunk",
+                    "Tanzee"
+                ],
+                [
+                    "Foxparks",
+                    "Flopie"
+                ]
+            ]
+        },
+        "28": {
+            "id": 28,
+            "key": "28",
+            "name": "Flopie",
+            "wiki": "https://palworld.fandom.com/wiki/Flopie",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Flopie_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1220,
+            "size": "xs",
+            "stats": {
+                "hp": 75.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "gathering": 1,
+                "medicine_production": 1,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "hydro_jet",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 22,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "low_grade_medical_supplies",
+                "wheat_seeds"
+            ],
+            "breeding": {
+                "power": 1280,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/028_flopie.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Gobfin"
+                ],
+                [
+                    "Cattiva",
+                    "Gobfin Ignis"
+                ],
+                [
+                    "Chikipi",
+                    "Direhowl"
+                ],
+                [
+                    "Lifmunk",
+                    "Rushoar"
+                ],
+                [
+                    "Foxparks",
+                    "Wixen"
+                ]
+            ]
+        },
+        "29": {
+            "id": 29,
+            "key": "29",
+            "name": "Mozzarina",
+            "wiki": "https://palworld.fandom.com/wiki/Mozzarina",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/3a/Mozzarina_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 2620,
+            "size": "s",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 580.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 15,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "mozzarina_meat",
+                "milk"
+            ],
+            "breeding": {
+                "power": 910,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/029_mozzarina.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Quivern"
+                ],
+                [
+                    "Cattiva",
+                    "Pyrin"
+                ],
+                [
+                    "Chikipi",
+                    "Reptyro"
+                ],
+                [
+                    "Lifmunk",
+                    "Mossanda Lux"
+                ],
+                [
+                    "Foxparks",
+                    "Nitewing"
+                ]
+            ]
+        },
+        "30": {
+            "id": 30,
+            "key": "30",
+            "name": "Bristla",
+            "wiki": "https://palworld.fandom.com/wiki/Bristla",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Bristla_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1140,
+            "size": "s",
+            "stats": {
+                "hp": 80.0,
+                "attack": 80.0,
+                "defense": 80.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "medicine_production": 2,
+                "transporting": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wheat_seeds",
+                "lettuce_seeds"
+            ],
+            "breeding": {
+                "power": 1320,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/030_bristla.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Nox"
+                ],
+                [
+                    "Chikipi",
+                    "Leezpunk Ignis"
+                ],
+                [
+                    "Lifmunk",
+                    "Dazzi"
+                ],
+                [
+                    "Foxparks",
+                    "Gumoss"
+                ],
+                [
+                    "Fuack",
+                    "Ribbuny"
+                ]
+            ]
+        },
+        "31": {
+            "id": 31,
+            "key": "31",
+            "name": "Gobfin",
+            "wiki": "https://palworld.fandom.com/wiki/Gobfin",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/ff/Gobfin_menu.png/",
+            "genus": "humanoid",
+            "rarity": 2,
+            "price": 1840,
+            "size": "s",
+            "stats": {
+                "hp": 90.0,
+                "attack": 90.0,
+                "defense": 75.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "watering": 2
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 1090,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/031_gobfin.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Blazehowl"
+                ],
+                [
+                    "Chikipi",
+                    "Univolt"
+                ],
+                [
+                    "Lifmunk",
+                    "Tombat"
+                ],
+                [
+                    "Foxparks",
+                    "Petallia"
+                ],
+                [
+                    "Fuack",
+                    "Digtoise"
+                ]
+            ]
+        },
+        "32": {
+            "id": 32,
+            "key": "32",
+            "name": "Hangyu",
+            "wiki": "https://palworld.fandom.com/wiki/Hangyu",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/08/Hangyu_menu.png/",
+            "genus": "other",
+            "rarity": 1,
+            "price": 1020,
+            "size": "xs",
+            "stats": {
+                "hp": 80.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 2,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "fiber"
+            ],
+            "breeding": {
+                "power": 1420,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/032_hangyu.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Jolthog"
+                ],
+                [
+                    "Cattiva",
+                    "Depresso"
+                ],
+                [
+                    "Chikipi",
+                    "Tocotoco"
+                ],
+                [
+                    "Lifmunk",
+                    "Sparkit"
+                ],
+                [
+                    "Foxparks",
+                    "Mau Cryst"
+                ]
+            ]
+        },
+        "33": {
+            "id": 33,
+            "key": "33",
+            "name": "Mossanda",
+            "wiki": "https://palworld.fandom.com/wiki/Mossanda",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Mossanda_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 6200,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "planting": 2,
+                "handiwork": 2,
+                "lumbering": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "crushing_punch",
+                    "level": 22,
+                    "power": 85,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "mushroom",
+                "leather",
+                "tomato_seeds"
+            ],
+            "breeding": {
+                "power": 430,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/033_mossanda.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Warsect"
+                ],
+                [
+                    "Mossanda",
+                    "Mossanda"
+                ],
+                [
+                    "Nitewing",
+                    "Ice Kingpaca"
+                ],
+                [
+                    "Incineram",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Cinnamoth",
+                    "Faleris"
+                ]
+            ]
+        },
+        "34": {
+            "id": 34,
+            "key": "34",
+            "name": "Woolipop",
+            "wiki": "https://palworld.fandom.com/wiki/Woolipop",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/fa/Woolipop_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 3,
+            "price": 1450,
+            "size": "s",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 90.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "cotton_candy",
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 1190,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/034_woolipop.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Mozzarina"
+                ],
+                [
+                    "Cattiva",
+                    "Eikthyrdeer"
+                ],
+                [
+                    "Chikipi",
+                    "Reindrix"
+                ],
+                [
+                    "Lifmunk",
+                    "Loupmoon"
+                ],
+                [
+                    "Foxparks",
+                    "Fenglope"
+                ]
+            ]
+        },
+        "35": {
+            "id": 35,
+            "key": "35",
+            "name": "Caprity",
+            "wiki": "https://palworld.fandom.com/wiki/Caprity",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Caprity_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 3,
+            "price": 2510,
+            "size": "s",
+            "stats": {
+                "hp": 100.0,
+                "attack": 70.0,
+                "defense": 90.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 120.0,
+                "food": 4.0
+            },
+            "work": {
+                "planting": 2,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "caprity_meat",
+                "red_berries",
+                "horn"
+            ],
+            "breeding": {
+                "power": 930,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/035_caprity.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Mossanda Lux"
+                ],
+                [
+                    "Chikipi",
+                    "Pyrin"
+                ],
+                [
+                    "Lifmunk",
+                    "Mossanda"
+                ],
+                [
+                    "Foxparks",
+                    "Wumpo"
+                ],
+                [
+                    "Fuack",
+                    "Elphidran Aqua"
+                ]
+            ]
+        },
+        "36": {
+            "id": 36,
+            "key": "36",
+            "name": "Melpaca",
+            "wiki": "https://palworld.fandom.com/wiki/Melpaca",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7f/Melpaca_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 3,
+            "price": 2740,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 90.0,
+                "defense": 90.0,
+                "speed": 460.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "fluffy_tackle",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 22,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 30,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wool",
+                "leather"
+            ],
+            "breeding": {
+                "power": 890,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/036_melpaca.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Jormuntide"
+                ],
+                [
+                    "Cattiva",
+                    "Reptyro"
+                ],
+                [
+                    "Chikipi",
+                    "Relaxaurus"
+                ],
+                [
+                    "Lifmunk",
+                    "Quivern"
+                ],
+                [
+                    "Foxparks",
+                    "Ragnahawk"
+                ]
+            ]
+        },
+        "37": {
+            "id": 37,
+            "key": "37",
+            "name": "Eikthyrdeer",
+            "wiki": "https://palworld.fandom.com/wiki/Eikthyrdeer",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Eikthyrdeer_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 4,
+            "price": 2620,
+            "size": "l",
+            "stats": {
+                "hp": 95.0,
+                "attack": 70.0,
+                "defense": 80.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "antler_uppercut",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 5.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "eikthyrdeer_venison",
+                "leather",
+                "horn"
+            ],
+            "breeding": {
+                "power": 920,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/037_eikthyrdeer.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Faleris"
+                ],
+                [
+                    "Cattiva",
+                    "Ragnahawk"
+                ],
+                [
+                    "Chikipi",
+                    "Warsect"
+                ],
+                [
+                    "Lifmunk",
+                    "Sweepa"
+                ],
+                [
+                    "Foxparks",
+                    "Ice Kingpaca"
+                ]
+            ]
+        },
+        "38": {
+            "id": 38,
+            "key": "38",
+            "name": "Nitewing",
+            "wiki": "https://palworld.fandom.com/wiki/Nitewing",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/34/Nitewing_menu.png/",
+            "genus": "bird",
+            "rarity": 3,
+            "price": 6300,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "tornado_attack",
+                    "level": 7,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather"
+            ],
+            "breeding": {
+                "power": 420,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/038_nitewing.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Reptyro"
+                ],
+                [
+                    "Mossanda",
+                    "Sweepa"
+                ],
+                [
+                    "Nitewing",
+                    "Nitewing"
+                ],
+                [
+                    "Incineram",
+                    "Lyleen"
+                ],
+                [
+                    "Cinnamoth",
+                    "Quivern"
+                ]
+            ]
+        },
+        "39": {
+            "id": 39,
+            "key": "39",
+            "name": "Ribbuny",
+            "wiki": "https://palworld.fandom.com/wiki/Ribbuny",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7e/Ribbuny_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 1160,
+            "size": "xs",
+            "stats": {
+                "hp": 75.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 245.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 22,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "beautiful_flower"
+            ],
+            "breeding": {
+                "power": 1310,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/039_ribbuny.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Maraith"
+                ],
+                [
+                    "Cattiva",
+                    "Wixen"
+                ],
+                [
+                    "Chikipi",
+                    "Leezpunk"
+                ],
+                [
+                    "Lifmunk",
+                    "Woolipop"
+                ],
+                [
+                    "Foxparks",
+                    "Fuddler"
+                ]
+            ]
+        },
+        "40": {
+            "id": 40,
+            "key": "40",
+            "name": "Incineram",
+            "wiki": "https://palworld.fandom.com/wiki/Incineram",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Incineram_menu.png/",
+            "genus": "humanoid",
+            "rarity": 4,
+            "price": 4780,
+            "size": "m",
+            "stats": {
+                "hp": 95.0,
+                "attack": 150.0,
+                "defense": 85.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "kindling": 1,
+                "handiwork": 2,
+                "transporting": 2,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "hellfire_claw",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 50,
+                    "power": 120,
+                    "cooldown": 40.0
+                }
+            ],
+            "drops": [
+                "horn",
+                "leather"
+            ],
+            "breeding": {
+                "power": 590,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/040_incineram.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Vanwyrm"
+                ],
+                [
+                    "Rushoar",
+                    "Suzaku"
+                ],
+                [
+                    "Celaray",
+                    "Jormuntide"
+                ],
+                [
+                    "Direhowl",
+                    "Frostallion"
+                ],
+                [
+                    "Mozzarina",
+                    "Relaxaurus Lux"
+                ]
+            ]
+        },
+        "41": {
+            "id": 41,
+            "key": "41",
+            "name": "Cinnamoth",
+            "wiki": "https://palworld.fandom.com/wiki/Cinnamoth",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7e/Cinnamoth_menu.png/",
+            "genus": "bird",
+            "rarity": 4,
+            "price": 5700,
+            "size": "m",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "planting": 2,
+                "medicine_production": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_fog",
+                    "level": 15,
+                    "power": 0,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 30,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "honey",
+                "lettuce_seeds",
+                "wheat_seeds"
+            ],
+            "breeding": {
+                "power": 490,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/041_cinnamoth.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Wumpo"
+                ],
+                [
+                    "Mozzarina",
+                    "Necromus"
+                ],
+                [
+                    "Mossanda",
+                    "Surfent Terra"
+                ],
+                [
+                    "Caprity",
+                    "Suzaku"
+                ],
+                [
+                    "Melpaca",
+                    "Jetragon"
+                ]
+            ]
+        },
+        "42": {
+            "id": 42,
+            "key": "42",
+            "name": "Arsox",
+            "wiki": "https://palworld.fandom.com/wiki/Arsox",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/f5/Arsox_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 4,
+            "price": 3520,
+            "size": "m",
+            "stats": {
+                "hp": 85.0,
+                "attack": 100.0,
+                "defense": 95.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "kindling": 2,
+                "lumbering": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "blazing_horn",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "horn",
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 790,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/042_arsox.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Frostallion"
+                ],
+                [
+                    "Chikipi",
+                    "Paladius"
+                ],
+                [
+                    "Lifmunk",
+                    "Astegon"
+                ],
+                [
+                    "Fuack",
+                    "Lyleen"
+                ],
+                [
+                    "Tanzee",
+                    "Elizabee"
+                ]
+            ]
+        },
+        "43": {
+            "id": 43,
+            "key": "43",
+            "name": "Dumud",
+            "wiki": "https://palworld.fandom.com/wiki/Dumud",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Dumud_menu.png/",
+            "genus": "fish",
+            "rarity": 4,
+            "price": 4690,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 95.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "watering": 1,
+                "mining": 2,
+                "transporting": 1
+            },
+            "skills": [],
+            "drops": [
+                "raw_dumud",
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 895,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/043_dumud.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Reptyro"
+                ],
+                [
+                    "Cattiva",
+                    "Elizabee"
+                ],
+                [
+                    "Chikipi",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Lifmunk",
+                    "Pyrin"
+                ],
+                [
+                    "Foxparks",
+                    "Mossanda Lux"
+                ]
+            ]
+        },
+        "44": {
+            "id": 44,
+            "key": "44",
+            "name": "Cawgnito",
+            "wiki": "https://palworld.fandom.com/wiki/Cawgnito",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/f6/Cawgnito_menu.png/",
+            "genus": "bird",
+            "rarity": 3,
+            "price": 1840,
+            "size": "m",
+            "stats": {
+                "hp": 75.0,
+                "attack": 80.0,
+                "defense": 80.0,
+                "speed": 920.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "lumbering": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "phantom_peck",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "venom_gland",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 1080,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/044_cawgnito.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Katress"
+                ],
+                [
+                    "Chikipi",
+                    "Vanwyrm"
+                ],
+                [
+                    "Foxparks",
+                    "Foxcicle"
+                ],
+                [
+                    "Fuack",
+                    "Kitsun"
+                ],
+                [
+                    "Sparkit",
+                    "Tombat"
+                ]
+            ]
+        },
+        "45": {
+            "id": 45,
+            "key": "45",
+            "name": "Leezpunk",
+            "wiki": "https://palworld.fandom.com/wiki/Leezpunk",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/09/Leezpunk_menu.png/",
+            "genus": "humanoid",
+            "rarity": 2,
+            "price": 1720,
+            "size": "s",
+            "stats": {
+                "hp": 80.0,
+                "attack": 90.0,
+                "defense": 50.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "handiwork": 1,
+                "gathering": 1,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "poison_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "copper_key",
+                "silver_key"
+            ],
+            "breeding": {
+                "power": 1120,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/045_leezpunk.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Petallia"
+                ],
+                [
+                    "Chikipi",
+                    "Rayhound"
+                ],
+                [
+                    "Lifmunk",
+                    "Dinossom Lux"
+                ],
+                [
+                    "Foxparks",
+                    "Broncherry Aqua"
+                ],
+                [
+                    "Fuack",
+                    "Mozzarina"
+                ]
+            ]
+        },
+        "46": {
+            "id": 46,
+            "key": "46",
+            "name": "Loupmoon",
+            "wiki": "https://palworld.fandom.com/wiki/Loupmoon",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/00/Loupmoon_menu.png/",
+            "genus": "humanoid",
+            "rarity": 3,
+            "price": 2400,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 130.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "handiwork": 2
+            },
+            "skills": [
+                {
+                    "name": "dark_ball",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "jumping_claw",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone"
+            ],
+            "breeding": {
+                "power": 950,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/046_loupmoon.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Mossanda"
+                ],
+                [
+                    "Cattiva",
+                    "Ice Kingpaca"
+                ],
+                [
+                    "Lifmunk",
+                    "Kingpaca"
+                ],
+                [
+                    "Foxparks",
+                    "Azurobe"
+                ],
+                [
+                    "Fuack",
+                    "Anubis"
+                ]
+            ]
+        },
+        "47": {
+            "id": 47,
+            "key": "47",
+            "name": "Galeclaw",
+            "wiki": "https://palworld.fandom.com/wiki/Galeclaw",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/08/Galeclaw_menu.png/",
+            "genus": "bird",
+            "rarity": 2,
+            "price": 2010,
+            "size": "m",
+            "stats": {
+                "hp": 75.0,
+                "attack": 120.0,
+                "defense": 60.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "gale_claw",
+                    "level": 1,
+                    "power": 60,
+                    "cooldown": 8.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "galeclaw_poultry",
+                "leather"
+            ],
+            "breeding": {
+                "power": 1030,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/047_galeclaw.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Incineram"
+                ],
+                [
+                    "Chikipi",
+                    "Surfent"
+                ],
+                [
+                    "Foxparks",
+                    "Vanwyrm"
+                ],
+                [
+                    "Tanzee",
+                    "Dinossom Lux"
+                ],
+                [
+                    "Pengullet",
+                    "Blazehowl"
+                ]
+            ]
+        },
+        "48": {
+            "id": 48,
+            "key": "48",
+            "name": "Robinquill",
+            "wiki": "https://palworld.fandom.com/wiki/Robinquill",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/bb/Robinquill_menu.png/",
+            "genus": "humanoid",
+            "rarity": 5,
+            "price": 2050,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 2,
+                "lumbering": 1,
+                "medicine_production": 1,
+                "transporting": 2,
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "focus_shot",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wheat_seeds",
+                "arrow"
+            ],
+            "breeding": {
+                "power": 1020,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/048_robinquill.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Anubis"
+                ],
+                [
+                    "Cattiva",
+                    "Incineram Noct"
+                ],
+                [
+                    "Chikipi",
+                    "Elphidran"
+                ],
+                [
+                    "Foxparks",
+                    "Bushi"
+                ],
+                [
+                    "Fuack",
+                    "Blazehowl"
+                ]
+            ]
+        },
+        "49": {
+            "id": 49,
+            "key": "49",
+            "name": "Gorirat",
+            "wiki": "https://palworld.fandom.com/wiki/Gorirat",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Gorirat_menu.png/",
+            "genus": "humanoid",
+            "rarity": 5,
+            "price": 2010,
+            "size": "s",
+            "stats": {
+                "hp": 90.0,
+                "attack": 110.0,
+                "defense": 90.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "handiwork": 1,
+                "lumbering": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ground_pound",
+                    "level": 15,
+                    "power": 85,
+                    "cooldown": 14.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 30,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "bone"
+            ],
+            "breeding": {
+                "power": 1040,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/049_gorirat.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Vanwyrm Cryst"
+                ],
+                [
+                    "Chikipi",
+                    "Incineram Noct"
+                ],
+                [
+                    "Foxparks",
+                    "Univolt"
+                ],
+                [
+                    "Fuack",
+                    "Tombat"
+                ],
+                [
+                    "Sparkit",
+                    "Blazehowl Noct"
+                ]
+            ]
+        },
+        "50": {
+            "id": 50,
+            "key": "50",
+            "name": "Beegarde",
+            "wiki": "https://palworld.fandom.com/wiki/Beegarde",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7b/Beegarde_menu.png/",
+            "genus": "humanoid",
+            "rarity": 4,
+            "price": 1880,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "lumbering": 1,
+                "medicine_production": 1,
+                "transporting": 2,
+                "gathering": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "bee_quiet",
+                    "level": 15,
+                    "power": 200,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 22,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "honey"
+            ],
+            "breeding": {
+                "power": 1070,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/050_beegarde.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Blazehowl Noct"
+                ],
+                [
+                    "Cattiva",
+                    "Univolt"
+                ],
+                [
+                    "Chikipi",
+                    "Bushi"
+                ],
+                [
+                    "Lifmunk",
+                    "Blazehowl"
+                ],
+                [
+                    "Foxparks",
+                    "Rayhound"
+                ]
+            ]
+        },
+        "51": {
+            "id": 51,
+            "key": "51",
+            "name": "Elizabee",
+            "wiki": "https://palworld.fandom.com/wiki/Elizabee",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Elizabee_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 6830,
+            "size": "l",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "planting": 2,
+                "handiwork": 2,
+                "lumbering": 1,
+                "medicine_production": 2,
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spinning_lance",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "honey",
+                "elizabee's_staff"
+            ],
+            "breeding": {
+                "power": 330,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/051_elizabee.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Orserk"
+                ],
+                [
+                    "Mossanda",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Nitewing",
+                    "Pyrin Noct"
+                ],
+                [
+                    "Incineram",
+                    "Necromus"
+                ],
+                [
+                    "Elizabee",
+                    "Elizabee"
+                ]
+            ]
+        },
+        "52": {
+            "id": 52,
+            "key": "52",
+            "name": "Grintale",
+            "wiki": "https://palworld.fandom.com/wiki/Grintale",
+            "image": "https://static.wikia.nocookie.net/palworld/images/c/c3/Grintale_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 5510,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "cat_press",
+                    "level": 15,
+                    "power": 60,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 510,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/052_grintale.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Azurobe"
+                ],
+                [
+                    "Celaray",
+                    "Astegon"
+                ],
+                [
+                    "Mossanda",
+                    "Incineram"
+                ],
+                [
+                    "Caprity",
+                    "Jetragon"
+                ],
+                [
+                    "Melpaca",
+                    "Cryolinx"
+                ]
+            ]
+        },
+        "53": {
+            "id": 53,
+            "key": "53",
+            "name": "Swee",
+            "wiki": "https://palworld.fandom.com/wiki/Swee",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b5/Swee_menu.png/",
+            "genus": "other",
+            "rarity": 1,
+            "price": 1180,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 100.0,
+                "defense": 60.0,
+                "speed": 250.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1,
+                "cooling": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "wool"
+            ],
+            "breeding": {
+                "power": 1300,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/053_swee.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Rushoar"
+                ],
+                [
+                    "Cattiva",
+                    "Leezpunk Ignis"
+                ],
+                [
+                    "Chikipi",
+                    "Gobfin Ignis"
+                ],
+                [
+                    "Fuack",
+                    "Kelpsea Ignis"
+                ],
+                [
+                    "Sparkit",
+                    "Woolipop"
+                ]
+            ]
+        },
+        "54": {
+            "id": 54,
+            "key": "54",
+            "name": "Sweepa",
+            "wiki": "https://palworld.fandom.com/wiki/Sweepa",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/f3/Sweepa_menu.png/",
+            "genus": "other",
+            "rarity": 6,
+            "price": 6400,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 2,
+                "cooling": 2
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "wool"
+            ],
+            "breeding": {
+                "power": 410,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/054_sweepa.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Mammorest"
+                ],
+                [
+                    "Mossanda",
+                    "Mossanda Lux"
+                ],
+                [
+                    "Incineram",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Cinnamoth",
+                    "Elizabee"
+                ],
+                [
+                    "Arsox",
+                    "Suzaku Aqua"
+                ]
+            ]
+        },
+        "55": {
+            "id": 55,
+            "key": "55",
+            "name": "Chillet",
+            "wiki": "https://palworld.fandom.com/wiki/Chillet",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/49/Chillet_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 4,
+            "price": 3450,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 1,
+                "cooling": 1
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather"
+            ],
+            "breeding": {
+                "power": 800,
+                "type1": "Ice",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Ice",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/055_chillet.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Cryolinx"
+                ],
+                [
+                    "Cattiva",
+                    "Orserk"
+                ],
+                [
+                    "Chikipi",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Foxparks",
+                    "Grizzbolt"
+                ],
+                [
+                    "Fuack",
+                    "Relaxaurus Lux"
+                ]
+            ]
+        },
+        "56": {
+            "id": 56,
+            "key": "56",
+            "name": "Univolt",
+            "wiki": "https://palworld.fandom.com/wiki/Univolt",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/0e/Univolt_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 5,
+            "price": 4280,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 110.0,
+                "defense": 105.0,
+                "speed": 720.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "generating_electricity": 2,
+                "lumbering": 1
+            },
+            "skills": [
+                {
+                    "name": "spark_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "lock-on_laser",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "electric_organ",
+                "horn"
+            ],
+            "breeding": {
+                "power": 680,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/056_univolt.png",
+            "breedingCombos": [
+                [
+                    "Fuack",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Pengullet",
+                    "Blazamut"
+                ],
+                [
+                    "Penking",
+                    "Broncherry Aqua"
+                ],
+                [
+                    "Gumoss",
+                    "Frostallion"
+                ],
+                [
+                    "Daedream",
+                    "Cryolinx"
+                ]
+            ]
+        },
+        "57": {
+            "id": 57,
+            "key": "57",
+            "name": "Foxcicle",
+            "wiki": "https://palworld.fandom.com/wiki/Foxcicle",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Foxcicle_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 5,
+            "price": 3730,
+            "size": "s",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 105.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "cooling": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 760,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/057_foxcicle.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Suzaku"
+                ],
+                [
+                    "Cattiva",
+                    "Shadowbeak"
+                ],
+                [
+                    "Lifmunk",
+                    "Jetragon"
+                ],
+                [
+                    "Foxparks",
+                    "Frostallion"
+                ],
+                [
+                    "Fuack",
+                    "Helzephyr"
+                ]
+            ]
+        },
+        "58": {
+            "id": 58,
+            "key": "58",
+            "name": "Pyrin",
+            "wiki": "https://palworld.fandom.com/wiki/Pyrin",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/e6/Pyrin_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 6720,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 110.0,
+                "defense": 90.0,
+                "speed": 850.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "kindling": 2,
+                "lumbering": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ignis_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_slam",
+                    "level": 30,
+                    "power": 85,
+                    "cooldown": 14.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 360,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/058_pyrin.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Grizzbolt"
+                ],
+                [
+                    "Mossanda",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Nitewing",
+                    "Mammorest"
+                ],
+                [
+                    "Incineram",
+                    "Cryolinx"
+                ],
+                [
+                    "Cinnamoth",
+                    "Ice Reptyro"
+                ]
+            ]
+        },
+        "59": {
+            "id": 59,
+            "key": "59",
+            "name": "Reindrix",
+            "wiki": "https://palworld.fandom.com/wiki/Reindrix",
+            "image": "https://static.wikia.nocookie.net/palworld/images/c/c1/Reindrix_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 4,
+            "price": 2800,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 80.0,
+                "defense": 110.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "lumbering": 2,
+                "cooling": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "freezing_charge",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "reindrix_venison",
+                "leather",
+                "horn",
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 880,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/059_reindrix.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Cattiva",
+                    "Mammorest"
+                ],
+                [
+                    "Chikipi",
+                    "Menasting"
+                ],
+                [
+                    "Lifmunk",
+                    "Elizabee"
+                ],
+                [
+                    "Foxparks",
+                    "Pyrin"
+                ]
+            ]
+        },
+        "60": {
+            "id": 60,
+            "key": "60",
+            "name": "Rayhound",
+            "wiki": "https://palworld.fandom.com/wiki/Rayhound",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/3f/Rayhound_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 5,
+            "price": 3880,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "generating_electricity": 2
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "spark_blast",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "electric_ball",
+                    "level": 30,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 40,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 740,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/060_rayhound.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Blazamut"
+                ],
+                [
+                    "Lifmunk",
+                    "Suzaku"
+                ],
+                [
+                    "Foxparks",
+                    "Paladius"
+                ],
+                [
+                    "Fuack",
+                    "Astegon"
+                ],
+                [
+                    "Sparkit",
+                    "Necromus"
+                ]
+            ]
+        },
+        "61": {
+            "id": 61,
+            "key": "61",
+            "name": "Kitsun",
+            "wiki": "https://palworld.fandom.com/wiki/Kitsun",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/6b/Kitsun_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 3170,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 70.0,
+                "defense": 100.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 110.0,
+                "food": 4.0
+            },
+            "work": {
+                "kindling": 2
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 15,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "daring_flames",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 830,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/061_kitsun.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Helzephyr"
+                ],
+                [
+                    "Cattiva",
+                    "Grizzbolt"
+                ],
+                [
+                    "Lifmunk",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Foxparks",
+                    "Menasting"
+                ],
+                [
+                    "Fuack",
+                    "Elizabee"
+                ]
+            ]
+        },
+        "62": {
+            "id": 62,
+            "key": "62",
+            "name": "Dazzi",
+            "wiki": "https://palworld.fandom.com/wiki/Dazzi",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b0/Dazzi_menu.png/",
+            "genus": "humanoid",
+            "rarity": 2,
+            "price": 1390,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 110.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "generating_electricity": 1,
+                "handiwork": 1,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 1210,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/062_dazzi.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Loupmoon"
+                ],
+                [
+                    "Chikipi",
+                    "Eikthyrdeer"
+                ],
+                [
+                    "Lifmunk",
+                    "Verdash"
+                ],
+                [
+                    "Foxparks",
+                    "Robinquill"
+                ],
+                [
+                    "Fuack",
+                    "Gobfin"
+                ]
+            ]
+        },
+        "63": {
+            "id": 63,
+            "key": "63",
+            "name": "Lunaris",
+            "wiki": "https://palworld.fandom.com/wiki/Lunaris",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/38/Lunaris_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 1760,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 80.0,
+                "defense": 90.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1,
+                "transporting": 1,
+                "handiwork": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "plasma_tornado",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "paldium_fragment"
+            ],
+            "breeding": {
+                "power": 1110,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/063_lunaris.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Tombat"
+                ],
+                [
+                    "Cattiva",
+                    "Foxcicle"
+                ],
+                [
+                    "Lifmunk",
+                    "Arsox"
+                ],
+                [
+                    "Foxparks",
+                    "Dinossom"
+                ],
+                [
+                    "Fuack",
+                    "Melpaca"
+                ]
+            ]
+        },
+        "64": {
+            "id": 64,
+            "key": "64",
+            "name": "Dinossom",
+            "wiki": "https://palworld.fandom.com/wiki/Dinossom",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b7/Dinossom_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 3240,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 90.0,
+                "defense": 90.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 150.0,
+                "food": 6.0
+            },
+            "work": {
+                "planting": 2,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "botanical_smash",
+                    "level": 7,
+                    "power": 60,
+                    "cooldown": 8.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wheat_seeds"
+            ],
+            "breeding": {
+                "power": 820,
+                "type1": "Grass",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Grass",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/064_dinossom.png",
+            "breedingCombos": [
+                [
+                    "Chikipi",
+                    "Orserk"
+                ],
+                [
+                    "Lifmunk",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Foxparks",
+                    "Pyrin Noct"
+                ],
+                [
+                    "Fuack",
+                    "Jormuntide"
+                ],
+                [
+                    "Sparkit",
+                    "Ice Reptyro"
+                ]
+            ]
+        },
+        "65": {
+            "id": 65,
+            "key": "65",
+            "name": "Surfent",
+            "wiki": "https://palworld.fandom.com/wiki/Surfent",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/1d/Surfent_menu.png/",
+            "genus": "fish",
+            "rarity": 4,
+            "price": 5050,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 70.0,
+                "defense": 80.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "watering": 2
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 560,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/065_surfent.png",
+            "breedingCombos": [
+                [
+                    "Celaray",
+                    "Lyleen"
+                ],
+                [
+                    "Direhowl",
+                    "Shadowbeak"
+                ],
+                [
+                    "Mozzarina",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Gobfin",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Caprity",
+                    "Helzephyr"
+                ]
+            ]
+        },
+        "66": {
+            "id": 66,
+            "key": "66",
+            "name": "Maraith",
+            "wiki": "https://palworld.fandom.com/wiki/Maraith",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Maraith_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 1570,
+            "size": "m",
+            "stats": {
+                "hp": 75.0,
+                "attack": 50.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 2,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 1150,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/066_maraith.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Kitsun"
+                ],
+                [
+                    "Cattiva",
+                    "Broncherry Aqua"
+                ],
+                [
+                    "Chikipi",
+                    "Chillet"
+                ],
+                [
+                    "Lifmunk",
+                    "Celaray"
+                ],
+                [
+                    "Foxparks",
+                    "Eikthyrdeer Terra"
+                ]
+            ]
+        },
+        "67": {
+            "id": 67,
+            "key": "67",
+            "name": "Digtoise",
+            "wiki": "https://palworld.fandom.com/wiki/Digtoise",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Digtoise_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 5,
+            "price": 2980,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 80.0,
+                "defense": 120.0,
+                "speed": 300.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "mining": 3
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shell_spin",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "ore",
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 850,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/067_digtoise.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Cattiva",
+                    "Pyrin Noct"
+                ],
+                [
+                    "Chikipi",
+                    "Grizzbolt"
+                ],
+                [
+                    "Lifmunk",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Foxparks",
+                    "Mammorest"
+                ]
+            ]
+        },
+        "68": {
+            "id": 68,
+            "key": "68",
+            "name": "Tombat",
+            "wiki": "https://palworld.fandom.com/wiki/Tombat",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/f2/Tombat_menu.png/",
+            "genus": "humanoid",
+            "rarity": 5,
+            "price": 3810,
+            "size": "m",
+            "stats": {
+                "hp": 95.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "gathering": 2,
+                "mining": 2,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 750,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/068_tombat.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Lifmunk",
+                    "Necromus"
+                ],
+                [
+                    "Foxparks",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Sparkit",
+                    "Jetragon"
+                ],
+                [
+                    "Tanzee",
+                    "Lyleen"
+                ]
+            ]
+        },
+        "69": {
+            "id": 69,
+            "key": "69",
+            "name": "Lovander",
+            "wiki": "https://palworld.fandom.com/wiki/Lovander",
+            "image": "https://static.wikia.nocookie.net/palworld/images/c/c8/Lovander_menu.png/",
+            "genus": "humanoid",
+            "rarity": 5,
+            "price": 2450,
+            "size": "l",
+            "stats": {
+                "hp": 120.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 750.0,
+                "stamina": 100.0,
+                "support": 140.0,
+                "food": 5.0
+            },
+            "work": {
+                "handiwork": 2,
+                "medicine_production": 2,
+                "transporting": 2,
+                "mining": 1
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "implode",
+                    "level": 40,
+                    "power": 180,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "mushroom",
+                "cake",
+                "suspicious_juice",
+                "strange_juice"
+            ],
+            "breeding": {
+                "power": 940,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/069_lovander.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Sweepa"
+                ],
+                [
+                    "Cattiva",
+                    "Nitewing"
+                ],
+                [
+                    "Chikipi",
+                    "Ragnahawk"
+                ],
+                [
+                    "Lifmunk",
+                    "Sibelyx"
+                ],
+                [
+                    "Foxparks",
+                    "Wumpo Botan"
+                ]
+            ]
+        },
+        "70": {
+            "id": 70,
+            "key": "70",
+            "name": "Flambelle",
+            "wiki": "https://palworld.fandom.com/wiki/Flambelle",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/20/Flambelle_menu.png/",
+            "genus": "humanoid",
+            "rarity": 1,
+            "price": 2500,
+            "size": "xs",
+            "stats": {
+                "hp": 60.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 250.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "kindling": 1,
+                "handiwork": 1,
+                "transporting": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 1405,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/070_flambelle.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Tocotoco"
+                ],
+                [
+                    "Cattiva",
+                    "Pengullet"
+                ],
+                [
+                    "Chikipi",
+                    "Ribbuny"
+                ],
+                [
+                    "Lifmunk",
+                    "Depresso"
+                ],
+                [
+                    "Foxparks",
+                    "Sparkit"
+                ]
+            ]
+        },
+        "71": {
+            "id": 71,
+            "key": "71",
+            "name": "Vanwyrm",
+            "wiki": "https://palworld.fandom.com/wiki/Vanwyrm",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/ea/Vanwyrm_menu.png/",
+            "genus": "bird",
+            "rarity": 4,
+            "price": 4360,
+            "size": "l",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 700.0,
+                "stamina": 150.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "kindling": 1,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ignis_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "ruby",
+                "gold_coin"
+            ],
+            "breeding": {
+                "power": 660,
+                "type1": "Fire",
+                "type2": "Dark"
+            },
+            "types": [
+                "Fire",
+                "Dark"
+            ],
+            "localImage": "assets/pals/071_vanwyrm.png",
+            "breedingCombos": [
+                [
+                    "Tanzee",
+                    "Necromus"
+                ],
+                [
+                    "Penking",
+                    "Chillet"
+                ],
+                [
+                    "Gumoss",
+                    "Paladius"
+                ],
+                [
+                    "Daedream",
+                    "Jetragon"
+                ],
+                [
+                    "Rushoar",
+                    "Helzephyr"
+                ]
+            ]
+        },
+        "72": {
+            "id": 72,
+            "key": "72",
+            "name": "Bushi",
+            "wiki": "https://palworld.fandom.com/wiki/Bushi",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/73/Bushi_menu.png/",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 4520,
+            "size": "m",
+            "stats": {
+                "hp": 80.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "kindling": 2,
+                "handiwork": 1,
+                "transporting": 2,
+                "lumbering": 3,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iaigiri",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 50,
+                    "power": 120,
+                    "cooldown": 40.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "ingot"
+            ],
+            "breeding": {
+                "power": 640,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/072_bushi.png",
+            "breedingCombos": [
+                [
+                    "Tanzee",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Penking",
+                    "Foxcicle"
+                ],
+                [
+                    "Daedream",
+                    "Suzaku"
+                ],
+                [
+                    "Rushoar",
+                    "Astegon"
+                ],
+                [
+                    "Nox",
+                    "Frostallion Noct"
+                ]
+            ]
+        },
+        "73": {
+            "id": 73,
+            "key": "73",
+            "name": "Beakon",
+            "wiki": "https://palworld.fandom.com/wiki/Beakon",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Beakon_menu.png/",
+            "genus": "bird",
+            "rarity": 6,
+            "price": 7490,
+            "size": "l",
+            "stats": {
+                "hp": 105.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 750.0,
+                "stamina": 160.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "gathering": 1,
+                "generating_electricity": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spark_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 220,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/073_beakon.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Blazamut"
+                ],
+                [
+                    "Sweepa",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Pyrin",
+                    "Paladius"
+                ],
+                [
+                    "Beakon",
+                    "Beakon"
+                ],
+                [
+                    "Ragnahawk",
+                    "Shadowbeak"
+                ]
+            ]
+        },
+        "74": {
+            "id": 74,
+            "key": "74",
+            "name": "Ragnahawk",
+            "wiki": "https://palworld.fandom.com/wiki/Ragnahawk",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/dd/Ragnahawk_menu.png/",
+            "genus": "bird",
+            "rarity": 7,
+            "price": 6720,
+            "size": "l",
+            "stats": {
+                "hp": 95.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 800.0,
+                "stamina": 150.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "kindling": 3,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 380,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/074_ragnahawk.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Pyrin Noct"
+                ],
+                [
+                    "Mossanda",
+                    "Elizabee"
+                ],
+                [
+                    "Nitewing",
+                    "Warsect"
+                ],
+                [
+                    "Cinnamoth",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Grintale",
+                    "Lyleen"
+                ]
+            ]
+        },
+        "75": {
+            "id": 75,
+            "key": "75",
+            "name": "Katress",
+            "wiki": "https://palworld.fandom.com/wiki/Katress",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/9e/Katress_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 4120,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 440.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "medicine_production": 2,
+                "handiwork": 2,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "katress_hair",
+                "high_grade_technical_manual"
+            ],
+            "breeding": {
+                "power": 700,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/075_katress.png",
+            "breedingCombos": [
+                [
+                    "Fuack",
+                    "Necromus"
+                ],
+                [
+                    "Tanzee",
+                    "Astegon"
+                ],
+                [
+                    "Pengullet",
+                    "Suzaku"
+                ],
+                [
+                    "Penking",
+                    "Reindrix"
+                ],
+                [
+                    "Jolthog",
+                    "Suzaku Aqua"
+                ]
+            ]
+        },
+        "76": {
+            "id": 76,
+            "key": "76",
+            "name": "Wixen",
+            "wiki": "https://palworld.fandom.com/wiki/Wixen",
+            "image": "https://static.wikia.nocookie.net/palworld/images/8/85/Wixen_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 1540,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 50.0,
+                "defense": 80.0,
+                "speed": 440.0,
+                "stamina": 100.0,
+                "support": 120.0,
+                "food": 5.0
+            },
+            "work": {
+                "kindling": 2,
+                "handiwork": 3,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "high_grade_technical_manual"
+            ],
+            "breeding": {
+                "power": 1160,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/076_wixen.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Digtoise"
+                ],
+                [
+                    "Cattiva",
+                    "Broncherry"
+                ],
+                [
+                    "Chikipi",
+                    "Dinossom"
+                ],
+                [
+                    "Lifmunk",
+                    "Melpaca"
+                ],
+                [
+                    "Foxparks",
+                    "Eikthyrdeer"
+                ]
+            ]
+        },
+        "77": {
+            "id": 77,
+            "key": "77",
+            "name": "Verdash",
+            "wiki": "https://palworld.fandom.com/wiki/Verdash",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/43/Verdash_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 2200,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 3,
+                "lumbering": 2,
+                "handiwork": 3,
+                "planting": 2,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 7,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 15,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "bone"
+            ],
+            "breeding": {
+                "power": 990,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/077_verdash.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Grintale"
+                ],
+                [
+                    "Cattiva",
+                    "Penking"
+                ],
+                [
+                    "Chikipi",
+                    "Wumpo Botan"
+                ],
+                [
+                    "Lifmunk",
+                    "Surfent Terra"
+                ],
+                [
+                    "Foxparks",
+                    "Incineram Noct"
+                ]
+            ]
+        },
+        "78": {
+            "id": 78,
+            "key": "78",
+            "name": "Vaelet",
+            "wiki": "https://palworld.fandom.com/wiki/Vaelet",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/24/Vaelet_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 1960,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 2,
+                "handiwork": 2,
+                "medicine_production": 3,
+                "planting": 2,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "poison_fog",
+                    "level": 1,
+                    "power": 0,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "low_grade_medical_supplies",
+                "tomato_seeds"
+            ],
+            "breeding": {
+                "power": 1050,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/078_vaelet.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Bushi"
+                ],
+                [
+                    "Lifmunk",
+                    "Blazehowl Noct"
+                ],
+                [
+                    "Foxparks",
+                    "Katress"
+                ],
+                [
+                    "Tanzee",
+                    "Digtoise"
+                ],
+                [
+                    "Pengullet",
+                    "Tombat"
+                ]
+            ]
+        },
+        "79": {
+            "id": 79,
+            "key": "79",
+            "name": "Sibelyx",
+            "wiki": "https://palworld.fandom.com/wiki/Sibelyx",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/66/Sibelyx_menu.png/",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 5900,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 90.0,
+                "defense": 100.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 90.0,
+                "food": 5.0
+            },
+            "work": {
+                "medicine_production": 2,
+                "cooling": 2,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "high_quality_cloth",
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 450,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/079_sibelyx.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Ragnahawk"
+                ],
+                [
+                    "Celaray",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Mossanda",
+                    "Kingpaca"
+                ],
+                [
+                    "Melpaca",
+                    "Blazamut"
+                ],
+                [
+                    "Nitewing",
+                    "Wumpo Botan"
+                ]
+            ]
+        },
+        "80": {
+            "id": 80,
+            "key": "80",
+            "name": "Elphidran",
+            "wiki": "https://palworld.fandom.com/wiki/Elphidran",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a6/Elphidran_menu.png/",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 5230,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 80.0,
+                "defense": 90.0,
+                "speed": 630.0,
+                "stamina": 130.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "dragon_cannon",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "mystic_whirlwind",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 540,
+                "type1": "Dragon",
+                "type2": null
+            },
+            "types": [
+                "Dragon"
+            ],
+            "localImage": "assets/pals/080_elphidran.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Surfent"
+                ],
+                [
+                    "Celaray",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Caprity",
+                    "Astegon"
+                ],
+                [
+                    "Melpaca",
+                    "Helzephyr"
+                ],
+                [
+                    "Nitewing",
+                    "Vanwyrm"
+                ]
+            ]
+        },
+        "81": {
+            "id": 81,
+            "key": "81",
+            "name": "Kelpsea",
+            "wiki": "https://palworld.fandom.com/wiki/Kelpsea",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/1b/Kelpsea_menu.png/",
+            "genus": "dragon",
+            "rarity": 1,
+            "price": 1260,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "watering": 1
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "raw_kelpsea",
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 1260,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/081_kelpsea.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Vaelet"
+                ],
+                [
+                    "Cattiva",
+                    "Direhowl"
+                ],
+                [
+                    "Chikipi",
+                    "Robinquill"
+                ],
+                [
+                    "Lifmunk",
+                    "Gobfin"
+                ],
+                [
+                    "Foxparks",
+                    "Leezpunk"
+                ]
+            ]
+        },
+        "82": {
+            "id": 82,
+            "key": "82",
+            "name": "Azurobe",
+            "wiki": "https://palworld.fandom.com/wiki/Azurobe",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a0/Azurobe_menu.png/",
+            "genus": "fish",
+            "rarity": 7,
+            "price": 5600,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 70.0,
+                "defense": 100.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "watering": 3
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "cloth",
+                "precious_dragon_stone"
+            ],
+            "breeding": {
+                "power": 500,
+                "type1": "Water",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Water",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/082_azurobe.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Wumpo Botan"
+                ],
+                [
+                    "Celaray",
+                    "Cryolinx"
+                ],
+                [
+                    "Mozzarina",
+                    "Jetragon"
+                ],
+                [
+                    "Mossanda",
+                    "Anubis"
+                ],
+                [
+                    "Caprity",
+                    "Necromus"
+                ]
+            ]
+        },
+        "83": {
+            "id": 83,
+            "key": "83",
+            "name": "Cryolinx",
+            "wiki": "https://palworld.fandom.com/wiki/Cryolinx",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/9d/Cryolinx_menu.png/",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 8440,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 140.0,
+                "defense": 110.0,
+                "speed": 720.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "handiwork": 1,
+                "lumbering": 2,
+                "cooling": 3
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 130,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/083_cryolinx.png",
+            "breedingCombos": [
+                [
+                    "Cryolinx",
+                    "Cryolinx"
+                ],
+                [
+                    "Blazamut",
+                    "Lyleen"
+                ],
+                [
+                    "Helzephyr",
+                    "Necromus"
+                ],
+                [
+                    "Suzaku",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Grizzbolt",
+                    "Shadowbeak"
+                ]
+            ]
+        },
+        "84": {
+            "id": 84,
+            "key": "84",
+            "name": "Blazehowl",
+            "wiki": "https://palworld.fandom.com/wiki/Blazehowl",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/33/Blazehowl_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 7,
+            "price": 4040,
+            "size": "l",
+            "stats": {
+                "hp": 105.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 750.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "kindling": 3,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 30,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 710,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/084_blazehowl.png",
+            "breedingCombos": [
+                [
+                    "Fuack",
+                    "Jetragon"
+                ],
+                [
+                    "Sparkit",
+                    "Blazamut"
+                ],
+                [
+                    "Pengullet",
+                    "Necromus"
+                ],
+                [
+                    "Penking",
+                    "Eikthyrdeer Terra"
+                ],
+                [
+                    "Jolthog",
+                    "Suzaku"
+                ]
+            ]
+        },
+        "85": {
+            "id": 85,
+            "key": "85",
+            "name": "Relaxaurus",
+            "wiki": "https://palworld.fandom.com/wiki/Relaxaurus",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/01/Relaxaurus_menu.png/",
+            "genus": "monster",
+            "rarity": 8,
+            "price": 10240,
+            "size": "xl",
+            "stats": {
+                "hp": 110.0,
+                "attack": 110.0,
+                "defense": 70.0,
+                "speed": 650.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "watering": 2,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "dragon_cannon",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil",
+                "ruby"
+            ],
+            "breeding": {
+                "power": 280,
+                "type1": "Dragon",
+                "type2": "Water"
+            },
+            "types": [
+                "Dragon",
+                "Water"
+            ],
+            "localImage": "assets/pals/085_relaxaurus.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Cryolinx"
+                ],
+                [
+                    "Nitewing",
+                    "Orserk"
+                ],
+                [
+                    "Cinnamoth",
+                    "Necromus"
+                ],
+                [
+                    "Elizabee",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Grintale",
+                    "Suzaku"
+                ]
+            ]
+        },
+        "86": {
+            "id": 86,
+            "key": "86",
+            "name": "Broncherry",
+            "wiki": "https://palworld.fandom.com/wiki/Broncherry",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/bd/Broncherry_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 7,
+            "price": 2920,
+            "size": "xl",
+            "stats": {
+                "hp": 120.0,
+                "attack": 80.0,
+                "defense": 100.0,
+                "speed": 350.0,
+                "stamina": 100.0,
+                "support": 120.0,
+                "food": 7.0
+            },
+            "work": {
+                "planting": 3
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "muscle_slam",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 12.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "broncherry_meat",
+                "tomato_seeds"
+            ],
+            "breeding": {
+                "power": 860,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/086_broncherry.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Lyleen"
+                ],
+                [
+                    "Cattiva",
+                    "Menasting"
+                ],
+                [
+                    "Chikipi",
+                    "Beakon"
+                ],
+                [
+                    "Lifmunk",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Foxparks",
+                    "Reptyro"
+                ]
+            ]
+        },
+        "87": {
+            "id": 87,
+            "key": "87",
+            "name": "Petallia",
+            "wiki": "https://palworld.fandom.com/wiki/Petallia",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/28/Petallia_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 3590,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "planting": 3,
+                "handiwork": 2,
+                "gathering": 2,
+                "medicine_production": 2,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 15,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "beautiful_flower"
+            ],
+            "breeding": {
+                "power": 780,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/087_petallia.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Jetragon"
+                ],
+                [
+                    "Cattiva",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Chikipi",
+                    "Shadowbeak"
+                ],
+                [
+                    "Lifmunk",
+                    "Cryolinx"
+                ],
+                [
+                    "Fuack",
+                    "Ice Reptyro"
+                ]
+            ]
+        },
+        "88": {
+            "id": 88,
+            "key": "88",
+            "name": "Reptyro",
+            "wiki": "https://palworld.fandom.com/wiki/Reptyro",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d0/Reptyro_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 6940,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 390.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "kindling": 3,
+                "mining": 3
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "volcanic_burst",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 320,
+                "type1": "Ground",
+                "type2": "Fire"
+            },
+            "types": [
+                "Ground",
+                "Fire"
+            ],
+            "localImage": "assets/pals/088_reptyro.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Frostallion"
+                ],
+                [
+                    "Mossanda",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Nitewing",
+                    "Beakon"
+                ],
+                [
+                    "Incineram",
+                    "Suzaku"
+                ],
+                [
+                    "Cinnamoth",
+                    "Astegon"
+                ]
+            ]
+        },
+        "89": {
+            "id": 89,
+            "key": "89",
+            "name": "Kingpaca",
+            "wiki": "https://palworld.fandom.com/wiki/Kingpaca",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/9d/Kingpaca_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 8,
+            "price": 5800,
+            "size": "xl",
+            "stats": {
+                "hp": 120.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "kingly_slam",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 21.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wool"
+            ],
+            "breeding": {
+                "power": 470,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/089_kingpaca.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Nitewing"
+                ],
+                [
+                    "Celaray",
+                    "Necromus"
+                ],
+                [
+                    "Mozzarina",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Mossanda",
+                    "Grintale"
+                ],
+                [
+                    "Caprity",
+                    "Blazamut"
+                ]
+            ]
+        },
+        "90": {
+            "id": 90,
+            "key": "90",
+            "name": "Mammorest",
+            "wiki": "https://palworld.fandom.com/wiki/Mammorest",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Mammorest_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 8,
+            "price": 9450,
+            "size": "xl",
+            "stats": {
+                "hp": 150.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 430.0,
+                "stamina": 100.0,
+                "support": 30.0,
+                "food": 8.0
+            },
+            "work": {
+                "planting": 2,
+                "lumbering": 2,
+                "mining": 2
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "earth_impact",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil",
+                "leather",
+                "mammorest_meat"
+            ],
+            "breeding": {
+                "power": 300,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/090_mammorest.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Paladius"
+                ],
+                [
+                    "Incineram",
+                    "Blazamut"
+                ],
+                [
+                    "Elizabee",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Grintale",
+                    "Jetragon"
+                ],
+                [
+                    "Sweepa",
+                    "Helzephyr"
+                ]
+            ]
+        },
+        "91": {
+            "id": 91,
+            "key": "91",
+            "name": "Wumpo",
+            "wiki": "https://palworld.fandom.com/wiki/Wumpo",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/0e/Wumpo_menu.png/",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 5900,
+            "size": "l",
+            "stats": {
+                "hp": 140.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 365.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "handiwork": 2,
+                "lumbering": 3,
+                "cooling": 2,
+                "transporting": 4
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "ice_organ",
+                "beautiful_flower"
+            ],
+            "breeding": {
+                "power": 460,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/091_wumpo.png",
+            "breedingCombos": [
+                [
+                    "Celaray",
+                    "Suzaku"
+                ],
+                [
+                    "Mozzarina",
+                    "Blazamut"
+                ],
+                [
+                    "Mossanda",
+                    "Cinnamoth"
+                ],
+                [
+                    "Melpaca",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Nitewing",
+                    "Azurobe"
+                ]
+            ]
+        },
+        "92": {
+            "id": 92,
+            "key": "92",
+            "name": "Warsect",
+            "wiki": "https://palworld.fandom.com/wiki/Warsect",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a7/Warsect_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 6830,
+            "size": "l",
+            "stats": {
+                "hp": 120.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 1,
+                "lumbering": 3,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "giga_horn",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 11.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "honey"
+            ],
+            "breeding": {
+                "power": 340,
+                "type1": "Grass",
+                "type2": "Ground"
+            },
+            "types": [
+                "Grass",
+                "Ground"
+            ],
+            "localImage": "assets/pals/092_warsect.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Lyleen"
+                ],
+                [
+                    "Nitewing",
+                    "Menasting"
+                ],
+                [
+                    "Incineram",
+                    "Jetragon"
+                ],
+                [
+                    "Cinnamoth",
+                    "Helzephyr"
+                ],
+                [
+                    "Elizabee",
+                    "Quivern"
+                ]
+            ]
+        },
+        "93": {
+            "id": 93,
+            "key": "93",
+            "name": "Fenglope",
+            "wiki": "https://palworld.fandom.com/wiki/Fenglope",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/68/Fenglope_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 3,
+            "price": 2250,
+            "size": "s",
+            "stats": {
+                "hp": 110.0,
+                "attack": 110.0,
+                "defense": 90.0,
+                "speed": 750.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "cloud_tempest",
+                    "level": 15,
+                    "power": 90,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "leather",
+                "horn"
+            ],
+            "breeding": {
+                "power": 980,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/093_fenglope.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Cinnamoth"
+                ],
+                [
+                    "Cattiva",
+                    "Azurobe"
+                ],
+                [
+                    "Chikipi",
+                    "Wumpo"
+                ],
+                [
+                    "Lifmunk",
+                    "Elphidran Aqua"
+                ],
+                [
+                    "Foxparks",
+                    "Surfent"
+                ]
+            ]
+        },
+        "94": {
+            "id": 94,
+            "key": "94",
+            "name": "Felbat",
+            "wiki": "https://palworld.fandom.com/wiki/Felbat",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7d/Felbat_menu.png/",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 2100,
+            "size": "m",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 110.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 110.0,
+                "food": 5.0
+            },
+            "work": {
+                "medicine_production": 3
+            },
+            "skills": [
+                {
+                    "name": "poison_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "cloth",
+                "small_pal_soul"
+            ],
+            "breeding": {
+                "power": 1010,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/094_felbat.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Surfent Terra"
+                ],
+                [
+                    "Cattiva",
+                    "Surfent"
+                ],
+                [
+                    "Chikipi",
+                    "Penking"
+                ],
+                [
+                    "Lifmunk",
+                    "Incineram"
+                ],
+                [
+                    "Foxparks",
+                    "Vanwyrm Cryst"
+                ]
+            ]
+        },
+        "95": {
+            "id": 95,
+            "key": "95",
+            "name": "Quivern",
+            "wiki": "https://palworld.fandom.com/wiki/Quivern",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d9/Quivern_menu.png/",
+            "genus": "dragon",
+            "rarity": 7,
+            "price": 6830,
+            "size": "l",
+            "stats": {
+                "hp": 105.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 800.0,
+                "stamina": 220.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "handiwork": 1,
+                "transporting": 3,
+                "gathering": 2,
+                "mining": 2
+            },
+            "skills": [
+                {
+                    "name": "dragon_cannon",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 350,
+                "type1": "Dragon",
+                "type2": null
+            },
+            "types": [
+                "Dragon"
+            ],
+            "localImage": "assets/pals/095_quivern.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Nitewing",
+                    "Relaxaurus"
+                ],
+                [
+                    "Cinnamoth",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Elizabee",
+                    "Faleris"
+                ],
+                [
+                    "Grintale",
+                    "Helzephyr"
+                ]
+            ]
+        },
+        "96": {
+            "id": 96,
+            "key": "96",
+            "name": "Blazamut",
+            "wiki": "https://palworld.fandom.com/wiki/Blazamut",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/ee/Blazamut_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 9,
+            "price": 10520,
+            "size": "xl",
+            "stats": {
+                "hp": 100.0,
+                "attack": 150.0,
+                "defense": 120.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 50.0,
+                "food": 8.0
+            },
+            "work": {
+                "kindling": 3,
+                "mining": 4
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ignis_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 30,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "coal",
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 10,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/096_blazamut.png",
+            "breedingCombos": [
+                [
+                    "Blazamut",
+                    "Blazamut"
+                ],
+                [
+                    "Blazamut",
+                    "Suzaku Aqua"
+                ]
+            ]
+        },
+        "97": {
+            "id": 97,
+            "key": "97",
+            "name": "Helzephyr",
+            "wiki": "https://palworld.fandom.com/wiki/Helzephyr",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/3c/Helzephyr_menu.png/",
+            "genus": "bird",
+            "rarity": 7,
+            "price": 7840,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 700.0,
+                "stamina": 170.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "spirit_fire",
+                    "level": 1,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "venom_gland",
+                "medium_pal_soul"
+            ],
+            "breeding": {
+                "power": 190,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/097_helzephyr.png",
+            "breedingCombos": [
+                [
+                    "Elizabee",
+                    "Suzaku"
+                ],
+                [
+                    "Cryolinx",
+                    "Lyleen"
+                ],
+                [
+                    "Relaxaurus",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Reptyro",
+                    "Shadowbeak"
+                ],
+                [
+                    "Mammorest",
+                    "Paladius"
+                ]
+            ]
+        },
+        "98": {
+            "id": 98,
+            "key": "98",
+            "name": "Astegon",
+            "wiki": "https://palworld.fandom.com/wiki/Astegon",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/d4/Astegon_menu.png/",
+            "genus": "monster",
+            "rarity": 9,
+            "price": 8200,
+            "size": "xl",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 125.0,
+                "speed": 600.0,
+                "stamina": 300.0,
+                "support": 100.0,
+                "food": 9.0
+            },
+            "work": {
+                "handiwork": 1,
+                "mining": 4
+            },
+            "skills": [
+                {
+                    "name": "dragon_cannon",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 7,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_metal_ingot",
+                "pure_quartz"
+            ],
+            "breeding": {
+                "power": 150,
+                "type1": "Dark",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Dark",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/098_astegon.png",
+            "breedingCombos": [
+                [
+                    "Beakon",
+                    "Paladius"
+                ],
+                [
+                    "Blazamut",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Astegon",
+                    "Astegon"
+                ],
+                [
+                    "Suzaku",
+                    "Lyleen"
+                ],
+                [
+                    "Grizzbolt",
+                    "Frostallion Noct"
+                ]
+            ]
+        },
+        "99": {
+            "id": 99,
+            "key": "99",
+            "name": "Menasting",
+            "wiki": "https://palworld.fandom.com/wiki/Menasting",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/57/Menasting_menu.png/",
+            "genus": "other",
+            "rarity": 9,
+            "price": 7050,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 130.0,
+                "speed": 1000.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "lumbering": 2,
+                "mining": 3
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "coal",
+                "venom_gland"
+            ],
+            "breeding": {
+                "power": 260,
+                "type1": "Dark",
+                "type2": "Ground"
+            },
+            "types": [
+                "Dark",
+                "Ground"
+            ],
+            "localImage": "assets/pals/099_menasting.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Jetragon"
+                ],
+                [
+                    "Nitewing",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Cinnamoth",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Elizabee",
+                    "Helzephyr"
+                ],
+                [
+                    "Grintale",
+                    "Blazamut"
+                ]
+            ]
+        },
+        "100": {
+            "id": 100,
+            "key": "100",
+            "name": "Anubis",
+            "wiki": "https://palworld.fandom.com/wiki/Anubis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/21/Anubis_menu.png/",
+            "genus": "humanoid",
+            "rarity": 10,
+            "price": 4960,
+            "size": "m",
+            "stats": {
+                "hp": 120.0,
+                "attack": 130.0,
+                "defense": 100.0,
+                "speed": 800.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "handiwork": 4,
+                "mining": 3,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "stone_blast",
+                    "level": 1,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 7,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spinning_roundhouse",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 21.0
+                },
+                {
+                    "name": "forceful_charge",
+                    "level": 30,
+                    "power": 120,
+                    "cooldown": 28.0
+                },
+                {
+                    "name": "ground_smash",
+                    "level": 40,
+                    "power": 140,
+                    "cooldown": 35.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "large_pal_soul",
+                "innovative_technical_manual"
+            ],
+            "breeding": {
+                "power": 570,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/100_anubis.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Vanwyrm Cryst"
+                ],
+                [
+                    "Rushoar",
+                    "Blazamut"
+                ],
+                [
+                    "Celaray",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Direhowl",
+                    "Paladius"
+                ],
+                [
+                    "Mozzarina",
+                    "Ice Reptyro"
+                ]
+            ]
+        },
+        "101": {
+            "id": 101,
+            "key": "101",
+            "name": "Jormuntide",
+            "wiki": "https://palworld.fandom.com/wiki/Jormuntide",
+            "image": "https://static.wikia.nocookie.net/palworld/images/8/8e/Jormuntide_menu.png/",
+            "genus": "fish",
+            "rarity": 8,
+            "price": 9320,
+            "size": "xl",
+            "stats": {
+                "hp": 130.0,
+                "attack": 150.0,
+                "defense": 100.0,
+                "speed": 525.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "watering": 4
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 310,
+                "type1": "Dragon",
+                "type2": "Water"
+            },
+            "types": [
+                "Dragon",
+                "Water"
+            ],
+            "localImage": "assets/pals/101_jormuntide.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Mossanda",
+                    "Helzephyr"
+                ],
+                [
+                    "Nitewing",
+                    "Grizzbolt"
+                ],
+                [
+                    "Incineram",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Cinnamoth",
+                    "Cryolinx"
+                ]
+            ]
+        },
+        "102": {
+            "id": 102,
+            "key": "102",
+            "name": "Suzaku",
+            "wiki": "https://palworld.fandom.com/wiki/Suzaku",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/b4/Suzaku_menu.png/",
+            "genus": "bird",
+            "rarity": 8,
+            "price": 9840,
+            "size": "xl",
+            "stats": {
+                "hp": 120.0,
+                "attack": 100.0,
+                "defense": 105.0,
+                "speed": 850.0,
+                "stamina": 350.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "kindling": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ignis_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 50,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/102_suzaku.png",
+            "breedingCombos": [
+                [
+                    "Blazamut",
+                    "Jetragon"
+                ],
+                [
+                    "Suzaku",
+                    "Suzaku"
+                ],
+                [
+                    "Necromus",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Blazamut",
+                    "Paladius"
+                ],
+                [
+                    "Blazamut",
+                    "Frostallion Noct"
+                ]
+            ]
+        },
+        "103": {
+            "id": 103,
+            "key": "103",
+            "name": "Grizzbolt",
+            "wiki": "https://palworld.fandom.com/wiki/Grizzbolt",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Grizzbolt_menu.png/",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 7720,
+            "size": "l",
+            "stats": {
+                "hp": 105.0,
+                "attack": 120.0,
+                "defense": 100.0,
+                "speed": 470.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "generating_electricity": 3,
+                "handiwork": 2,
+                "transporting": 3,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "spark_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "lightning_claw",
+                    "level": 15,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 200,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/103_grizzbolt.png",
+            "breedingCombos": [
+                [
+                    "Elizabee",
+                    "Necromus"
+                ],
+                [
+                    "Cryolinx",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Relaxaurus",
+                    "Frostallion"
+                ],
+                [
+                    "Reptyro",
+                    "Paladius"
+                ],
+                [
+                    "Mammorest",
+                    "Frostallion Noct"
+                ]
+            ]
+        },
+        "104": {
+            "id": 104,
+            "key": "104",
+            "name": "Lyleen",
+            "wiki": "https://palworld.fandom.com/wiki/Lyleen",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Lyleen_menu.png/",
+            "genus": "humanoid",
+            "rarity": 9,
+            "price": 7160,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 105.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "planting": 4,
+                "handiwork": 3,
+                "medicine_production": 3,
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "seed_machine_gun",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 40,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "low_grade_medical_supplies",
+                "beautiful_flower",
+                "innovative_technical_manual"
+            ],
+            "breeding": {
+                "power": 250,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/104_lyleen.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Necromus"
+                ],
+                [
+                    "Nitewing",
+                    "Paladius"
+                ],
+                [
+                    "Cinnamoth",
+                    "Blazamut"
+                ],
+                [
+                    "Sweepa",
+                    "Jetragon"
+                ],
+                [
+                    "Pyrin",
+                    "Orserk"
+                ]
+            ]
+        },
+        "105": {
+            "id": 105,
+            "key": "105",
+            "name": "Faleris",
+            "wiki": "https://palworld.fandom.com/wiki/Faleris",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/99/Faleris_menu.png/",
+            "genus": "bird",
+            "rarity": 9,
+            "price": 6720,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 110.0,
+                "speed": 1000.0,
+                "stamina": 230.0,
+                "support": 90.0,
+                "food": 8.0
+            },
+            "work": {
+                "kindling": 3,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "phoenix_flare",
+                    "level": 30,
+                    "power": 135,
+                    "cooldown": 28.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 370,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/105_faleris.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Beakon"
+                ],
+                [
+                    "Mossanda",
+                    "Jormuntide"
+                ],
+                [
+                    "Nitewing",
+                    "Reptyro"
+                ],
+                [
+                    "Incineram",
+                    "Astegon"
+                ],
+                [
+                    "Cinnamoth",
+                    "Lyleen"
+                ]
+            ]
+        },
+        "106": {
+            "id": 106,
+            "key": "106",
+            "name": "Orserk",
+            "wiki": "https://palworld.fandom.com/wiki/Orserk",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/6e/Orserk_menu.png/",
+            "genus": "humanoid",
+            "rarity": 9,
+            "price": 8320,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 900.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "generating_electricity": 4,
+                "handiwork": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "kerauno",
+                    "level": 1,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 7,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "spark_blast",
+                    "level": 15,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "electric_organ"
+            ],
+            "breeding": {
+                "power": 140,
+                "type1": "Dragon",
+                "type2": "Electric"
+            },
+            "types": [
+                "Dragon",
+                "Electric"
+            ],
+            "localImage": "assets/pals/106_orserk.png",
+            "breedingCombos": [
+                [
+                    "Beakon",
+                    "Shadowbeak"
+                ],
+                [
+                    "Cryolinx",
+                    "Astegon"
+                ],
+                [
+                    "Blazamut",
+                    "Relaxaurus Lux"
+                ],
+                [
+                    "Helzephyr",
+                    "Jetragon"
+                ],
+                [
+                    "Suzaku",
+                    "Ice Reptyro"
+                ]
+            ]
+        },
+        "107": {
+            "id": 107,
+            "key": "107",
+            "name": "Shadowbeak",
+            "wiki": "https://palworld.fandom.com/wiki/Shadowbeak",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/0c/Shadowbeak_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 10,
+            "price": 9060,
+            "size": "l",
+            "stats": {
+                "hp": 120.0,
+                "attack": 130.0,
+                "defense": 140.0,
+                "speed": 850.0,
+                "stamina": 250.0,
+                "support": 90.0,
+                "food": 8.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "divine_disaster",
+                    "level": 40,
+                    "power": 160,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_metal_ingot",
+                "carbon_fiber",
+                "innovative_technical_manual"
+            ],
+            "breeding": {
+                "power": 60,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/107_shadowbeak.png",
+            "breedingCombos": [
+                [
+                    "Suzaku",
+                    "Necromus"
+                ],
+                [
+                    "Shadowbeak",
+                    "Shadowbeak"
+                ],
+                [
+                    "Jetragon",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Blazamut",
+                    "Frostallion"
+                ],
+                [
+                    "Suzaku",
+                    "Paladius"
+                ]
+            ]
+        },
+        "108": {
+            "id": 108,
+            "key": "108",
+            "name": "Paladius",
+            "wiki": "https://palworld.fandom.com/wiki/Paladius",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/09/Paladius_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 20,
+            "price": 8810,
+            "size": "l",
+            "stats": {
+                "hp": 130.0,
+                "attack": 110.0,
+                "defense": 145.0,
+                "speed": 800.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 9.0
+            },
+            "work": {
+                "mining": 2,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 30,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "spear_thrust",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "pal_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_metal_ingot",
+                "diamond"
+            ],
+            "breeding": {
+                "power": 80,
+                "type1": "Neutral",
+                "type2": null
+            },
+            "types": [
+                "Neutral"
+            ],
+            "localImage": "assets/pals/108_paladius.png",
+            "breedingCombos": [
+                [
+                    "Cryolinx",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Blazamut",
+                    "Astegon"
+                ],
+                [
+                    "Shadowbeak",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Paladius",
+                    "Paladius"
+                ],
+                [
+                    "Necromus",
+                    "Jetragon"
+                ]
+            ]
+        },
+        "109": {
+            "id": 109,
+            "key": "109",
+            "name": "Necromus",
+            "wiki": "https://palworld.fandom.com/wiki/Necromus",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/13/Necromus_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 20,
+            "price": 8930,
+            "size": "l",
+            "stats": {
+                "hp": 130.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 900.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 9.0
+            },
+            "work": {
+                "mining": 2,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "shadow_burst",
+                    "level": 1,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 15,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 30,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "twin_spears",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_metal_ingot",
+                "large_pal_soul"
+            ],
+            "breeding": {
+                "power": 70,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/109_necromus.png",
+            "breedingCombos": [
+                [
+                    "Cryolinx",
+                    "Blazamut"
+                ],
+                [
+                    "Suzaku",
+                    "Jetragon"
+                ],
+                [
+                    "Shadowbeak",
+                    "Paladius"
+                ],
+                [
+                    "Necromus",
+                    "Necromus"
+                ]
+            ]
+        },
+        "110": {
+            "id": 110,
+            "key": "110",
+            "name": "Frostallion",
+            "wiki": "https://palworld.fandom.com/wiki/Frostallion",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/00/Frostallion_menu.png/",
+            "genus": "fourlegged",
+            "rarity": 20,
+            "price": 8440,
+            "size": "l",
+            "stats": {
+                "hp": 140.0,
+                "attack": 100.0,
+                "defense": 120.0,
+                "speed": 1000.0,
+                "stamina": 300.0,
+                "support": 70.0,
+                "food": 7.0
+            },
+            "work": {
+                "cooling": 4
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "crystal_wing",
+                    "level": 30,
+                    "power": 110,
+                    "cooldown": 24.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "ice_organ",
+                "diamond"
+            ],
+            "breeding": {
+                "power": 120,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/110_frostallion.png",
+            "breedingCombos": [
+                [
+                    "Blazamut",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Helzephyr",
+                    "Suzaku"
+                ],
+                [
+                    "Astegon",
+                    "Jetragon"
+                ],
+                [
+                    "Orserk",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Frostallion",
+                    "Frostallion"
+                ]
+            ]
+        },
+        "111": {
+            "id": 111,
+            "key": "111",
+            "name": "Jetragon",
+            "wiki": "https://palworld.fandom.com/wiki/Jetragon",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/e5/Jetragon_menu.png/",
+            "genus": "dragon",
+            "rarity": 20,
+            "price": 8680,
+            "size": "xl",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 110.0,
+                "speed": 1700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 9.0
+            },
+            "work": {
+                "gathering": 3
+            },
+            "skills": [
+                {
+                    "name": "spirit_fire",
+                    "level": 1,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "beam_comet",
+                    "level": 30,
+                    "power": 140,
+                    "cooldown": 50.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pure_quartz",
+                "polymer",
+                "carbon_fiber",
+                "diamond"
+            ],
+            "breeding": {
+                "power": 90,
+                "type1": "Dragon",
+                "type2": null
+            },
+            "types": [
+                "Dragon"
+            ],
+            "localImage": "assets/pals/111_jetragon.png",
+            "breedingCombos": [
+                [
+                    "Cryolinx",
+                    "Suzaku"
+                ],
+                [
+                    "Astegon",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Shadowbeak",
+                    "Frostallion"
+                ],
+                [
+                    "Paladius",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Jetragon",
+                    "Jetragon"
+                ]
+            ]
+        },
+        "112": {
+            "id": 112,
+            "key": "012B",
+            "name": "Jolthog Cryst",
+            "wiki": "https://palworld.fandom.com/wiki/Jolthog_Cryst",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/72/Jolthog_Cryst_menu.png",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 1070,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 80.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "cooling": 1
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 1360,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/112_jolthog_cryst.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Tanzee"
+                ],
+                [
+                    "Cattiva",
+                    "Kelpsea"
+                ],
+                [
+                    "Chikipi",
+                    "Fuddler"
+                ],
+                [
+                    "Lifmunk",
+                    "Killamari"
+                ],
+                [
+                    "Foxparks",
+                    "Bristla"
+                ]
+            ]
+        },
+        "113": {
+            "id": 113,
+            "key": "024B",
+            "name": "Mau Cryst",
+            "wiki": "https://palworld.fandom.com/wiki/Mau_Cryst",
+            "image": "https://static.wikia.nocookie.net/palworld/images/7/7a/Mau_Cryst_menu.png",
+            "genus": "fourlegged",
+            "rarity": 2,
+            "price": 1010,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 475.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "cooling": 1,
+                "farming": 1
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "air_cannon",
+                    "level": 7,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "sand_blast",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "ice_organ",
+                "sapphire"
+            ],
+            "breeding": {
+                "power": 1440,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/113_mau_cryst.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Sparkit"
+                ],
+                [
+                    "Cattiva",
+                    "Hangyu"
+                ],
+                [
+                    "Chikipi",
+                    "Depresso"
+                ],
+                [
+                    "Lifmunk",
+                    "Vixy"
+                ],
+                [
+                    "Foxparks",
+                    "Mau"
+                ]
+            ]
+        },
+        "114": {
+            "id": 114,
+            "key": "031B",
+            "name": "Gobfin Ignis",
+            "wiki": "https://palworld.fandom.com/wiki/Gobfin_Ignis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/9/9c/Gobfin_Ignis_menu.png",
+            "genus": "humanoid",
+            "rarity": 3,
+            "price": 1800,
+            "size": "s",
+            "stats": {
+                "hp": 90.0,
+                "attack": 90.0,
+                "defense": 75.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "kindling": 2,
+                "handiwork": 1,
+                "transporting": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 7,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 30,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 50,
+                    "power": 120,
+                    "cooldown": 40.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 1100,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/114_gobfin_ignis.png",
+            "breedingCombos": [
+                [
+                    "Cattiva",
+                    "Rayhound"
+                ],
+                [
+                    "Chikipi",
+                    "Katress"
+                ],
+                [
+                    "Foxparks",
+                    "Chillet"
+                ],
+                [
+                    "Fuack",
+                    "Celaray"
+                ],
+                [
+                    "Sparkit",
+                    "Arsox"
+                ]
+            ]
+        },
+        "115": {
+            "id": 115,
+            "key": "032B",
+            "name": "Hangyu Cryst",
+            "wiki": "https://palworld.fandom.com/wiki/Hangyu_Cryst",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/49/Hangyu_Cryst_menu.png",
+            "genus": "other",
+            "rarity": 2,
+            "price": 1020,
+            "size": "xs",
+            "stats": {
+                "hp": 80.0,
+                "attack": 70.0,
+                "defense": 70.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 2.0
+            },
+            "work": {
+                "gathering": 1,
+                "cooling": 1,
+                "handiwork": 1,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "power_shot",
+                    "level": 15,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "fiber",
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 1422,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/115_hangyu_cryst.png",
+            "breedingCombos": [
+                [
+                    "Hangyu Cryst",
+                    "Hangyu Cryst"
+                ],
+                [
+                    "Hoocrates",
+                    "Cremis"
+                ],
+                [
+                    "Flambelle",
+                    "Mau Cryst"
+                ],
+                [
+                    "Lamball",
+                    "Depresso"
+                ],
+                [
+                    "Cattiva",
+                    "Hoocrates"
+                ]
+            ]
+        },
+        "116": {
+            "id": 116,
+            "key": "033B",
+            "name": "Mossanda Lux",
+            "wiki": "https://palworld.fandom.com/wiki/Mossanda_Lux",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/05/Mossanda_Lux_menu.png",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 6610,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 100.0,
+                "defense": 100.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "generating_electricity": 2,
+                "handiwork": 2,
+                "lumbering": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "spark_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 15,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "blast_punch",
+                    "level": 22,
+                    "power": 85,
+                    "cooldown": 14.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "mushroom",
+                "electric_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 390,
+                "type1": "Electric",
+                "type2": null
+            },
+            "types": [
+                "Electric"
+            ],
+            "localImage": "assets/pals/116_mossanda_lux.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Menasting"
+                ],
+                [
+                    "Mossanda",
+                    "Quivern"
+                ],
+                [
+                    "Nitewing",
+                    "Pyrin"
+                ],
+                [
+                    "Incineram",
+                    "Helzephyr"
+                ],
+                [
+                    "Cinnamoth",
+                    "Mammorest Cryst"
+                ]
+            ]
+        },
+        "117": {
+            "id": 117,
+            "key": "037B",
+            "name": "Eikthyrdeer Terra",
+            "wiki": "https://palworld.fandom.com/wiki/Eikthyrdeer_Terra",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Eikthyrdeer_Terra_menu.png",
+            "genus": "fourlegged",
+            "rarity": 6,
+            "price": 2680,
+            "size": "l",
+            "stats": {
+                "hp": 95.0,
+                "attack": 70.0,
+                "defense": 80.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "power_shot",
+                    "level": 1,
+                    "power": 35,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "antler_uppercut",
+                    "level": 7,
+                    "power": 50,
+                    "cooldown": 5.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 40,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "eikthyrdeer_venison",
+                "leather",
+                "horn"
+            ],
+            "breeding": {
+                "power": 900,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/117_eikthyrdeer_terra.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Elizabee"
+                ],
+                [
+                    "Cattiva",
+                    "Warsect"
+                ],
+                [
+                    "Chikipi",
+                    "Mammorest"
+                ],
+                [
+                    "Lifmunk",
+                    "Faleris"
+                ],
+                [
+                    "Fuack",
+                    "Kingpaca"
+                ]
+            ]
+        },
+        "118": {
+            "id": 118,
+            "key": "040B",
+            "name": "Incineram Noct",
+            "wiki": "https://palworld.fandom.com/wiki/Incineram_Noct",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Incineram_Noct_menu.png",
+            "genus": "humanoid",
+            "rarity": 5,
+            "price": 4870,
+            "size": "m",
+            "stats": {
+                "hp": 95.0,
+                "attack": 150.0,
+                "defense": 85.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 4.0
+            },
+            "work": {
+                "handiwork": 2,
+                "mining": 1,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 7,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "hellfire_claw",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 50,
+                    "power": 120,
+                    "cooldown": 40.0
+                }
+            ],
+            "drops": [
+                "horn",
+                "leather"
+            ],
+            "breeding": {
+                "power": 580,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/118_incineram_noct.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Bushi"
+                ],
+                [
+                    "Rushoar",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Celaray",
+                    "Mammorest Cryst"
+                ],
+                [
+                    "Direhowl",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Mozzarina",
+                    "Lyleen"
+                ]
+            ]
+        },
+        "119": {
+            "id": 119,
+            "key": "045B",
+            "name": "Leezpunk Ignis",
+            "wiki": "https://palworld.fandom.com/wiki/Leezpunk_Ignis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/e/ea/Leezpunk_Ignis_menu.png",
+            "genus": "humanoid",
+            "rarity": 3,
+            "price": 1640,
+            "size": "s",
+            "stats": {
+                "hp": 80.0,
+                "attack": 90.0,
+                "defense": 50.0,
+                "speed": 400.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "kindling": 1,
+                "handiwork": 1,
+                "transporting": 1,
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "poison_blast",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "silver_key"
+            ],
+            "breeding": {
+                "power": 1140,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/119_leezpunk_ignis.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Dinossom Lux"
+                ],
+                [
+                    "Cattiva",
+                    "Dinossom"
+                ],
+                [
+                    "Chikipi",
+                    "Petallia"
+                ],
+                [
+                    "Lifmunk",
+                    "Digtoise"
+                ],
+                [
+                    "Foxparks",
+                    "Reindrix"
+                ]
+            ]
+        },
+        "120": {
+            "id": 120,
+            "key": "048B",
+            "name": "Robinquill Terra",
+            "wiki": "https://palworld.fandom.com/wiki/Robinquill_Terra",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/45/Robinquill_Terra_menu.png",
+            "genus": "humanoid",
+            "rarity": 6,
+            "price": 2150,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 600.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 3.0
+            },
+            "work": {
+                "gathering": 2,
+                "lumbering": 1,
+                "handiwork": 2,
+                "medicine_production": 1,
+                "transporting": 2
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "wind_cutter",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "focus_shot",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 9.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "wheat_seeds",
+                "arrow"
+            ],
+            "breeding": {
+                "power": 1000,
+                "type1": "Grass",
+                "type2": "Ground"
+            },
+            "types": [
+                "Grass",
+                "Ground"
+            ],
+            "localImage": "assets/pals/120_robinquill_terra.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Elphidran Aqua"
+                ],
+                [
+                    "Cattiva",
+                    "Elphidran"
+                ],
+                [
+                    "Chikipi",
+                    "Azurobe"
+                ],
+                [
+                    "Lifmunk",
+                    "Anubis"
+                ],
+                [
+                    "Fuack",
+                    "Blazehowl Noct"
+                ]
+            ]
+        },
+        "121": {
+            "id": 121,
+            "key": "058B",
+            "name": "Pyrin Noct",
+            "wiki": "https://palworld.fandom.com/wiki/Pyrin_Noct",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/2b/Pyrin_Noct_menu.png",
+            "genus": "fourlegged",
+            "rarity": 7,
+            "price": 7270,
+            "size": "l",
+            "stats": {
+                "hp": 100.0,
+                "attack": 110.0,
+                "defense": 90.0,
+                "speed": 850.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "kindling": 2,
+                "lumbering": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "dark_charge",
+                    "level": 30,
+                    "power": 85,
+                    "cooldown": 14.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ",
+                "leather"
+            ],
+            "breeding": {
+                "power": 240,
+                "type1": "Fire",
+                "type2": "Dark"
+            },
+            "types": [
+                "Fire",
+                "Dark"
+            ],
+            "localImage": "assets/pals/121_pyrin_noct.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Suzaku"
+                ],
+                [
+                    "Nitewing",
+                    "Shadowbeak"
+                ],
+                [
+                    "Elizabee",
+                    "Astegon"
+                ],
+                [
+                    "Sweepa",
+                    "Necromus"
+                ],
+                [
+                    "Pyrin",
+                    "Frostallion"
+                ]
+            ]
+        },
+        "122": {
+            "id": 122,
+            "key": "064B",
+            "name": "Dinossom Lux",
+            "wiki": "https://palworld.fandom.com/wiki/Dinossom_Lux",
+            "image": "https://static.wikia.nocookie.net/palworld/images/c/c7/Dinossom_Lux_menu.png",
+            "genus": "humanoid",
+            "rarity": 7,
+            "price": 3380,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 90.0,
+                "defense": 90.0,
+                "speed": 550.0,
+                "stamina": 100.0,
+                "support": 150.0,
+                "food": 6.0
+            },
+            "work": {
+                "generating_electricity": 2,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "shockwave",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "plasma_tornado",
+                    "level": 7,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "botanical_smash",
+                    "level": 15,
+                    "power": 60,
+                    "cooldown": 8.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "tomato_seeds"
+            ],
+            "breeding": {
+                "power": 810,
+                "type1": "Electric",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Electric",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/122_dinossom_lux.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Astegon"
+                ],
+                [
+                    "Chikipi",
+                    "Frostallion"
+                ],
+                [
+                    "Lifmunk",
+                    "Helzephyr"
+                ],
+                [
+                    "Foxparks",
+                    "Beakon"
+                ],
+                [
+                    "Fuack",
+                    "Mammorest Cryst"
+                ]
+            ]
+        },
+        "123": {
+            "id": 123,
+            "key": "065B",
+            "name": "Surfent Terra",
+            "wiki": "https://palworld.fandom.com/wiki/Surfent_Terra",
+            "image": "https://static.wikia.nocookie.net/palworld/images/f/ff/Surfent_Terra_menu.png",
+            "genus": "fish",
+            "rarity": 5,
+            "price": 5140,
+            "size": "m",
+            "stats": {
+                "hp": 90.0,
+                "attack": 70.0,
+                "defense": 100.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "gathering": 1
+            },
+            "skills": [
+                {
+                    "name": "sand_blast",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "stone_cannon",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "sand_tornado",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 550,
+                "type1": "Ground",
+                "type2": null
+            },
+            "types": [
+                "Ground"
+            ],
+            "localImage": "assets/pals/123_surfent_terra.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Incineram Noct"
+                ],
+                [
+                    "Celaray",
+                    "Ice Reptyro"
+                ],
+                [
+                    "Mozzarina",
+                    "Helzephyr"
+                ],
+                [
+                    "Gobfin",
+                    "Blazamut"
+                ],
+                [
+                    "Mossanda",
+                    "Blazehowl Noct"
+                ]
+            ]
+        },
+        "124": {
+            "id": 124,
+            "key": "071B",
+            "name": "Vanwyrm Cryst",
+            "wiki": "https://palworld.fandom.com/wiki/Vanwyrm_Cryst",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/19/Vanwyrm_Cryst_menu.png",
+            "genus": "bird",
+            "rarity": 5,
+            "price": 4610,
+            "size": "l",
+            "stats": {
+                "hp": 90.0,
+                "attack": 100.0,
+                "defense": 95.0,
+                "speed": 700.0,
+                "stamina": 150.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "cooling": 2,
+                "transporting": 3
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "bone",
+                "ice_organ",
+                "sapphire"
+            ],
+            "breeding": {
+                "power": 620,
+                "type1": "Ice",
+                "type2": "Dark"
+            },
+            "types": [
+                "Ice",
+                "Dark"
+            ],
+            "localImage": "assets/pals/124_vanwyrm_cryst.png",
+            "breedingCombos": [
+                [
+                    "Daedream",
+                    "Blazamut"
+                ],
+                [
+                    "Nox",
+                    "Shadowbeak"
+                ],
+                [
+                    "Celaray",
+                    "Faleris"
+                ],
+                [
+                    "Mozzarina",
+                    "Elizabee"
+                ],
+                [
+                    "Gobfin",
+                    "Astegon"
+                ]
+            ]
+        },
+        "125": {
+            "id": 125,
+            "key": "080B",
+            "name": "Elphidran Aqua",
+            "wiki": "https://palworld.fandom.com/wiki/Elphidran_Aqua",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5e/Elphidran_Aqua_menu.png",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 5320,
+            "size": "l",
+            "stats": {
+                "hp": 115.0,
+                "attack": 80.0,
+                "defense": 95.0,
+                "speed": 630.0,
+                "stamina": 130.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "watering": 3,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "mystic_whirlwind",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "acid_rain",
+                    "level": 30,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil"
+            ],
+            "breeding": {
+                "power": 530,
+                "type1": "Water",
+                "type2": "Dragon"
+            },
+            "types": [
+                "Water",
+                "Dragon"
+            ],
+            "localImage": "assets/pals/125_elphidran_aqua.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Elphidran"
+                ],
+                [
+                    "Celaray",
+                    "Helzephyr"
+                ],
+                [
+                    "Mozzarina",
+                    "Astegon"
+                ],
+                [
+                    "Caprity",
+                    "Cryolinx"
+                ],
+                [
+                    "Eikthyrdeer",
+                    "Orserk"
+                ]
+            ]
+        },
+        "126": {
+            "id": 126,
+            "key": "081B",
+            "name": "Kelpsea Ignis",
+            "wiki": "https://palworld.fandom.com/wiki/Kelpsea_Ignis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/b/ba/Kelpsea_Ignis_menu.png",
+            "genus": "dragon",
+            "rarity": 2,
+            "price": 1240,
+            "size": "xs",
+            "stats": {
+                "hp": 70.0,
+                "attack": 100.0,
+                "defense": 70.0,
+                "speed": 700.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 1.0
+            },
+            "work": {
+                "kindling": 1
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "spirit_fire",
+                    "level": 15,
+                    "power": 45,
+                    "cooldown": 7.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 22,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "dragon_burst",
+                    "level": 30,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 40,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "raw_kelpsea",
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 1270,
+                "type1": "Fire",
+                "type2": null
+            },
+            "types": [
+                "Fire"
+            ],
+            "localImage": "assets/pals/126_kelpsea_ignis.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Beegarde"
+                ],
+                [
+                    "Cattiva",
+                    "Cawgnito"
+                ],
+                [
+                    "Chikipi",
+                    "Gorirat"
+                ],
+                [
+                    "Lifmunk",
+                    "Lunaris"
+                ],
+                [
+                    "Foxparks",
+                    "Leezpunk Ignis"
+                ]
+            ]
+        },
+        "127": {
+            "id": 127,
+            "key": "084B",
+            "name": "Blazehowl Noct",
+            "wiki": "https://palworld.fandom.com/wiki/Blazehowl_Noct",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5d/Blazehowl_Noct_menu.png",
+            "genus": "fourlegged",
+            "rarity": 8,
+            "price": 4360,
+            "size": "l",
+            "stats": {
+                "hp": 105.0,
+                "attack": 100.0,
+                "defense": 80.0,
+                "speed": 750.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "kindling": 3,
+                "lumbering": 2
+            },
+            "skills": [
+                {
+                    "name": "shadow_burst",
+                    "level": 1,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "flare_arrow",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "ignis_rage",
+                    "level": 30,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 670,
+                "type1": "Fire",
+                "type2": "Dark"
+            },
+            "types": [
+                "Fire",
+                "Dark"
+            ],
+            "localImage": "assets/pals/127_blazehowl_noct.png",
+            "breedingCombos": [
+                [
+                    "Fuack",
+                    "Blazamut"
+                ],
+                [
+                    "Tanzee",
+                    "Jetragon"
+                ],
+                [
+                    "Penking",
+                    "Dinossom"
+                ],
+                [
+                    "Gumoss",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Rushoar",
+                    "Lyleen Noct"
+                ]
+            ]
+        },
+        "128": {
+            "id": 128,
+            "key": "085B",
+            "name": "Relaxaurus Lux",
+            "wiki": "https://palworld.fandom.com/wiki/Relaxaurus_Lux",
+            "image": "https://static.wikia.nocookie.net/palworld/images/4/40/Relaxaurus_Lux_menu.png",
+            "genus": "monster",
+            "rarity": 9,
+            "price": 10380,
+            "size": "xl",
+            "stats": {
+                "hp": 110.0,
+                "attack": 110.0,
+                "defense": 75.0,
+                "speed": 650.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "transporting": 1,
+                "generating_electricity": 3
+            },
+            "skills": [
+                {
+                    "name": "spark_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "shockwave",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "lightning_streak",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "draconic_breath",
+                    "level": 30,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "lightning_strike",
+                    "level": 40,
+                    "power": 120,
+                    "cooldown": 40.0
+                },
+                {
+                    "name": "lightning_bolt",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil",
+                "electric_organ",
+                "sapphire"
+            ],
+            "breeding": {
+                "power": 270,
+                "type1": "Dragon",
+                "type2": "Electric"
+            },
+            "types": [
+                "Dragon",
+                "Electric"
+            ],
+            "localImage": "assets/pals/128_relaxaurus_lux.png",
+            "breedingCombos": [
+                [
+                    "Nitewing",
+                    "Frostallion"
+                ],
+                [
+                    "Cinnamoth",
+                    "Suzaku"
+                ],
+                [
+                    "Elizabee",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Grintale",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Sweepa",
+                    "Cryolinx"
+                ]
+            ]
+        },
+        "129": {
+            "id": 129,
+            "key": "086B",
+            "name": "Broncherry Aqua",
+            "wiki": "https://palworld.fandom.com/wiki/Broncherry_Aqua",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Broncherry_Aqua_menu.png",
+            "genus": "fourlegged",
+            "rarity": 8,
+            "price": 3110,
+            "size": "xl",
+            "stats": {
+                "hp": 120.0,
+                "attack": 80.0,
+                "defense": 100.0,
+                "speed": 350.0,
+                "stamina": 100.0,
+                "support": 120.0,
+                "food": 7.0
+            },
+            "work": {
+                "watering": 3
+            },
+            "skills": [
+                {
+                    "name": "aqua_gun",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "bubble_blast",
+                    "level": 7,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "muscle_slam",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 12.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 22,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 30,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "broncherry_meat",
+                "lettuce_seeds"
+            ],
+            "breeding": {
+                "power": 840,
+                "type1": "Grass",
+                "type2": "Water"
+            },
+            "types": [
+                "Grass",
+                "Water"
+            ],
+            "localImage": "assets/pals/129_broncherry_aqua.png",
+            "breedingCombos": [
+                [
+                    "Lamball",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Cattiva",
+                    "Beakon"
+                ],
+                [
+                    "Lifmunk",
+                    "Lyleen"
+                ],
+                [
+                    "Foxparks",
+                    "Relaxaurus"
+                ],
+                [
+                    "Fuack",
+                    "Quivern"
+                ]
+            ]
+        },
+        "130": {
+            "id": 130,
+            "key": "088B",
+            "name": "Ice Reptyro",
+            "wiki": "https://palworld.fandom.com/wiki/Ice_Reptyro",
+            "image": "https://static.wikia.nocookie.net/palworld/images/2/2c/Ice_Reptyro_menu.png",
+            "genus": "fourlegged",
+            "rarity": 7,
+            "price": 7380,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 130.0,
+                "speed": 390.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 5.0
+            },
+            "work": {
+                "mining": 3,
+                "cooling": 3
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "stone_blast",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "frost_burst",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "rock_lance",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 230,
+                "type1": "Ground",
+                "type2": "Ice"
+            },
+            "types": [
+                "Ground",
+                "Ice"
+            ],
+            "localImage": "assets/pals/130_ice_reptyro.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Elizabee",
+                    "Cryolinx"
+                ],
+                [
+                    "Sweepa",
+                    "Suzaku"
+                ],
+                [
+                    "Pyrin",
+                    "Frostallion Noct"
+                ],
+                [
+                    "Beakon",
+                    "Pyrin Noct"
+                ]
+            ]
+        },
+        "131": {
+            "id": 131,
+            "key": "089B",
+            "name": "Ice Kingpaca",
+            "wiki": "https://palworld.fandom.com/wiki/Ice_Kingpaca",
+            "image": "https://static.wikia.nocookie.net/palworld/images/5/5a/Ice_Kingpaca_menu.png",
+            "genus": "fourlegged",
+            "rarity": 9,
+            "price": 6100,
+            "size": "xl",
+            "stats": {
+                "hp": 120.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 500.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "gathering": 1,
+                "cooling": 3
+            },
+            "skills": [
+                {
+                    "name": "ice_missile",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "kingly_slam",
+                    "level": 22,
+                    "power": 100,
+                    "cooldown": 21.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "wool",
+                "ice_organ"
+            ],
+            "breeding": {
+                "power": 440,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/131_ice_kingpaca.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Pyrin"
+                ],
+                [
+                    "Celaray",
+                    "Blazamut"
+                ],
+                [
+                    "Mossanda",
+                    "Sibelyx"
+                ],
+                [
+                    "Nitewing",
+                    "Wumpo"
+                ],
+                [
+                    "Incineram",
+                    "Mammorest Cryst"
+                ]
+            ]
+        },
+        "132": {
+            "id": 132,
+            "key": "090B",
+            "name": "Mammorest Cryst",
+            "wiki": "https://palworld.fandom.com/wiki/Mammorest_Cryst",
+            "image": "https://static.wikia.nocookie.net/palworld/images/d/db/Mammorest_Cryst_menu.png",
+            "genus": "fourlegged",
+            "rarity": 9,
+            "price": 9580,
+            "size": "xl",
+            "stats": {
+                "hp": 150.0,
+                "attack": 100.0,
+                "defense": 90.0,
+                "speed": 430.0,
+                "stamina": 100.0,
+                "support": 30.0,
+                "food": 8.0
+            },
+            "work": {
+                "lumbering": 2,
+                "mining": 2,
+                "cooling": 2
+            },
+            "skills": [
+                {
+                    "name": "stone_cannon",
+                    "level": 1,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "power_bomb",
+                    "level": 15,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "iceberg",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "earth_impact",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 40,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 50,
+                    "power": 130,
+                    "cooldown": 45.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil",
+                "leather",
+                "mammorest_meat"
+            ],
+            "breeding": {
+                "power": 290,
+                "type1": "Ice",
+                "type2": null
+            },
+            "types": [
+                "Ice"
+            ],
+            "localImage": "assets/pals/132_mammorest_cryst.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Shadowbeak"
+                ],
+                [
+                    "Mossanda",
+                    "Astegon"
+                ],
+                [
+                    "Cinnamoth",
+                    "Jetragon"
+                ],
+                [
+                    "Elizabee",
+                    "Lyleen"
+                ],
+                [
+                    "Grintale",
+                    "Necromus"
+                ]
+            ]
+        },
+        "133": {
+            "id": 133,
+            "key": "091B",
+            "name": "Wumpo Botan",
+            "wiki": "https://palworld.fandom.com/wiki/Wumpo_Botan",
+            "image": "https://static.wikia.nocookie.net/palworld/images/6/68/Wumpo_Botan_menu.png",
+            "genus": "humanoid",
+            "rarity": 8,
+            "price": 5700,
+            "size": "l",
+            "stats": {
+                "hp": 140.0,
+                "attack": 100.0,
+                "defense": 110.0,
+                "speed": 365.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "planting": 1,
+                "handiwork": 2,
+                "lumbering": 3,
+                "transporting": 4
+            },
+            "skills": [
+                {
+                    "name": "wind_cutter",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "seed_mine",
+                    "level": 15,
+                    "power": 65,
+                    "cooldown": 13.0
+                },
+                {
+                    "name": "grass_tornado",
+                    "level": 22,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "spine_vine",
+                    "level": 30,
+                    "power": 95,
+                    "cooldown": 25.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "solar_blast",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "lettuce_seeds",
+                "tomato_seeds",
+                "beautiful_flower"
+            ],
+            "breeding": {
+                "power": 480,
+                "type1": "Grass",
+                "type2": null
+            },
+            "types": [
+                "Grass"
+            ],
+            "localImage": "assets/pals/133_wumpo_botan.png",
+            "breedingCombos": [
+                [
+                    "Penking",
+                    "Ice Kingpaca"
+                ],
+                [
+                    "Celaray",
+                    "Jetragon"
+                ],
+                [
+                    "Mozzarina",
+                    "Suzaku"
+                ],
+                [
+                    "Mossanda",
+                    "Elphidran Aqua"
+                ],
+                [
+                    "Caprity",
+                    "Suzaku Aqua"
+                ]
+            ]
+        },
+        "134": {
+            "id": 134,
+            "key": "101B",
+            "name": "Jormuntide Ignis",
+            "wiki": "https://palworld.fandom.com/wiki/Jormuntide_Ignis",
+            "image": "https://static.wikia.nocookie.net/palworld/images/0/0d/Jormuntide_Ignis_menu.png",
+            "genus": "fish",
+            "rarity": 9,
+            "price": 9500,
+            "size": "xl",
+            "stats": {
+                "hp": 130.0,
+                "attack": 150.0,
+                "defense": 100.0,
+                "speed": 525.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 7.0
+            },
+            "work": {
+                "kindling": 4
+            },
+            "skills": [
+                {
+                    "name": "ignis_blast",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dragon_cannon",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "flare_storm",
+                    "level": 15,
+                    "power": 80,
+                    "cooldown": 18.0
+                },
+                {
+                    "name": "ignis_breath",
+                    "level": 22,
+                    "power": 70,
+                    "cooldown": 15.0
+                },
+                {
+                    "name": "tri-lightning",
+                    "level": 30,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "fire_ball",
+                    "level": 40,
+                    "power": 150,
+                    "cooldown": 55.0
+                },
+                {
+                    "name": "dragon_meteor",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "high_quality_pal_oil",
+                "flame_organ"
+            ],
+            "breeding": {
+                "power": 315,
+                "type1": "Dragon",
+                "type2": "Fire"
+            },
+            "types": [
+                "Dragon",
+                "Fire"
+            ],
+            "localImage": "assets/pals/134_jormuntide_ignis.png",
+            "breedingCombos": [
+                [
+                    "Mossanda",
+                    "Grizzbolt"
+                ],
+                [
+                    "Nitewing",
+                    "Lyleen Noct"
+                ],
+                [
+                    "Cinnamoth",
+                    "Orserk"
+                ],
+                [
+                    "Elizabee",
+                    "Mammorest"
+                ],
+                [
+                    "Grintale",
+                    "Frostallion"
+                ]
+            ]
+        },
+        "135": {
+            "id": 135,
+            "key": "102B",
+            "name": "Suzaku Aqua",
+            "wiki": "https://palworld.fandom.com/wiki/Suzaku_Aqua",
+            "image": "https://static.wikia.nocookie.net/palworld/images/a/a1/Suzaku_Aqua_menu.png",
+            "genus": "bird",
+            "rarity": 9,
+            "price": 10110,
+            "size": "xl",
+            "stats": {
+                "hp": 125.0,
+                "attack": 100.0,
+                "defense": 105.0,
+                "speed": 850.0,
+                "stamina": 350.0,
+                "support": 100.0,
+                "food": 8.0
+            },
+            "work": {
+                "watering": 3
+            },
+            "skills": [
+                {
+                    "name": "hydro_jet",
+                    "level": 1,
+                    "power": 30,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "ice_missile",
+                    "level": 7,
+                    "power": 30,
+                    "cooldown": 3.0
+                },
+                {
+                    "name": "aqua_gun",
+                    "level": 15,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "aqua_burst",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "hydro_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pal_fluids"
+            ],
+            "breeding": {
+                "power": 30,
+                "type1": "Water",
+                "type2": null
+            },
+            "types": [
+                "Water"
+            ],
+            "localImage": "assets/pals/135_suzaku_aqua.png",
+            "breedingCombos": [
+                [
+                    "Blazamut",
+                    "Suzaku"
+                ],
+                [
+                    "Suzaku Aqua",
+                    "Suzaku Aqua"
+                ],
+                [
+                    "Blazamut",
+                    "Shadowbeak"
+                ]
+            ]
+        },
+        "136": {
+            "id": 136,
+            "key": "104B",
+            "name": "Lyleen Noct",
+            "wiki": "https://palworld.fandom.com/wiki/Lyleen_Noct",
+            "image": "https://static.wikia.nocookie.net/palworld/images/3/30/Lyleen_Noct_menu.png",
+            "genus": "humanoid",
+            "rarity": 10,
+            "price": 7610,
+            "size": "l",
+            "stats": {
+                "hp": 110.0,
+                "attack": 100.0,
+                "defense": 115.0,
+                "speed": 450.0,
+                "stamina": 100.0,
+                "support": 100.0,
+                "food": 6.0
+            },
+            "work": {
+                "handiwork": 3,
+                "medicine_production": 3,
+                "gathering": 2
+            },
+            "skills": [
+                {
+                    "name": "dark_ball",
+                    "level": 1,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "icicle_cutter",
+                    "level": 7,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "cryst_breath",
+                    "level": 22,
+                    "power": 90,
+                    "cooldown": 22.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 30,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "blizzard_spike",
+                    "level": 40,
+                    "power": 130,
+                    "cooldown": 45.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "low_grade_medical_supplies",
+                "beautiful_flower",
+                "innovative_technical_manual"
+            ],
+            "breeding": {
+                "power": 210,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/136_lyleen_noct.png",
+            "breedingCombos": [
+                [
+                    "Elizabee",
+                    "Jetragon"
+                ],
+                [
+                    "Sweepa",
+                    "Blazamut"
+                ],
+                [
+                    "Pyrin",
+                    "Shadowbeak"
+                ],
+                [
+                    "Beakon",
+                    "Grizzbolt"
+                ],
+                [
+                    "Cryolinx",
+                    "Mammorest Cryst"
+                ]
+            ]
+        },
+        "137": {
+            "id": 137,
+            "key": "110B",
+            "name": "Frostallion Noct",
+            "wiki": "https://palworld.fandom.com/wiki/Frostallion_Noct",
+            "image": "https://static.wikia.nocookie.net/palworld/images/1/14/Frostallion_Noct_menu.png",
+            "genus": "fourlegged",
+            "rarity": 20,
+            "price": 8560,
+            "size": "l",
+            "stats": {
+                "hp": 140.0,
+                "attack": 100.0,
+                "defense": 135.0,
+                "speed": 1000.0,
+                "stamina": 300.0,
+                "support": 70.0,
+                "food": 7.0
+            },
+            "work": {
+                "gathering": 4
+            },
+            "skills": [
+                {
+                    "name": "air_cannon",
+                    "level": 1,
+                    "power": 25,
+                    "cooldown": 2.0
+                },
+                {
+                    "name": "dark_ball",
+                    "level": 7,
+                    "power": 40,
+                    "cooldown": 4.0
+                },
+                {
+                    "name": "shadow_burst",
+                    "level": 15,
+                    "power": 55,
+                    "cooldown": 10.0
+                },
+                {
+                    "name": "spirit_flame",
+                    "level": 22,
+                    "power": 75,
+                    "cooldown": 16.0
+                },
+                {
+                    "name": "crystal_wing",
+                    "level": 30,
+                    "power": 110,
+                    "cooldown": 24.0
+                },
+                {
+                    "name": "nightmare_ball",
+                    "level": 40,
+                    "power": 100,
+                    "cooldown": 30.0
+                },
+                {
+                    "name": "dark_laser",
+                    "level": 50,
+                    "power": 150,
+                    "cooldown": 55.0
+                }
+            ],
+            "drops": [
+                "pure_quartz",
+                "large_pal_soul"
+            ],
+            "breeding": {
+                "power": 100,
+                "type1": "Dark",
+                "type2": null
+            },
+            "types": [
+                "Dark"
+            ],
+            "localImage": "assets/pals/137_frostallion_noct.png",
+            "breedingCombos": [
+                [
+                    "Cryolinx",
+                    "Necromus"
+                ],
+                [
+                    "Blazamut",
+                    "Helzephyr"
+                ],
+                [
+                    "Astegon",
+                    "Suzaku"
+                ],
+                [
+                    "Orserk",
+                    "Shadowbeak"
+                ],
+                [
+                    "Paladius",
+                    "Frostallion"
+                ]
+            ]
+        }
+    },
+    "items": {
+        "wool": {
+            "category": "Misc"
+        },
+        "lamball_mutton": {
+            "category": "Food"
+        },
+        "red_berries": {
+            "category": "Food"
+        },
+        "egg": {
+            "category": "Food"
+        },
+        "chikipi_poultry": {
+            "category": "Food"
+        },
+        "berry_seeds": {
+            "category": "Food"
+        },
+        "low_grade_medical_supplies": {
+            "category": "Misc"
+        },
+        "leather": {
+            "category": "Material"
+        },
+        "flame_organ": {
+            "category": "Misc"
+        },
+        "pal_fluids": {
+            "category": "Misc"
+        },
+        "electric_organ": {
+            "category": "Misc"
+        },
+        "mushroom": {
+            "category": "Material"
+        },
+        "ice_organ": {
+            "category": "Misc"
+        },
+        "penking_plume": {
+            "category": "Misc"
+        },
+        "gumoss_leaf": {
+            "category": "Misc"
+        },
+        "bone": {
+            "category": "Misc"
+        },
+        "fiber": {
+            "category": "Material"
+        },
+        "high_grade_technical_manual": {
+            "category": "Misc"
+        },
+        "venom_gland": {
+            "category": "Material"
+        },
+        "small_pal_soul": {
+            "category": "Misc"
+        },
+        "rushoar_pork": {
+            "category": "Misc"
+        },
+        "gold_coin": {
+            "category": "Misc"
+        },
+        "ruby": {
+            "category": "Misc"
+        },
+        "gunpowder": {
+            "category": "Equipment"
+        },
+        "tocotoco_feather": {
+            "category": "Misc"
+        },
+        "wheat_seeds": {
+            "category": "Misc"
+        },
+        "mozzarina_meat": {
+            "category": "Food"
+        },
+        "milk": {
+            "category": "Food"
+        },
+        "lettuce_seeds": {
+            "category": "Misc"
+        },
+        "tomato_seeds": {
+            "category": "Misc"
+        },
+        "cotton_candy": {
+            "category": "Misc"
+        },
+        "high_quality_pal_oil": {
+            "category": "Material"
+        },
+        "caprity_meat": {
+            "category": "Food"
+        },
+        "horn": {
+            "category": "Misc"
+        },
+        "eikthyrdeer_venison": {
+            "category": "Misc"
+        },
+        "beautiful_flower": {
+            "category": "Misc"
+        },
+        "honey": {
+            "category": "Food"
+        },
+        "raw_dumud": {
+            "category": "Misc"
+        },
+        "copper_key": {
+            "category": "Misc"
+        },
+        "silver_key": {
+            "category": "Misc"
+        },
+        "galeclaw_poultry": {
+            "category": "Food"
+        },
+        "arrow": {
+            "category": "Misc"
+        },
+        "elizabee's_staff": {
+            "category": "Misc"
+        },
+        "reindrix_venison": {
+            "category": "Misc"
+        },
+        "paldium_fragment": {
+            "category": "Material"
+        },
+        "ore": {
+            "category": "Material"
+        },
+        "cake": {
+            "category": "Food"
+        },
+        "suspicious_juice": {
+            "category": "Misc"
+        },
+        "strange_juice": {
+            "category": "Misc"
+        },
+        "ingot": {
+            "category": "Material"
+        },
+        "katress_hair": {
+            "category": "Misc"
+        },
+        "high_quality_cloth": {
+            "category": "Material"
+        },
+        "raw_kelpsea": {
+            "category": "Misc"
+        },
+        "cloth": {
+            "category": "Material"
+        },
+        "precious_dragon_stone": {
+            "category": "Material"
+        },
+        "broncherry_meat": {
+            "category": "Food"
+        },
+        "mammorest_meat": {
+            "category": "Food"
+        },
+        "coal": {
+            "category": "Material"
+        },
+        "medium_pal_soul": {
+            "category": "Misc"
+        },
+        "pal_metal_ingot": {
+            "category": "Material"
+        },
+        "pure_quartz": {
+            "category": "Misc"
+        },
+        "large_pal_soul": {
+            "category": "Misc"
+        },
+        "innovative_technical_manual": {
+            "category": "Misc"
+        },
+        "carbon_fiber": {
+            "category": "Material"
+        },
+        "diamond": {
+            "category": "Misc"
+        },
+        "polymer": {
+            "category": "Material"
+        },
+        "sapphire": {
+            "category": "Misc"
+        }
+    },
+    "tech": [
+        {
+            "level": 1,
+            "items": [
+                {
+                    "id": "arrow",
+                    "name": "Arrow",
+                    "category": "Ammo",
+                    "description": "Basic arrows crafted for the Old Bow."
+                },
+                {
+                    "id": "primitive-workbench",
+                    "name": "Primitive Workbench",
+                    "category": "Base",
+                    "description": "Basic crafting bench for starter tools."
+                },
+                {
+                    "id": "stone-axe",
+                    "name": "Stone Axe",
+                    "category": "Tool",
+                    "description": "Basic axe for chopping trees."
+                },
+                {
+                    "id": "stone-pickaxe",
+                    "name": "Stone Pickaxe",
+                    "category": "Tool",
+                    "description": "Basic pickaxe for gathering ore."
+                }
+            ]
+        },
+        {
+            "level": 2,
+            "items": [
+                {
+                    "id": "old-bow",
+                    "name": "Old Bow",
+                    "category": "Weapon",
+                    "description": "Starter bow crafted from stone and wood."
+                },
+                {
+                    "name": "Pal Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 1,
+                        "Wood": 3,
+                        "Stone": 3
+                    },
+                    "description": "Craft Pal Sphere with materials and capture high-level pals."
+                },
+                {
+                    "id": "palbox",
+                    "name": "Palbox",
+                    "category": "Base",
+                    "description": "Core structure that anchors your base and stores pals."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "items": [
+                {
+                    "id": "alarm-bell",
+                    "name": "Alarm Bell",
+                    "category": "Base",
+                    "description": "Sounds an alarm when invaders approach your base."
+                },
+                {
+                    "id": "common-shield",
+                    "name": "Common Shield",
+                    "category": "Armor",
+                    "description": "Early defensive shield for blocking attacks."
+                }
+            ]
+        },
+        {
+            "level": 5,
+            "items": [
+                {
+                    "id": "feed-box",
+                    "name": "Feed Box",
+                    "category": "Base",
+                    "description": "Automatically feeds pals assigned to your base."
+                },
+                {
+                    "id": "normal-parachute",
+                    "name": "Normal Parachute",
+                    "category": "Gear",
+                    "description": "Basic parachute that softens falls and helps kids explore."
+                },
+                {
+                    "id": "ranch",
+                    "name": "Ranch",
+                    "category": "Base",
+                    "description": "Lets pals produce resources like Eggs and Milk while assigned."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "items": [
+                {
+                    "id": "statue-of-power",
+                    "name": "Statue of Power",
+                    "category": "Base",
+                    "description": "Shrine that converts Lifmunk Effigies into capture bonuses."
+                }
+            ]
+        },
+        {
+            "level": 7,
+            "items": [
+                {
+                    "id": "egg-incubator",
+                    "name": "Egg Incubator",
+                    "category": "Ancient Tech",
+                    "description": "Ancient device that hatches pal eggs at your base."
+                },
+                {
+                    "id": "logging-site",
+                    "name": "Logging Site",
+                    "category": "Base",
+                    "description": "Automated lumber station for your workers."
+                },
+                {
+                    "id": "stone-pit",
+                    "name": "Stone Pit",
+                    "category": "Base",
+                    "description": "Assign pals here to gather stone automatically."
+                }
+            ]
+        },
+        {
+            "level": 8,
+            "items": [
+                {
+                    "id": "crusher",
+                    "name": "Crusher",
+                    "category": "Production",
+                    "description": "Crushes ore and stone into refined materials."
+                },
+                {
+                    "id": "daedreams-necklace",
+                    "name": "Daedream's Necklace",
+                    "category": "Pal Gear",
+                    "description": "Allows Daedream to float beside you and auto-attack."
+                }
+            ]
+        },
+        {
+            "level": 9,
+            "items": [
+                {
+                    "id": "hot-spring",
+                    "name": "Hot Spring",
+                    "category": "Base",
+                    "description": "Comfort spot that restores pal sanity and stamina."
+                }
+            ]
+        },
+        {
+            "level": 10,
+            "items": [
+                {
+                    "id": "primitive-furnace",
+                    "name": "Primitive Furnace",
+                    "category": "Production",
+                    "description": "Early furnace for smelting ore into ingots."
+                },
+                {
+                    "id": "small-feed-bag",
+                    "name": "Small Feed Bag",
+                    "category": "Ancient Tech",
+                    "description": "Ancient bag that auto-feeds you and your mount."
+                }
+            ]
+        },
+        {
+            "level": 12,
+            "items": [
+                {
+                    "id": "grappling-gun",
+                    "name": "Grappling Gun",
+                    "category": "Ancient Tech",
+                    "description": "Ancient mobility tool that lets you zip across terrain."
+                }
+            ]
+        },
+        {
+            "level": 13,
+            "items": [
+                {
+                    "id": "cooler-box",
+                    "name": "Cooler Box",
+                    "category": "Base",
+                    "description": "Keeps food fresh by providing passive cooling."
+                },
+                {
+                    "id": "crossbow",
+                    "name": "Crossbow",
+                    "category": "Weapon",
+                    "description": "High-power ranged weapon for early towers."
+                }
+            ]
+        },
+        {
+            "level": 14,
+            "items": [
+                {
+                    "name": "Mega Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 1,
+                        "Ingot": 1,
+                        "Wood": 5,
+                        "Stone": 5
+                    },
+                    "description": "Craft Mega Sphere with materials and capture high-level pals."
+                },
+                {
+                    "id": "pal-essence-condenser",
+                    "name": "Pal Essence Condenser",
+                    "category": "Ancient Tech",
+                    "description": "Combines duplicate pals to strengthen a favorite worker."
+                },
+                {
+                    "id": "sphere-workbench",
+                    "name": "Sphere Workbench",
+                    "category": "Production",
+                    "description": "Workbench that crafts Mega, Giga, and Hyper Spheres."
+                }
+            ]
+        },
+        {
+            "level": 15,
+            "items": [
+                {
+                    "id": "mill",
+                    "name": "Mill",
+                    "category": "Production",
+                    "description": "Processes wheat into flour for advanced cooking."
+                },
+                {
+                    "id": "monitoring-stand",
+                    "name": "Monitoring Stand",
+                    "category": "Base",
+                    "description": "Lets you watch and direct pals assigned to your base."
+                },
+                {
+                    "id": "nitewing-saddle",
+                    "name": "Nitewing Saddle",
+                    "category": "Pal Gear",
+                    "description": "Unlocks riding for Nitewing so you can fly."
+                },
+                {
+                    "id": "wheat-plantation",
+                    "name": "Wheat Plantation",
+                    "category": "Base",
+                    "description": "Farm plot that grows wheat for flour and Cake."
+                }
+            ]
+        },
+        {
+            "level": 17,
+            "items": [
+                {
+                    "id": "cake",
+                    "name": "Cake",
+                    "category": "Cooking",
+                    "description": "Essential dessert used to initiate pal breeding."
+                },
+                {
+                    "id": "cooking-pot",
+                    "name": "Cooking Pot",
+                    "category": "Cooking",
+                    "description": "Lets you prepare cooked meals and Cake."
+                },
+                {
+                    "id": "heat-resistant-armor",
+                    "name": "Heat Resistant Armor",
+                    "category": "Armor",
+                    "description": "Protective gear that lets you travel hot regions safely."
+                }
+            ]
+        },
+        {
+            "level": 19,
+            "items": [
+                {
+                    "id": "breeding-farm",
+                    "name": "Breeding Farm",
+                    "category": "Base",
+                    "description": "Facility that hatches new pals when stocked with Cake."
+                },
+                {
+                    "id": "tundra-outfit",
+                    "name": "Tundra Outfit",
+                    "category": "Armor",
+                    "description": "Cold-resistant gear for snowy regions."
+                }
+            ]
+        },
+        {
+            "level": 20,
+            "items": [
+                {
+                    "name": "Giga Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 2,
+                        "Ingot": 2,
+                        "Wood": 7,
+                        "Stone": 7
+                    },
+                    "description": "Craft Giga Sphere with materials and capture high-level pals."
+                },
+                {
+                    "id": "mega-grappling-gun",
+                    "name": "Mega Grappling Gun",
+                    "category": "Ancient Tech",
+                    "description": "Upgraded grapple with longer range and speed."
+                }
+            ]
+        },
+        {
+            "level": 21,
+            "items": [
+                {
+                    "id": "fire-arrow",
+                    "name": "Fire Arrow",
+                    "category": "Ammo",
+                    "description": "Ignited arrows that deal fire damage on impact."
+                },
+                {
+                    "id": "three-shot-bow",
+                    "name": "Three-Shot Bow",
+                    "category": "Weapon",
+                    "description": "Bow that fires three arrows in rapid succession."
+                }
+            ]
+        },
+        {
+            "level": 24,
+            "items": [
+                {
+                    "id": "ore-mining-site",
+                    "name": "Ore Mining Site",
+                    "category": "Ancient Tech",
+                    "description": "Ancient extractor that passively mines ore."
+                }
+            ]
+        },
+        {
+            "level": 27,
+            "items": [
+                {
+                    "name": "Hyper Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 3,
+                        "Ingot": 3,
+                        "Wood": 10,
+                        "Cement": 2
+                    },
+                    "description": "Craft Hyper Sphere with materials and capture high-level pals."
+                }
+            ]
+        },
+        {
+            "level": 28,
+            "items": [
+                {
+                    "id": "sphere-assembly-line",
+                    "name": "Sphere Assembly Line",
+                    "category": "Production",
+                    "description": "Automated station for crafting advanced spheres."
+                }
+            ]
+        },
+        {
+            "level": 30,
+            "items": [
+                {
+                    "id": "homeward-thundercloud",
+                    "name": "Homeward Thundercloud",
+                    "category": "Ancient Tech",
+                    "description": "Ancient recall gadget that returns you to your base."
+                },
+                {
+                    "id": "large-feed-bag",
+                    "name": "Large Feed Bag",
+                    "category": "Ancient Tech",
+                    "description": "Expanded feed bag that keeps more snacks on hand."
+                }
+            ]
+        },
+        {
+            "level": 32,
+            "items": [
+                {
+                    "id": "electric-egg-incubator",
+                    "name": "Electric Egg Incubator",
+                    "category": "Ancient Tech",
+                    "description": "Improved incubator that speeds hatching with power."
+                }
+            ]
+        },
+        {
+            "level": 35,
+            "items": [
+                {
+                    "id": "giga-grappling-gun",
+                    "name": "Giga Grappling Gun",
+                    "category": "Ancient Tech",
+                    "description": "Top-tier grapple for extreme mobility across the map."
+                },
+                {
+                    "id": "sphere-assembly-line-2",
+                    "name": "Sphere Assembly Line II",
+                    "category": "Production",
+                    "description": "Improved line that produces Ultra Spheres efficiently."
+                },
+                {
+                    "name": "Ultra Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 5,
+                        "Refined Ingot": 5,
+                        "Carbon Fiber": 2,
+                        "Cement": 3
+                    },
+                    "description": "Craft Ultra Sphere with materials and capture high-level pals."
+                }
+            ]
+        },
+        {
+            "level": 40,
+            "items": [
+                {
+                    "name": "Legendary Sphere",
+                    "category": "Equipment",
+                    "materials": {
+                        "Paladium Fragment": 10,
+                        "Carbon Fiber": 5,
+                        "Circuit Board": 5,
+                        "Polymer": 5
+                    },
+                    "description": "Craft Legendary Sphere with materials and capture high-level pals."
+                }
+            ]
+        },
+        {
+            "level": 42,
+            "items": [
+                {
+                    "id": "pump-action-shotgun",
+                    "name": "Pump-Action Shotgun",
+                    "category": "Weapon",
+                    "description": "Close-range firearm with high burst damage."
+                }
+            ]
+        },
+        {
+            "level": 44,
+            "items": [
+                {
+                    "id": "electric-furnace",
+                    "name": "Electric Furnace",
+                    "category": "Production",
+                    "description": "High-tier furnace needed for Pal Metal Ingots."
+                },
+                {
+                    "id": "pal-metal-ingot",
+                    "name": "Pal Metal Ingot",
+                    "category": "Production",
+                    "description": "Recipe for forging Pal Metal, used in late-game gear."
+                }
+            ]
+        },
+        {
+            "level": 45,
+            "items": [
+                {
+                    "id": "assault-rifle",
+                    "name": "Assault Rifle",
+                    "category": "Weapon",
+                    "description": "Fully automatic rifle for late-game firefights."
+                },
+                {
+                    "id": "assault-rifle-ammo",
+                    "name": "Assault Rifle Ammo",
+                    "category": "Ammo",
+                    "description": "Ammo crafted for the Assault Rifle."
+                }
+            ]
+        }
+    ]
 }

--- a/data/route.chapters.json
+++ b/data/route.chapters.json
@@ -1,156 +1,1685 @@
 {
-  "version": "1.0",
-  "chapters": [
-    {
-      "id": "ch1",
-      "title": "Chapter 1 — First Camp, First Helpers (Lv 1–6)",
-      "why": "Start near Plateau of Beginnings. Build a safe mini-base and catch versatile early Pals so a second grader can explore without overwhelm.",
-      "steps": [
-        { "id":"ch1-base-palbox", "category":"Base", "text":"Place Palbox, Feed Box, and Straw Pal Beds.", "links":[] },
-        { "id":"ch1-base-berry", "category":"Base", "text":"Place a Berry Plantation for food security.", "links":[{"type":"tech","id":"berry-plantation"}], "optional": false },
-        { "id":"ch1-base-logging-stone", "category":"Base", "text":"When Tech 7 unlocks, add a Logging Site and Stone Pit.", "links":[{"type":"tech","id":"logging-site"},{"type":"tech","id":"stone-pit"}], "optional": true },
-        { "id":"ch1-gear-bow", "category":"Gear", "text":"Craft Stone tools and a Bow. Plan to upgrade to Crossbow later.", "links":[{"type":"tech","id":"bow"},{"type":"tech","id":"crossbow"}], "optional": false },
-        { "id":"ch1-gear-pal-gear-bench", "category":"Gear", "text":"Unlock and build the Pal Gear Workbench (Tech Lv 6) for saddles/partner gear.", "links":[{"type":"tech","id":"pal-gear-workbench"}] },
-        { "id":"ch1-gear-statue", "category":"Gear", "text":"Build a Statue of Power (Tech Lv 6) and feed it Lifmunk Effigies to raise Capture Power.", "links":[{"type":"tech","id":"statue-of-power"},{"type":"glossary","id":"lifmunk-effigy"}] },
-        { "id":"ch1-catch-lamball", "category":"Catch", "text":"Catch Lamball or Cattiva (Handiwork/Transport 1) as early crafters/haulers.", "links":[{"type":"pal","slug":"lamball"},{"type":"pal","slug":"cattiva"}] },
-        { "id":"ch1-catch-foxparks", "category":"Catch", "text":"Catch Foxparks (Kindling 1). Its harness (via Pal Gear Workbench) powers cooking/furnaces.", "links":[{"type":"pal","slug":"foxparks"},{"type":"tech","id":"pal-gear-workbench"}] },
-        { "id":"ch1-catch-pengullet", "category":"Catch", "text":"Catch Pengullet (Watering 1, Cooling 1). Great for crops and later the Mill.", "links":[{"type":"pal","slug":"pengullet"}] },
-        { "id":"ch1-catch-daedream", "category":"Catch", "text":"Catch Daedream (strong early fighter; Lv 8 necklace partner skill is fun).", "links":[{"type":"pal","slug":"daedream"}], "optional": true },
-        { "id":"ch1-catch-vixy-tanzee", "category":"Catch", "text":"Optionally catch Vixy (coins from digging) and Tanzee (Lumber+Transport).", "links":[{"type":"pal","slug":"vixy"},{"type":"pal","slug":"tanzee"}], "optional": true },
-        { "id":"ch1-explore-effigies", "category":"Explore", "text":"Grab Lifmunk Effigies when you see them and feed the Statue of Power for better catch odds.", "links":[{"type":"glossary","id":"lifmunk-effigy"},{"type":"tech","id":"statue-of-power"}], "optional": false }
-      ]
-    },
-    {
-      "id": "ch2",
-      "title": "Chapter 2 — Move Faster, Smelt Ore, First Mount (Lv 6–13)",
-      "why": "Mobility + Ingots unlock real crafting. Get your first ride, first Ingots, and Crossbow before Tower 1.",
-      "steps": [
-        { "id":"ch2-base-furnace", "category":"Base", "text":"Build a Primitive Furnace (Lv 10) and start Ingots (assign Foxparks for Kindling).", "links":[{"type":"tech","id":"primitive-furnace"},{"type":"pal","slug":"foxparks"}] },
-        { "id":"ch2-gear-grapple", "category":"Gear", "text":"Craft a Grappling Gun (Lv 12) to help with terrain (kid-friendly).", "links":[{"type":"tech","id":"grappling-gun"}], "optional": true },
-        { "id":"ch2-gear-crossbow", "category":"Gear", "text":"Craft a Crossbow (Lv 13). Big upgrade over the Bow.", "links":[{"type":"tech","id":"crossbow"}] },
-        { "id":"ch2-catch-rushoar", "category":"Catch", "text":"Catch Rushoar (Ground; first saddle at Lv 6). Good vs Electric and can mine while mounted.", "links":[{"type":"pal","slug":"rushoar"},{"type":"tech","id":"pal-gear-workbench"}] },
-        { "id":"ch2-catch-direhowl", "category":"Catch", "text":"Catch Direhowl (fast ground mount; Lv 9 saddle). Great kid‑fun speed boost.", "links":[{"type":"pal","slug":"direhowl"}], "optional": true },
-        { "id":"ch2-explore-dungeons", "category":"Explore", "text":"Dip into 1–2 nearby dungeons for chests and the chance at Skill Fruits (save for later).", "links":[{"type":"glossary","id":"skill-fruit"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch3",
-      "title": "Chapter 3 — Tower 1: Zoe & Grizzbolt (Lv ~10, Electric → weak to Ground)",
-      "why": "You have Crossbow and a Ground pal. This gives Ancient Tech Points and confidence for the loop.",
-      "steps": [
-        { "id":"ch3-prep-ground", "category":"Prep", "text":"Bring Rushoar (Ground) and healing items.", "links":[{"type":"pal","slug":"rushoar"}] },
-        { "id":"ch3-prep-capture-power", "category":"Prep", "text":"Spend a few Lifmunk Effigies at the Statue of Power to raise Capture Power.", "links":[{"type":"tech","id":"statue-of-power"},{"type":"glossary","id":"lifmunk-effigy"}], "optional": true },
-        { "id":"ch3-boss-zoe", "category":"Boss", "text":"Clear Rayne Tower — Zoe & Grizzbolt.", "links":[{"type":"tower","id":"zoe-grizzbolt","url":"https://palworld.gg/map","map":{"title":"Rayne Syndicate Tower","label":"Rayne Tower","region":"Windswept Hills","coords":[112,-434],"kid":["Ride south of the Plateau of Beginnings until you see the big tower with lightning sparks."],"grown":["The Rayne Syndicate Tower overlooks the Windswept Hills around (112, -434). Bring Ground pals for Zoe & Grizzbolt."]}}] },
-        { "id":"ch3-spend-ancient-qol", "category":"Tech", "text":"Spend your Ancient Tech Points on quality-of-life you like (optional).", "links":[{"type":"tech","id":"ancient-tech"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch4",
-      "title": "Chapter 4 — Farm → Cake → Breeding (Lv 14–20)",
-      "why": "Breeding enables passive inheritance and specialized workers/mounts. Stand up a Cake factory and start Pal improvements.",
-      "steps": [
-        { "id":"ch4-gear-sphere-bench", "category":"Gear", "text":"Build Sphere Workbench (Lv 14) to craft Mega Spheres for higher catch rates.", "links":[{"type":"tech","id":"sphere-workbench"}] },
-        { "id":"ch4-base-wheat-mill", "category":"Base", "text":"Build Wheat Plantation + Mill (Lv 15). Assign Planting/Watering pals (Pengullet runs the Mill).", "links":[{"type":"tech","id":"wheat-plantation"},{"type":"tech","id":"mill"},{"type":"pal","slug":"pengullet"}] },
-        { "id":"ch4-base-ranch", "category":"Base", "text":"Place a Ranch (Lv 5) and add Chikipi (Eggs), Mozzarina (Milk), Beegarde (Honey). You can also buy Milk from merchants if needed.", "links":[{"type":"tech","id":"ranch"},{"type":"pal","slug":"chikipi"},{"type":"pal","slug":"mozzarina"},{"type":"pal","slug":"beegarde"}], "optional": true },
-        { "id":"ch4-gear-cooking-cake", "category":"Gear", "text":"Build Cooking Pot (Lv 17) and craft Cake (Flour, Red Berries, Milk, Eggs, Honey).", "links":[{"type":"tech","id":"cooking-pot"}] },
-        { "id":"ch4-gear-breeding-farm", "category":"Gear", "text":"Build Breeding Farm (Lv 19) and place Cake in its chest to start breeding.", "links":[{"type":"tech","id":"breeding-farm"}] },
-        { "id":"ch4-catch-penking", "category":"Catch", "text":"Catch Penking (great multi‑job worker: Watering, Mining, Cooling, Handiwork, Transport 2).", "links":[{"type":"pal","slug":"penking"}], "optional": true },
-        { "id":"ch4-breed-passives", "category":"Catch", "text":"Begin breeding for passives: Swift/Runner for mounts, Artisan/Serious for workers, Legend for strong combat. (Optional deepening.)", "links":[{"type":"passive","id":"swift"},{"type":"passive","id":"runner"},{"type":"passive","id":"artisan"},{"type":"passive","id":"serious"},{"type":"passive","id":"legend"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch5",
-      "title": "Chapter 5 — Mobility & Climate Prep → Tower 2: Lily & Lyleen (Lv ~18–25)",
-      "why": "A first flyer + cold/heat gear make travel fun and safe for a child; Fire counters this tower.",
-      "steps": [
-        { "id":"ch5-gear-heat-cold-armor", "category":"Gear", "text":"Craft Heat‑Resistant Pelt Armor (Lv 16) and Cold‑Resistant Pelt Armor (Lv 18) as needed.", "links":[{"type":"tech","id":"heat-resistant-pelt-armor"},{"type":"tech","id":"cold-resistant-pelt-armor"}] },
-        { "id":"ch5-catch-nitewing", "category":"Catch", "text":"Catch Nitewing (first flying mount) and craft its Saddle (Lv 15).", "links":[{"type":"pal","slug":"nitewing"},{"type":"tech","id":"pal-gear-workbench"}] },
-        { "id":"ch5-catch-fire", "category":"Catch", "text":"Ensure you have a solid Fire attacker for this tower (Foxparks can carry early).", "links":[{"type":"pal","slug":"foxparks"}], "optional": true },
-        { "id":"ch5-boss-lily", "category":"Boss", "text":"Clear Free Pal Alliance Tower — Lily & Lyleen (weak to Fire).", "links":[{"type":"tower","id":"lily-lyleen","url":"https://palworld.gg/map","map":{"title":"Free Pal Alliance Tower","label":"Lily & Lyleen","region":"Free Pal Alliance","coords":[185,28],"kid":["Head into the snowy Free Pal Alliance base near the big crystal trees."],"grown":["The Free Pal Alliance Tower stands at roughly (185, 28) amid the frozen north. Pack heat gear and Fire pals."]}}] }
-      ]
-    },
-    {
-      "id": "ch6",
-      "title": "Chapter 6 — Industrial Takeoff (Lv 20–26)",
-      "why": "Guns, research, and ore automation accelerate everything before the volcano/desert legs.",
-      "steps": [
-        { "id":"ch6-gear-weapon-bench-musket", "category":"Gear", "text":"Build Weapon Workbench (Lv 20), unlock Musket (Lv 21) and craft Gunpowder.", "links":[{"type":"tech","id":"weapon-workbench"},{"type":"tech","id":"musket"}] },
-        { "id":"ch6-gear-research-lab", "category":"Gear", "text":"Build Pal Labor Research Laboratory (Lv 20). Assign Pals with matching work skills to speed research.", "links":[{"type":"tech","id":"pal-labor-research-lab"}] },
-        { "id":"ch6-base-ore-site", "category":"Base", "text":"Unlock Ore Mining Site (Lv 25) and place it near your base for passive ore.", "links":[{"type":"tech","id":"ore-mining-site"}] },
-        { "id":"ch6-catch-digtoise", "category":"Catch", "text":"Catch Digtoise (Mining Lv 3) to drive your ore economy.", "links":[{"type":"pal","slug":"digtoise"}] },
-        { "id":"ch6-catch-lumber", "category":"Catch", "text":"Add a strong Lumbering Pal (e.g., Tanzee or Mammorest line) and a flyer as a hauler.", "links":[{"type":"pal","slug":"tanzee"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch7",
-      "title": "Chapter 7 — Tower 3: Axel & Orserk (Volcano; weak to Ice or Ground) (Lv ~30–40)",
-      "why": "With ore, research, and a musket, the volcano is manageable. Bring Ice or Ground.",
-      "steps": [
-        { "id":"ch7-prep-heat-gear", "category":"Prep", "text":"Equip heat protection for the approach.", "links":[{"type":"tech","id":"heat-resistant-pelt-armor"}], "optional": true },
-        { "id":"ch7-prep-ice-ground", "category":"Prep", "text":"Field Ground (Rushoar/Digtoise) or an Ice attacker.", "links":[{"type":"pal","slug":"rushoar"},{"type":"pal","slug":"digtoise"}] },
-        { "id":"ch7-boss-axel", "category":"Boss", "text":"Clear Eternal Pyre Tower — Axel & Orserk.", "links":[{"type":"tower","id":"axel-orserk","url":"https://palworld.gg/map","map":{"title":"Brothers of the Eternal Pyre Tower","label":"Eternal Pyre","region":"Mount Obsidian","coords":[-560,-518],"kid":["Sail to the big volcano island and look for the glowing tower in the lava fields."],"grown":["Axel & Orserk wait on Mount Obsidian near (-560, -518). Bring cooling gear or water mounts for the lava run."]}}] }
-      ]
-    },
-    {
-      "id": "ch8",
-      "title": "Chapter 8 — Assembly Lines & Better Spheres (Lv 28–36)",
-      "why": "Catching late‑game Pals gets much easier with better spheres and production lines.",
-      "steps": [
-        { "id":"ch8-tech-sphere-line", "category":"Tech", "text":"Build Sphere Assembly Line → craft Hyper Spheres.", "links":[{"type":"tech","id":"sphere-assembly-line"}] },
-        { "id":"ch8-tech-ultra", "category":"Tech", "text":"At Lv 35, unlock Ultra Spheres and Sphere Assembly Line II.", "links":[{"type":"tech","id":"ultra-sphere"},{"type":"tech","id":"sphere-assembly-line-2"}] },
-        { "id":"ch8-tech-weapon-line", "category":"Tech", "text":"Build Weapon Assembly Line (Lv 32). Upgrade bows/ranged while climbing toward rifles.", "links":[{"type":"tech","id":"weapon-assembly-line"}], "optional": true },
-        { "id":"ch8-tech-improved-furnace", "category":"Tech", "text":"Upgrade to Improved Furnace (Lv 34) for faster ore processing.", "links":[{"type":"tech","id":"improved-furnace"}], "optional": true },
-        { "id":"ch8-catch-water", "category":"Catch", "text":"Catch a Water DPS (Azurobe or Jormuntide line) to prep for the next Fire tower.", "links":[{"type":"pal","slug":"azurobe"},{"type":"pal","slug":"jormuntide"}], "optional": true },
-        { "id":"ch8-catch-transport", "category":"Catch", "text":"Breed/assemble a Transport team (fliers make great haulers) to avoid factory clogs.", "links":[{"type":"passive","id":"swift"},{"type":"passive","id":"runner"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch9",
-      "title": "Chapter 9 — Tower 4: Marcus & Faleris (Desert; weak to Water) (Lv ~40–45)",
-      "why": "Your Water team is ready; bring Water to counter Fire.",
-      "steps": [
-        { "id":"ch9-prep-heat", "category":"Prep", "text":"Equip heat protection for travel.", "links":[{"type":"tech","id":"heat-resistant-pelt-armor"}], "optional": true },
-        { "id":"ch9-prep-water", "category":"Prep", "text":"Field Water attackers with decent spheres.", "links":[{"type":"pal","slug":"azurobe"},{"type":"pal","slug":"jormuntide"}], "optional": true },
-        { "id":"ch9-boss-marcus", "category":"Boss", "text":"Clear PIDF Tower — Marcus & Faleris.", "links":[{"type":"tower","id":"marcus-faleris","url":"https://palworld.gg/map","map":{"title":"PIDF Tower","label":"PIDF HQ","region":"Sandy Barrens","coords":[350,-200],"kid":["Zip through the desert base full of robots—look for the tall tower with red lights."],"grown":["The PIDF desert headquarters is around (350, -200). Carry heat and cold protection for Marcus & Faleris."]}}] }
-      ]
-    },
-    {
-      "id": "ch10",
-      "title": "Chapter 10 — Refined Metals & Rifle Era (Lv 41–46)",
-      "why": "High‑tier armor/weaponry smooth the last towers.",
-      "steps": [
-        { "id":"ch10-tech-electric-kitchen", "category":"Tech", "text":"Unlock Electric Kitchen (Lv 41) to speed up Cake and cooking.", "links":[{"type":"tech","id":"electric-kitchen"}], "optional": true },
-        { "id":"ch10-tech-electric-furnace-legendary", "category":"Tech", "text":"Build Electric Furnace and craft Legendary Spheres (Lv 44).", "links":[{"type":"tech","id":"electric-furnace"},{"type":"tech","id":"legendary-sphere"}] },
-        { "id":"ch10-gear-assault-rifle", "category":"Gear", "text":"Craft an Assault Rifle (Lv 45) and ammo at the assembly line.", "links":[{"type":"tech","id":"assault-rifle"}] },
-        { "id":"ch10-catch-anubis", "category":"Catch", "text":"Catch or breed for Anubis (alpha spawn; Handiwork 4) to foreman your crafting lines.", "links":[{"type":"pal","slug":"anubis"}], "optional": true }
-      ]
-    },
-    {
-      "id": "ch11",
-      "title": "Chapter 11 — Tower 5: Victor & Shadowbeak (Dark; weak to Dragon) (Lv ~50)",
-      "why": "By now you’re armored and armed. Dragon counters Dark cleanly.",
-      "steps": [
-        { "id":"ch11-prep-dragon", "category":"Prep", "text":"Field a Dragon DPS (Astegon/Jetragon or any solid Dragon).", "links":[{"type":"pal","slug":"astegon"},{"type":"pal","slug":"jetragon"}], "optional": true },
-        { "id":"ch11-boss-victor", "category":"Boss", "text":"Clear PAL Genetic Research Unit — Victor & Shadowbeak.", "links":[{"type":"tower","id":"victor-shadowbeak","url":"https://palworld.gg/map","map":{"title":"PAL Genetic Research Unit","label":"Victor & Shadowbeak","region":"Astral Mountain","coords":[558,340],"kid":["Fly into the snowy science lab glowing above the frozen cliffs."],"grown":["Victor hides in the PAL Genetic Research Unit at about (558, 340). Bring Dragon pals and heavy cold gear."]}}] }
-      ]
-    },
-    {
-      "id": "ch12",
-      "title": "Chapter 12 — Tower 6: Saya & Selyne (weak to Dragon) (Lv ~55)",
-      "why": "Selyne is also weak to Dragon—reuse your Dragon plan.",
-      "steps": [
-        { "id":"ch12-prep-dragon", "category":"Prep", "text":"Bring your Dragon DPS and climate gear as needed.", "links":[{"type":"pal","slug":"astegon"},{"type":"pal","slug":"jetragon"}], "optional": true },
-        { "id":"ch12-boss-saya", "category":"Boss", "text":"Clear Sakurajima Tower — Saya & Selyne.", "links":[{"type":"tower","id":"saya-selyne","url":"https://palworld.gg/map","map":{"title":"Moonflower Tower","label":"Sakurajima","region":"Sakurajima Island","coords":[640,120],"kid":["Glide onto the pink island and follow the glowing petals to the Moonflower cult tower."],"grown":["Saya & Selyne occupy Moonflower Tower on Sakurajima near (640, 120). Pack antidotes for the toxic mists."]}}] }
-      ]
-    },
-    {
-      "id": "ch13",
-      "title": "Chapter 13 — Tower 7: Bjorn & Bastigor (weak to Fire) (Lv ~60)",
-      "why": "Final tower—swap back to Fire and finish the run.",
-      "steps": [
-        { "id":"ch13-prep-fire", "category":"Prep", "text":"Bring strong Fire attackers and top‑tier gear/spheres.", "links":[{"type":"pal","slug":"faleris"},{"type":"pal","slug":"foxparks"}], "optional": true },
-        { "id":"ch13-boss-bjorn", "category":"Boss", "text":"Clear Feybreak Tower — Bjorn & Bastigor. 🎉", "links":[{"type":"tower","id":"bjorn-bastigor","url":"https://palworld.gg/map","map":{"title":"Feybreak Tower","label":"Bjorn & Bastigor","region":"Feybreak Island","coords":[512,-662],"kid":["Finish the adventure on the snowy Feybreak island tower after beating the night pals."],"grown":["Bjorn & Bastigor guard Feybreak Tower around (512, -662). Bring legendary fire pals and plenty of heat support."]}}] }
-      ]
-    }
-  ]
+    "version": "2.0",
+    "chapters": [
+        {
+            "id": "ch0",
+            "title": "Chapter 0 \u2014 Quick Setup & Kid-Friendly UI (10\u201315 min)",
+            "titleKid": "Chapter 0 \u2014 Quick Start",
+            "why": "Set the world rules and helper UI so young players feel safe before the real route begins.",
+            "whyKid": "Make the world comfy and easy before big jobs.",
+            "steps": [
+                {
+                    "id": "ch0-world-normal",
+                    "category": "Prep",
+                    "text": "Create a Normal world using the default multipliers; adjust XP or sphere drops later if needed.",
+                    "textKid": "Make a Normal world. Keep all rules the same."
+                },
+                {
+                    "id": "ch0-settings-visibility",
+                    "category": "Prep",
+                    "text": "Enable Show Damage Numbers and Always Show Subtitles to boost readability.",
+                    "textKid": "Turn on damage numbers and subtitles so words always show."
+                },
+                {
+                    "id": "ch0-fast-travel",
+                    "category": "Explore",
+                    "text": "Unlock the Small Settlement fast travel point plus the nearest Great Eagle Statue.",
+                    "textKid": "Touch the Small Settlement statue and the closest big bird statue."
+                },
+                {
+                    "id": "ch0-base-foundation",
+                    "category": "Base",
+                    "text": "Place a Palbox and Primitive Workbench to anchor Base #1.",
+                    "textKid": "Place a Palbox and a Primitive Workbench for Base One.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "palbox"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "primitive-workbench"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-gear-starter",
+                    "category": "Gear",
+                    "text": "Craft Stone Pickaxe, Stone Axe, the Old Bow, and a stack of Arrows.",
+                    "textKid": "Make a stone pickaxe, stone axe, old bow, and arrows.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "stone-pickaxe"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "stone-axe"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "old-bow"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "arrow"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-tech-defense",
+                    "category": "Tech",
+                    "text": "Spend early tech points on the Common Shield and Normal Parachute.",
+                    "textKid": "Spend points on the Common Shield and Normal Parachute.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "common-shield"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "normal-parachute"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-base-feedbox",
+                    "category": "Base",
+                    "text": "Optional: Build a Feed Box so early pals eat automatically.",
+                    "textKid": "Optional: Build a Feed Box so pals eat alone.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "feed-box"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ch0-explore-coop-statues",
+                    "category": "Explore",
+                    "text": "Co-op Optional: Let player two sprint around and unlock nearby fast-travel statues.",
+                    "textKid": "Co-op optional: Player two runs to open nearby statues.",
+                    "optional": true
+                },
+                {
+                    "id": "ch0-catch-cattiva",
+                    "category": "Catch",
+                    "text": "Catch Cattiva for the +50 carry weight passive.",
+                    "textKid": "Catch a Cattiva. It lets you carry more.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "cattiva"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-catch-lifmunk",
+                    "category": "Catch",
+                    "text": "Catch Lifmunk for Planting work and the future Lifmunk Effigy hunt theme.",
+                    "textKid": "Catch a Lifmunk to help with plants and statues.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "lifmunk"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-catch-chikipi",
+                    "category": "Catch",
+                    "text": "Catch Chikipi so the Ranch can supply Eggs later.",
+                    "textKid": "Catch a Chikipi so the Ranch makes eggs.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "chikipi"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-catch-foxparks-rooby",
+                    "category": "Catch",
+                    "text": "Catch Foxparks or Rooby for early Kindling and a simple Fire partner buff.",
+                    "textKid": "Catch Foxparks or Rooby for easy fire help.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "foxparks"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "rooby"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-catch-pengullet",
+                    "category": "Catch",
+                    "text": "Catch Pengullet so Cooling and Watering jobs are covered from the start.",
+                    "textKid": "Catch a Pengullet for watering and cooling jobs.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "pengullet"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch0-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 200 Wood, 200 Stone, 60 Fiber, 40 Paldium Fragments, and 5 Flame Organs before Chapter 1.",
+                    "textKid": "Collect 200 wood, 200 stone, 60 fiber, 40 paldium bits, and 5 flame organs."
+                },
+                {
+                    "id": "ch0-tip-catch-bonus",
+                    "category": "Prep",
+                    "text": "Remind your kid that catching up to 10 of a pal grants bonus EXP\u2014make it a playful hunt.",
+                    "textKid": "Tell your kid that catching ten of one pal gives big EXP.",
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "ch1",
+            "title": "Chapter 1 \u2014 First Tower Prep (Lv 6\u201312) \u2192 Zoe & Grizzbolt",
+            "titleKid": "Chapter 1 \u2014 Get Ready for Zoe",
+            "why": "Build early automation and Ground counters so the first tower feels fair and fun.",
+            "whyKid": "Build more stuff and grab Ground pals before the lightning boss.",
+            "steps": [
+                {
+                    "id": "ch1-base-alarm-monitor",
+                    "category": "Base",
+                    "text": "Build an Alarm Bell now and plan a Monitoring Stand at tech level 15 to manage base alerts.",
+                    "textKid": "Build an Alarm Bell now and add the Monitor Stand at level 15.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "alarm-bell"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "monitoring-stand"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-base-resource-sites",
+                    "category": "Base",
+                    "text": "Add a Logging Site and Stone Pit at tech level 7, then a Crusher at level 8 to speed materials.",
+                    "textKid": "Put down a Logging Site, Stone Pit, and later a Crusher to speed supplies.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "logging-site"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "stone-pit"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "crusher"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-gear-crossbow",
+                    "category": "Gear",
+                    "text": "Craft the Crossbow as soon as level 13 unlocks it for a simple power spike.",
+                    "textKid": "Make a Crossbow at level 13 for a big damage jump.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "crossbow"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-base-hot-spring",
+                    "category": "Base",
+                    "text": "Place a Hot Spring at level 9 to keep worker pals happy and rested.",
+                    "textKid": "Build a Hot Spring at level 9 so pals can rest and smile.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "hot-spring"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-tech-ancient-qol",
+                    "category": "Tech",
+                    "text": "Spend Ancient Tech Points on the Small Feed Bag and Egg Incubator once Zoe falls.",
+                    "textKid": "Spend Ancient points on the Small Feed Bag and Egg Incubator after Zoe.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "small-feed-bag"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "egg-incubator"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-catch-ground-team",
+                    "category": "Catch",
+                    "text": "Catch Ground pals like Rushoar, Fuddler, and Dumud so Zoe & Grizzbolt crumble fast.",
+                    "textKid": "Catch Rushoar, Fuddler, and Dumud so Ground moves beat Zoe fast.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "rushoar"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "fuddler"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "dumud"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-catch-daedream",
+                    "category": "Catch",
+                    "text": "Optional: Catch Daedream at night and craft Daedream's Necklace for a floating auto-attacker.",
+                    "textKid": "Optional: Catch Daedream at night and make the necklace so it floats and fights.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "daedream"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "daedreams-necklace"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ch1-boss-zoe",
+                    "category": "Boss",
+                    "text": "Clear Rayne Syndicate Tower \u2014 Zoe & Grizzbolt (weak to Ground) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Zoe & Grizzbolt at the lightning tower to earn Ancient points.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "zoe-grizzbolt",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "Rayne Syndicate Tower",
+                                "label": "Rayne Tower",
+                                "region": "Windswept Hills",
+                                "coords": [
+                                    112,
+                                    -434
+                                ],
+                                "kid": [
+                                    "Glide south from the starting island to the tall storm tower.",
+                                    "Bring Ground pals so lightning can't hurt you much."
+                                ],
+                                "grown": [
+                                    "The Rayne Syndicate Tower stands around (112, -434) in the Windswept Hills.",
+                                    "Ground pals shred Grizzbolt\u2014keep poison bolts handy for chip damage."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch1-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 40 Ingots, 15 Nails, 20 Leather, and 20 Cloth before pushing to Chapter 2.",
+                    "textKid": "Collect 40 ingots, 15 nails, 20 leather, and 20 cloth before the next chapter."
+                }
+            ]
+        },
+        {
+            "id": "ch2",
+            "title": "Chapter 2 \u2014 First Flyer & Base #2 (Lv 12\u201320) \u2192 Farming & Cake",
+            "titleKid": "Chapter 2 \u2014 Fly and Bake Cake",
+            "why": "Unlock mobility and early automation so ore, crops, and breeding all come online fast.",
+            "whyKid": "Learn to fly, cook cake, and build a new ore base.",
+            "steps": [
+                {
+                    "id": "ch2-tech-grapple",
+                    "category": "Tech",
+                    "text": "Spend Ancient Tech on the Grappling Gun at level 12 for fast travel while heavy.",
+                    "textKid": "Buy the Grappling Gun with Ancient points at level 12 so you can zip even when heavy.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "grappling-gun"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-catch-nitewing",
+                    "category": "Catch",
+                    "text": "Catch Nitewing and craft its saddle (level 15) to unlock your first flying mount.",
+                    "textKid": "Catch a Nitewing and make its saddle at level 15 so you can fly.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "nitewing"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "nitewing-saddle"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-base-furnace",
+                    "category": "Base",
+                    "text": "Build a Primitive Furnace at level 10 and assign Kindling pals to pump out Ingots.",
+                    "textKid": "Build a Primitive Furnace at level 10 and set a fire pal to make ingots.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "primitive-furnace"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-base-farm-line",
+                    "category": "Base",
+                    "text": "Place a Wheat Plantation, Mill, and Cooking Pot so Cake ingredients flow.",
+                    "textKid": "Set a Wheat Farm, a Mill, and a Cooking Pot so cake parts never stop.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "wheat-plantation"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "mill"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "cooking-pot"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-base-ranch",
+                    "category": "Base",
+                    "text": "Build a Ranch and assign Chikipi (Eggs), Mozzarina (Milk), and Beegarde (Honey) to feed Cake.",
+                    "textKid": "Build a Ranch with Chikipi for eggs, Mozzarina for milk, and Beegarde for honey.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "ranch"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "chikipi"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "mozzarina"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "beegarde"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-base-new-site",
+                    "category": "Base",
+                    "text": "Reach base level 10 and place Base #2 at a rich ore pocket like the Desolate Church cliffs.",
+                    "textKid": "Hit base level 10 and drop Base Two near a fat ore spot like the Desolate Church.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "desolate-church",
+                            "url": "https://palworld.gg/map"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-tech-breeding-farm",
+                    "category": "Tech",
+                    "text": "Craft Cake x5 and build the Breeding Farm at level 19 so passive hunts can start.",
+                    "textKid": "Bake five cakes and build the Breeding Farm at level 19 to start baby pals.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "cake"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "breeding-farm"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch2-coop-crafting",
+                    "category": "Explore",
+                    "text": "Co-op Optional: Have player two babysit Ingots and Sphere crafting while you scout with Nitewing.",
+                    "textKid": "Co-op optional: Player two stays home to make ingots and spheres while you fly.",
+                    "optional": true
+                },
+                {
+                    "id": "ch2-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 400 Ore, 120 Coal, 40 Leather, 20 Honey, 20 Milk, 20 Eggs, 20 Flour, and bake 5 Cakes.",
+                    "textKid": "Collect 400 ore, 120 coal, 40 leather, 20 honey, 20 milk, 20 eggs, 20 flour, and bake five cakes."
+                }
+            ]
+        },
+        {
+            "id": "ch3",
+            "title": "Chapter 3 \u2014 Second Tower (Lv ~18\u201328) \u2192 Lily & Lyleen",
+            "titleKid": "Chapter 3 \u2014 Fire Beats Grass",
+            "why": "Gear up for the frozen march north and kick off the automation spike after Lily falls.",
+            "whyKid": "Make warm clothes and fire pals to win in the snow.",
+            "steps": [
+                {
+                    "id": "ch3-gear-tundra",
+                    "category": "Gear",
+                    "text": "Craft the Tundra Outfit for cold resistance before the snowy approach.",
+                    "textKid": "Make the Tundra Outfit so the cold does not hurt.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "tundra-outfit"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-catch-fire-team",
+                    "category": "Catch",
+                    "text": "Catch or breed Fire pals like Wixen, Ragnahawk, or a leveled Rooby to counter Lily.",
+                    "textKid": "Catch fire pals like Wixen, Ragnahawk, or Rooby so grass pals burn.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "wixen"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "ragnahawk"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "rooby"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-gear-fire-bow",
+                    "category": "Gear",
+                    "text": "Upgrade to the Three-Shot Bow or load your Crossbow with Fire Arrows for steady burst.",
+                    "textKid": "Use the Three-Shot Bow or fire bolts so every hit burns.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "three-shot-bow"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "fire-arrow"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-base-cooler",
+                    "category": "Base",
+                    "text": "Place a Cooler Box so food stays fresh while you explore colder zones.",
+                    "textKid": "Build a Cooler Box so food stays fresh in the cold.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "cooler-box"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-tech-essence",
+                    "category": "Tech",
+                    "text": "Spend Ancient Tech Points on the Pal Essence Condenser at level 14 to tune your best workers.",
+                    "textKid": "Spend Ancient points on the Pal Essence Condenser at level 14 to power up pals.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "pal-essence-condenser"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-boss-lily",
+                    "category": "Boss",
+                    "text": "Clear Free Pal Alliance Tower \u2014 Lily & Lyleen (weak to Fire) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Lily & Lyleen in the snowy tower with your Fire pals.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "lily-lyleen",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "Free Pal Alliance Tower",
+                                "label": "Lily & Lyleen",
+                                "region": "Free Pal Alliance",
+                                "coords": [
+                                    185,
+                                    28
+                                ],
+                                "kid": [
+                                    "Ride into the snowy Free Pal base and find the tall crystal tower.",
+                                    "Fire moves melt Lily fast."
+                                ],
+                                "grown": [
+                                    "The Free Pal Alliance Tower sits near (185, 28) amid the frozen north.",
+                                    "Pack cold gear and stack Fire damage for Lyleen."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-tech-ore-site",
+                    "category": "Tech",
+                    "text": "Unlock the Ore Mining Site (Ancient level 24) and assign Ground/Handiwork pals to fuel it.",
+                    "textKid": "Unlock the Ore Mining Site and put strong pals there so ore never stops.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "ore-mining-site"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-tech-sphere-line",
+                    "category": "Tech",
+                    "text": "Climb the Sphere Workbench ladder toward the Sphere Assembly Line so Ultra Spheres arrive on time.",
+                    "textKid": "Build the Sphere Workbench now so the Sphere Assembly Line comes soon.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "sphere-workbench"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "sphere-assembly-line"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch3-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 200 Ingots, 50 Refined Ingots, 20 Polymer, 10 Circuit Boards, and 40 Carbon Fiber before Chapter 4.",
+                    "textKid": "Collect 200 ingots, 50 refined ingots, 20 polymer, 10 circuit boards, and 40 carbon fiber."
+                }
+            ]
+        },
+        {
+            "id": "ch4",
+            "title": "Chapter 4 \u2014 Ultra Spheres & Mobility (Lv 28\u201336)",
+            "titleKid": "Chapter 4 \u2014 Better Balls and Travel",
+            "why": "Upgrade capture rates, escapes, and mounts before heading into harder biomes.",
+            "whyKid": "Make strong spheres and faster travel so the world feels easy.",
+            "steps": [
+                {
+                    "id": "ch4-tech-ultra-sphere",
+                    "category": "Tech",
+                    "text": "Unlock Sphere Assembly Line II at level 35 and craft Ultra Spheres in bulk.",
+                    "textKid": "Unlock Sphere Line II at level 35 so you can craft lots of Ultra Spheres.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "sphere-assembly-line-2"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch4-tech-homeward",
+                    "category": "Tech",
+                    "text": "Unlock the Homeward Thundercloud (Ancient level 30) as a kid-safe emergency recall.",
+                    "textKid": "Unlock the Homeward Thundercloud so you can warp home when scared.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "homeward-thundercloud"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch4-gear-upgrades",
+                    "category": "Gear",
+                    "text": "Upgrade grapples, shields, and armor tiers so movement and defense stay ahead of threats.",
+                    "textKid": "Upgrade your grapples, shields, and armor so you move fast and stay safe.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "mega-grappling-gun"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "giga-grappling-gun"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch4-catch-flyers",
+                    "category": "Catch",
+                    "text": "Improve flying by catching Vanwyrm, Beakon, or Helzephyr for faster travel.",
+                    "textKid": "Catch Vanwyrm, Beakon, or Helzephyr to fly faster.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "vanwyrm"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "beakon"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "helzephyr"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch4-base-plan",
+                    "category": "Base",
+                    "text": "Sketch Base #3 (unlocked at base level 15) in a desert or ice zone for coal and quartz logistics.",
+                    "textKid": "Plan Base Three in a desert or ice place so you gather coal and quartz.",
+                    "optional": true
+                },
+                {
+                    "id": "ch4-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 50+ Ultra Spheres, favorite ammo types, and both heat and cold outfits.",
+                    "textKid": "Make 50 Ultra Spheres, gather ammo you like, and pack hot and cold outfits."
+                }
+            ]
+        },
+        {
+            "id": "ch5",
+            "title": "Chapter 5 \u2014 Third Tower (Lv 36\u201342) \u2192 Axel & Orserk",
+            "titleKid": "Chapter 5 \u2014 Beat Axel in the Volcano",
+            "why": "Prep for Mount Obsidian with heat gear, Ground/Ice counters, and better capture tools.",
+            "whyKid": "Pack heat suits and Ground/Ice pals for the lava fight.",
+            "steps": [
+                {
+                    "id": "ch5-gear-heat",
+                    "category": "Gear",
+                    "text": "Craft heat-resistant outfits so the volcano approach stays safe.",
+                    "textKid": "Make heat armor so the volcano path is safe.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "heat-resistant-armor"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch5-catch-ground-ice",
+                    "category": "Catch",
+                    "text": "Field Ground and Ice pals such as Anubis, Digtoise, Cryolinx, or Sibelyx for dual weaknesses.",
+                    "textKid": "Use Ground pals like Anubis or Digtoise and Ice pals like Cryolinx or Sibelyx.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "anubis"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "digtoise"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "cryolinx"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "sibelyx"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch5-prep-ultra-spheres",
+                    "category": "Prep",
+                    "text": "Carry plenty of Ultra Spheres to snag strong volcano spawns en route.",
+                    "textKid": "Bring lots of Ultra Spheres to catch strong pals on the volcano trip."
+                },
+                {
+                    "id": "ch5-boss-axel",
+                    "category": "Boss",
+                    "text": "Clear Eternal Pyre Tower \u2014 Axel & Orserk (weak to Ground and Ice) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Axel & Orserk at the lava tower with Ground and Ice pals.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "axel-orserk",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "Brothers of the Eternal Pyre Tower",
+                                "label": "Eternal Pyre",
+                                "region": "Mount Obsidian",
+                                "coords": [
+                                    -560,
+                                    -518
+                                ],
+                                "kid": [
+                                    "Sail to the big volcano island and find the glowing lava tower.",
+                                    "Ground and Ice pals smash Orserk."
+                                ],
+                                "grown": [
+                                    "Axel & Orserk wait near (-560, -518) on Mount Obsidian.",
+                                    "Stack cooling gear or water mounts for the lava run."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch5-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 150 Refined Ingots, 60 Polymer, 120 Carbon Fiber, and 200 Sulfur for ammo and bombs.",
+                    "textKid": "Collect 150 refined ingots, 60 polymer, 120 carbon fiber, and 200 sulfur for ammo and bombs."
+                }
+            ]
+        },
+        {
+            "id": "ch6",
+            "title": "Chapter 6 \u2014 Fourth Tower (Lv 42\u201346) \u2192 Marcus & Faleris",
+            "titleKid": "Chapter 6 \u2014 Water Beats Fire",
+            "why": "Unlock higher-tier weapons and polish Water teams before the desert tower.",
+            "whyKid": "Get strong water pals and gear for the hot desert boss.",
+            "steps": [
+                {
+                    "id": "ch6-tech-shotgun",
+                    "category": "Tech",
+                    "text": "Unlock the Pump-Action Shotgun at tech level 42 if you want a simple, strong firearm.",
+                    "textKid": "Unlock the Pump-Action Shotgun at level 42 for an easy strong gun.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "pump-action-shotgun"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch6-catch-water-team",
+                    "category": "Catch",
+                    "text": "Build a Water squad with Relaxaurus, Azurobe, or Jormuntide to counter Faleris.",
+                    "textKid": "Bring Water pals like Relaxaurus, Azurobe, or Jormuntide to beat Faleris.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "relaxaurus"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "azurobe"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jormuntide"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch6-gear-desert",
+                    "category": "Gear",
+                    "text": "Pack heat gear for the day and cold gear for the desert night swing.",
+                    "textKid": "Wear heat gear in the day and cold gear at night so the desert stays comfy."
+                },
+                {
+                    "id": "ch6-boss-marcus",
+                    "category": "Boss",
+                    "text": "Clear PIDF Tower \u2014 Marcus & Faleris (weak to Water) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Marcus & Faleris in the desert tower with your Water pals.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "marcus-faleris",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "PIDF Tower",
+                                "label": "PIDF HQ",
+                                "region": "Sandy Barrens",
+                                "coords": [
+                                    350,
+                                    -200
+                                ],
+                                "kid": [
+                                    "Zip through the desert base full of robots and find the tall red tower.",
+                                    "Water blasts stop Faleris fast."
+                                ],
+                                "grown": [
+                                    "The PIDF desert headquarters sits near (350, -200).",
+                                    "Bring both heat and cold protection for Marcus & Faleris."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch6-tech-upgrades",
+                    "category": "Tech",
+                    "text": "Optional: Use new Ancient points on bigger Feed Bags, stronger Grapples, and better Egg Incubators.",
+                    "textKid": "Optional: Spend Ancient points on bigger Feed Bags, better Grapples, and stronger Incubators.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "large-feed-bag"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "giga-grappling-gun"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "electric-egg-incubator"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ch6-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 200 Refined Ingots, 80 Polymer, 20 Circuit Boards, and 160 Carbon Fiber for Pal Metal gear.",
+                    "textKid": "Collect 200 refined ingots, 80 polymer, 20 circuit boards, and 160 carbon fiber."
+                }
+            ]
+        },
+        {
+            "id": "ch7",
+            "title": "Chapter 7 \u2014 Fifth Tower (Lv 46\u201350) \u2192 Victor & Shadowbeak",
+            "titleKid": "Chapter 7 \u2014 Dragons vs Shadowbeak",
+            "why": "Shift into Pal Metal production and firearm support before the late-game tower.",
+            "whyKid": "Make shiny metal gear and gather dragon pals for Shadowbeak.",
+            "steps": [
+                {
+                    "id": "ch7-tech-electric-furnace",
+                    "category": "Tech",
+                    "text": "Unlock the Electric Furnace at level 44 to start Pal Metal Ingot production.",
+                    "textKid": "Unlock the Electric Furnace at level 44 so you can make Pal Metal Ingots.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "electric-furnace"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "pal-metal-ingot"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch7-tech-assault-rifle",
+                    "category": "Tech",
+                    "text": "Unlock the Assault Rifle at level 45 along with ammo if you want ranged backup.",
+                    "textKid": "Unlock the Assault Rifle at level 45 and craft ammo for big range damage.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "assault-rifle"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "assault-rifle-ammo"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch7-catch-dragon-team",
+                    "category": "Catch",
+                    "text": "Gather Dragon pals like Quivern, Jormuntide Ignis, Faleris, or Jetragon to counter Shadowbeak.",
+                    "textKid": "Bring dragons like Quivern, Jormuntide Ignis, Faleris, or Jetragon.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "quivern"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jormuntide-ignis"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "faleris"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jetragon"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch7-boss-victor",
+                    "category": "Boss",
+                    "text": "Clear PAL Genetic Research Unit \u2014 Victor & Shadowbeak (weak to Dragon) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Victor & Shadowbeak in the snowy lab with your Dragon pals.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "victor-shadowbeak",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "PAL Genetic Research Unit",
+                                "label": "Victor & Shadowbeak",
+                                "region": "Astral Mountain",
+                                "coords": [
+                                    558,
+                                    340
+                                ],
+                                "kid": [
+                                    "Fly to the glowing science lab in the snowy cliffs.",
+                                    "Your dragons beat Shadowbeak."
+                                ],
+                                "grown": [
+                                    "Victor hides near (558, 340) in the PAL Genetic Research Unit.",
+                                    "Bring cold gear and Dragon DPS."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch7-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile 75 Pal Metal Ingots, 200 Carbon Fiber, and 100 Polymer before Chapter 8.",
+                    "textKid": "Collect 75 Pal Metal Ingots, 200 carbon fiber, and 100 polymer."
+                }
+            ]
+        },
+        {
+            "id": "ch8",
+            "title": "Chapter 8 \u2014 Sakurajima (Lv 50\u201356) \u2192 Saya & Selyne",
+            "titleKid": "Chapter 8 \u2014 Moonflower Fight",
+            "why": "Prep dragons with Ice answers and explore Sakurajima for late-game schematics.",
+            "whyKid": "Fly dragons to the pink island and watch for cold attacks.",
+            "steps": [
+                {
+                    "id": "ch8-catch-dragon-resist",
+                    "category": "Catch",
+                    "text": "Tune your Dragon team with Ice-resist passives or gear so Selyne's Ice skills hurt less.",
+                    "textKid": "Give your dragons ice protection so Selyne cannot freeze you.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "quivern"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jetragon"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch8-explore-schem",
+                    "category": "Explore",
+                    "text": "Optional: Explore Sakurajima for new pals and oil rig legendary schematics when you feel ready.",
+                    "textKid": "Optional: Explore the new island for new pals and shiny chest plans when ready.",
+                    "optional": true
+                },
+                {
+                    "id": "ch8-boss-saya",
+                    "category": "Boss",
+                    "text": "Clear Moonflower Tower \u2014 Saya & Selyne (Dark with heavy Ice) for +5 Ancient Tech Points.",
+                    "textKid": "Beat Saya & Selyne at the pink tower with your dragons.",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "saya-selyne",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "Moonflower Tower",
+                                "label": "Sakurajima",
+                                "region": "Sakurajima Island",
+                                "coords": [
+                                    640,
+                                    120
+                                ],
+                                "kid": [
+                                    "Glide to the pink island and follow the glowing petals to the tall tower.",
+                                    "Watch out for cold blasts from Selyne."
+                                ],
+                                "grown": [
+                                    "Saya & Selyne occupy Moonflower Tower near (640, 120).",
+                                    "Bring antidotes and Ice mitigation for the toxic mist and Ice barrages."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch8-stockpile",
+                    "category": "Prep",
+                    "text": "Stockpile top-tier meds, food, Ultra/Legendary Spheres, and preferred ammo before the finale.",
+                    "textKid": "Pack best food, medicine, Ultra or Legendary Spheres, and ammo you like."
+                }
+            ]
+        },
+        {
+            "id": "ch9",
+            "title": "Chapter 9 \u2014 Feybreak (Lv 56\u201360) \u2192 Bjorn & Bastigor",
+            "titleKid": "Chapter 9 \u2014 Final Fire Finish",
+            "why": "Clear the nocturnal field bosses, prep Fire teams, and finish with a co-op celebration.",
+            "whyKid": "Beat the night bosses for keys, use fire pals, then celebrate the win.",
+            "steps": [
+                {
+                    "id": "ch9-prep-bounties",
+                    "category": "Prep",
+                    "text": "Defeat Dazzi Noct, Caprity Noct, and Omascul field bosses to earn the bounty tokens for the tower.",
+                    "textKid": "Beat Dazzi Noct, Caprity Noct, and Omascul to get the tower keys.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "dazzi-noct"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "caprity-noct"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "omascul"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch9-catch-fire-team",
+                    "category": "Catch",
+                    "text": "Prepare Fire pals like Blazamut, Ragnahawk, Faleris, or Suzaku to counter Bastigor.",
+                    "textKid": "Bring Fire pals like Blazamut, Ragnahawk, Faleris, or Suzaku.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "blazamut"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "ragnahawk"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "faleris"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "suzaku"
+                        }
+                    ]
+                },
+                {
+                    "id": "ch9-boss-bjorn",
+                    "category": "Boss",
+                    "text": "Clear Feybreak Tower \u2014 Bjorn & Bastigor (weak to Fire) and celebrate the victory.",
+                    "textKid": "Beat Bjorn & Bastigor at the ice tower with your Fire pals and cheer!",
+                    "links": [
+                        {
+                            "type": "tower",
+                            "id": "bjorn-bastigor",
+                            "url": "https://palworld.gg/map",
+                            "map": {
+                                "title": "Feybreak Tower",
+                                "label": "Bjorn & Bastigor",
+                                "region": "Feybreak Island",
+                                "coords": [
+                                    512,
+                                    -662
+                                ],
+                                "kid": [
+                                    "Fly to the snowy Feybreak island tower after beating the night pals.",
+                                    "Fire pals melt Bastigor fast."
+                                ],
+                                "grown": [
+                                    "Bjorn & Bastigor guard Feybreak Tower around (512, -662).",
+                                    "Bring legendary fire pals and plenty of heat support."
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ch9-celebrate",
+                    "category": "Explore",
+                    "text": "Optional: Take a victory lap\u2014decorate bases, pick a favorite mount, or start shiny hunts together.",
+                    "textKid": "Optional: Celebrate by decorating, picking a favorite mount, or hunting shinies together.",
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "evergreen",
+            "title": "Evergreen Tasks \u2014 Sprinkle Anywhere",
+            "titleKid": "Bonus Tasks \u2014 Do Anytime",
+            "why": "Use these ongoing goals to keep progress flowing between story beats.",
+            "whyKid": "Do these fun extras whenever you want.",
+            "steps": [
+                {
+                    "id": "evergreen-catch-ten",
+                    "category": "Catch",
+                    "text": "Whenever you enter a new biome, pick pals to catch up to 10 times for EXP bonuses.",
+                    "textKid": "In each new area, pick a pal and catch ten for big EXP.",
+                    "optional": true
+                },
+                {
+                    "id": "evergreen-statue",
+                    "category": "Tech",
+                    "text": "Feed Lifmunk Effigies to the Statue of Power and invest Pal Souls into favorite stats.",
+                    "textKid": "Feed Lifmunk Effigies to the statue and spend Pal Souls on pals you love.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "statue-of-power"
+                        },
+                        {
+                            "type": "glossary",
+                            "id": "lifmunk-effigy"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "evergreen-passives",
+                    "category": "Catch",
+                    "text": "Breed passives such as Artisan, Legend, Runner, or Swift depending on your focus.",
+                    "textKid": "Breed pals for passives like Artisan, Legend, Runner, or Swift.",
+                    "links": [
+                        {
+                            "type": "passive",
+                            "id": "artisan"
+                        },
+                        {
+                            "type": "passive",
+                            "id": "legend"
+                        },
+                        {
+                            "type": "passive",
+                            "id": "runner"
+                        },
+                        {
+                            "type": "passive",
+                            "id": "swift"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "evergreen-condenser",
+                    "category": "Tech",
+                    "text": "Condense your go-to workers and mounts with the Pal Essence Condenser to keep bases snappy.",
+                    "textKid": "Use the Pal Essence Condenser to make your best pals stronger.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "pal-essence-condenser"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "evergreen-legendaries",
+                    "category": "Explore",
+                    "text": "Optional: Farm legendary schematics from Alpha pals or the Oil Rig when you crave harder content.",
+                    "textKid": "Optional: Hunt legendary plans from big Alpha pals or the Oil Rig when you feel brave.",
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "base-roster",
+            "title": "Suggested Base Rosters",
+            "titleKid": "Base Team Ideas",
+            "why": "Keep machines moving by spreading key work types across each base.",
+            "whyKid": "Pick pals so every base keeps working without help.",
+            "steps": [
+                {
+                    "id": "roster-mining",
+                    "category": "Base",
+                    "text": "Keep 2\u20133 Mining pals such as Digtoise, Rushoar, or late-game Anubis at every base.",
+                    "textKid": "Have 2 or 3 mining pals like Digtoise, Rushoar, or Anubis at each base.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "digtoise"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "rushoar"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "anubis"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-lumber",
+                    "category": "Base",
+                    "text": "Assign 2 Lumbering pals like Tanzee or Eikthyrdeer to keep wood inputs steady.",
+                    "textKid": "Use 2 lumber pals like Tanzee or Eikthyrdeer so wood keeps coming.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "tanzee"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "eikthyrdeer"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-transport",
+                    "category": "Base",
+                    "text": "Maintain 2 Transporting pals\u2014fliers like Vixy or Pengullet keep lines unclogged.",
+                    "textKid": "Keep 2 hauling pals like Vixy or Pengullet so goods move fast.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "vixy"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "pengullet"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-kindling",
+                    "category": "Base",
+                    "text": "Keep 2 Kindling pals\u2014Foxparks early and Ragnahawk later cover ovens and furnaces.",
+                    "textKid": "Use 2 fire pals like Foxparks or Ragnahawk to heat ovens and furnaces.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "foxparks"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "ragnahawk"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-watering",
+                    "category": "Base",
+                    "text": "Keep 2 Watering/Cooling pals such as Pengullet or Jormuntide to cover farms and fridges.",
+                    "textKid": "Have 2 water pals like Pengullet or Jormuntide for farms and coolers.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "pengullet"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jormuntide"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-handiwork",
+                    "category": "Base",
+                    "text": "Run 3 Handiwork pals\u2014stack Artisan passives so crafting lines stay fast.",
+                    "textKid": "Use 3 handi pals with Artisan so crafting stays fast.",
+                    "links": [
+                        {
+                            "type": "passive",
+                            "id": "artisan"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "roster-ranch",
+                    "category": "Base",
+                    "text": "Reserve 1\u20132 Ranch producers like Chikipi, Mozzarina, or Beegarde for steady cooking inputs.",
+                    "textKid": "Keep 1 or 2 ranch pals like Chikipi, Mozzarina, or Beegarde for cooking stuff.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "chikipi"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "mozzarina"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "beegarde"
+                        }
+                    ],
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "ancient-tech",
+            "title": "Ancient Tech Priorities",
+            "titleKid": "Ancient Tech Picks",
+            "why": "Spend Ancient points on mobility, safety, and automation that match this route.",
+            "whyKid": "Use purple points on these handy toys first.",
+            "steps": [
+                {
+                    "id": "ancient-egg-incubator",
+                    "category": "Tech",
+                    "text": "Unlock the Egg Incubator early for painless hatching.",
+                    "textKid": "Unlock the Egg Incubator so eggs hatch easy.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "egg-incubator"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-feed-bags",
+                    "category": "Tech",
+                    "text": "Upgrade Feed Bags from Small to Large so snacks stay stocked.",
+                    "textKid": "Upgrade Feed Bags from small to big so snacks stay full.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "small-feed-bag"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "large-feed-bag"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-grapple",
+                    "category": "Tech",
+                    "text": "Invest in Grappling Gun upgrades for faster movement while encumbered.",
+                    "textKid": "Buy Grappling Gun upgrades so you zoom even when heavy.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "grappling-gun"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "mega-grappling-gun"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "giga-grappling-gun"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-condenser",
+                    "category": "Tech",
+                    "text": "Use the Pal Essence Condenser to boost favorite workers and mounts.",
+                    "textKid": "Use the Pal Essence Condenser to power up favorite pals.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "pal-essence-condenser"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-homeward",
+                    "category": "Tech",
+                    "text": "Grab Homeward Thundercloud as a kid-safe escape button.",
+                    "textKid": "Unlock Homeward Thundercloud for a safe warp home.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "homeward-thundercloud"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-ore-site",
+                    "category": "Tech",
+                    "text": "Unlock the Ore Mining Site once automation ramps up after Lily.",
+                    "textKid": "Unlock the Ore Mining Site to make ore on its own.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "ore-mining-site"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "ancient-big-incubators",
+                    "category": "Tech",
+                    "text": "Upgrade to Electric or Large Egg Incubators if you enjoy breeding hunts.",
+                    "textKid": "Upgrade to bigger Egg Incubators if you love breeding.",
+                    "links": [
+                        {
+                            "type": "tech",
+                            "id": "electric-egg-incubator"
+                        }
+                    ],
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "tower-cheatsheet",
+            "title": "Tower Team Cheatsheet",
+            "titleKid": "Tower Team Quick List",
+            "why": "Use this snapshot to recall weaknesses before each boss.",
+            "whyKid": "Use this quick list to remember what beats each boss.",
+            "steps": [
+                {
+                    "id": "sheet-zoe",
+                    "category": "Prep",
+                    "text": "Zoe & Grizzbolt \u2014 Electric weak to Ground: Rushoar, Fuddler, Dumud.",
+                    "textKid": "Zoe & Grizzbolt: Ground pals like Rushoar, Fuddler, Dumud.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "rushoar"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "fuddler"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "dumud"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-lily",
+                    "category": "Prep",
+                    "text": "Lily & Lyleen \u2014 Grass weak to Fire: Rooby, Wixen, Ragnahawk.",
+                    "textKid": "Lily & Lyleen: Fire pals like Rooby, Wixen, Ragnahawk.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "rooby"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "wixen"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "ragnahawk"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-axel",
+                    "category": "Prep",
+                    "text": "Axel & Orserk \u2014 Electric/Dragon weak to Ground and Ice: Anubis, Digtoise, Cryolinx, Sibelyx.",
+                    "textKid": "Axel & Orserk: Ground and Ice pals like Anubis, Digtoise, Cryolinx, Sibelyx.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "anubis"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "digtoise"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "cryolinx"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "sibelyx"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-marcus",
+                    "category": "Prep",
+                    "text": "Marcus & Faleris \u2014 Fire weak to Water: Relaxaurus, Azurobe, Jormuntide.",
+                    "textKid": "Marcus & Faleris: Water pals like Relaxaurus, Azurobe, Jormuntide.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "relaxaurus"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "azurobe"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jormuntide"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-victor",
+                    "category": "Prep",
+                    "text": "Victor & Shadowbeak \u2014 Dark weak to Dragon: Quivern, Jormuntide Ignis, Faleris, Jetragon.",
+                    "textKid": "Victor & Shadowbeak: Dragon pals like Quivern, Jormuntide Ignis, Faleris, Jetragon.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "quivern"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jormuntide-ignis"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "faleris"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jetragon"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-saya",
+                    "category": "Prep",
+                    "text": "Saya & Selyne \u2014 Dark with Ice tricks, still weak to Dragon: Quivern, Jetragon, keep Ice resist.",
+                    "textKid": "Saya & Selyne: Dragons like Quivern or Jetragon with ice protection.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "quivern"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "jetragon"
+                        }
+                    ],
+                    "optional": true
+                },
+                {
+                    "id": "sheet-bjorn",
+                    "category": "Prep",
+                    "text": "Bjorn & Bastigor \u2014 Ice weak to Fire: Blazamut, Faleris, Ragnahawk, Suzaku.",
+                    "textKid": "Bjorn & Bastigor: Fire pals like Blazamut, Faleris, Ragnahawk, Suzaku.",
+                    "links": [
+                        {
+                            "type": "pal",
+                            "slug": "blazamut"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "faleris"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "ragnahawk"
+                        },
+                        {
+                            "type": "pal",
+                            "slug": "suzaku"
+                        }
+                    ],
+                    "optional": true
+                }
+            ]
+        },
+        {
+            "id": "stockpile-milestones",
+            "title": "Stockpile Milestones",
+            "titleKid": "Stockpile Reminders",
+            "why": "Check these resource targets before each major push.",
+            "whyKid": "Make sure you have these items before the next boss.",
+            "steps": [
+                {
+                    "id": "stockpile-zoe",
+                    "category": "Prep",
+                    "text": "After Zoe: 40 Ingots, 15 Nails, 20 Leather, 20 Cloth.",
+                    "textKid": "After Zoe: 40 ingots, 15 nails, 20 leather, 20 cloth.",
+                    "optional": true
+                },
+                {
+                    "id": "stockpile-lily",
+                    "category": "Prep",
+                    "text": "Before Lily: 400 Ore, 120 Coal, 5 Cakes.",
+                    "textKid": "Before Lily: 400 ore, 120 coal, 5 cakes.",
+                    "optional": true
+                },
+                {
+                    "id": "stockpile-axel",
+                    "category": "Prep",
+                    "text": "Before Axel: 150 Refined Ingots, 60 Polymer, 120 Carbon Fiber, 200 Sulfur.",
+                    "textKid": "Before Axel: 150 refined ingots, 60 polymer, 120 carbon fiber, 200 sulfur.",
+                    "optional": true
+                },
+                {
+                    "id": "stockpile-marcus",
+                    "category": "Prep",
+                    "text": "Before Marcus: 200 Refined Ingots, 80 Polymer, 20 Circuit Boards, 160 Carbon Fiber.",
+                    "textKid": "Before Marcus: 200 refined ingots, 80 polymer, 20 circuit boards, 160 carbon fiber.",
+                    "optional": true
+                },
+                {
+                    "id": "stockpile-victor",
+                    "category": "Prep",
+                    "text": "Before Victor: 75 Pal Metal Ingots, 200 Carbon Fiber, 100 Polymer.",
+                    "textKid": "Before Victor: 75 Pal Metal Ingots, 200 carbon fiber, 100 polymer.",
+                    "optional": true
+                }
+            ]
+        }
+    ]
 }

--- a/index.html
+++ b/index.html
@@ -2822,6 +2822,29 @@
         });
     }
 
+    function routeChapterTitle(chapter){
+      if(!chapter) return '';
+      return kidMode ? (chapter.titleKid || chapter.title || '') : (chapter.title || chapter.titleKid || '');
+    }
+
+    function routeChapterWhy(chapter){
+      if(!chapter) return '';
+      return kidMode ? (chapter.whyKid || chapter.why || '') : (chapter.why || chapter.whyKid || '');
+    }
+
+    function routeStepText(step){
+      if(!step) return '';
+      if(!kidMode && step.textAdult) return step.textAdult;
+      return kidMode ? (step.textKid || step.text || '') : (step.text || step.textKid || '');
+    }
+
+    function routeOptionalToggleLabel(hidden){
+      if(kidMode){
+        return hidden ? 'Show bonus steps' : 'Hide bonus steps';
+      }
+      return hidden ? 'Show Optional' : 'Hide Optional';
+    }
+
     function renderRouteGuide(){
       ensureRouteGuide().then(guide => {
         const node = document.getElementById('routePage');
@@ -2837,7 +2860,7 @@
             <h2>Boss Route & Progress</h2>
             <p>Work through each chapter. Check off steps as you do them. <em>Optional</em> steps don’t block completion.</p>
             <div class="badges" style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
-              <button class="btn" id="toggleOptional">${routeHideOptional ? 'Show Optional' : 'Hide Optional'}</button>
+              <button class="btn" id="toggleOptional">${routeOptionalToggleLabel(routeHideOptional)}</button>
             </div>
           </section>
           <div id="routeChapters"></div>
@@ -2854,7 +2877,7 @@
         if(toggleBtn){
           toggleBtn.onclick = () => {
             routeHideOptional = !routeHideOptional;
-            toggleBtn.textContent = routeHideOptional ? 'Show Optional' : 'Hide Optional';
+            toggleBtn.textContent = routeOptionalToggleLabel(routeHideOptional);
             chapters.forEach(ch => rerenderChapter(ch));
           };
         }
@@ -2870,8 +2893,8 @@
       section.innerHTML = `
         <div style="display:flex;align-items:center;gap:12px;justify-content:space-between;flex-wrap:wrap">
           <div>
-            <h3 style="margin:0">${escapeHTML(chapter.title)}</h3>
-            <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(chapter.why)}</p>
+            <h3 style="margin:0">${escapeHTML(routeChapterTitle(chapter))}</h3>
+            <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(routeChapterWhy(chapter))}</p>
           </div>
           <div style="min-width:220px">${renderProgress(progress)}</div>
         </div>
@@ -2896,8 +2919,8 @@
       node.innerHTML = `
         <div style="display:flex;align-items:center;gap:12px;justify-content:space-between;flex-wrap:wrap">
           <div>
-            <h3 style="margin:0">${escapeHTML(chapter.title)}</h3>
-            <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(chapter.why)}</p>
+            <h3 style="margin:0">${escapeHTML(routeChapterTitle(chapter))}</h3>
+            <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(routeChapterWhy(chapter))}</p>
           </div>
           <div style="min-width:220px">${renderProgress(progress)}</div>
         </div>
@@ -2994,7 +3017,7 @@
         groups[step.category].push(`
           <label class="step ${step.optional ? 'optional' : ''}">
             <input type="checkbox" data-step="${step.id}" ${checked ? 'checked' : ''} />
-            <span class="step-text">${escapeHTML(step.text)} ${step.optional ? '<em>(Optional)</em>' : ''}</span>
+            <span class="step-text">${escapeHTML(routeStepText(step))} ${step.optional ? '<em>(Optional)</em>' : ''}</span>
             ${renderLinks(step.links || [])}
           </label>
         `);
@@ -3248,12 +3271,15 @@
 
     function renderProgress(progress){
       const pct = progress.requiredCount ? Math.round((progress.requiredChecked / progress.requiredCount) * 100) : 0;
+      const label = kidMode
+        ? `${progress.requiredChecked}/${progress.requiredCount} steps done (${pct}%)`
+        : `${progress.requiredChecked}/${progress.requiredCount} required done (${pct}%)`;
       return `
         <div class="progress" aria-label="Chapter progress" style="display:grid;gap:6px">
           <div style="height:10px;border-radius:999px;background:#22314A;overflow:hidden">
             <div style="height:10px;width:${pct}%;background:var(--accent)"></div>
           </div>
-          <div style="font-size:.9rem;color:var(--muted)">${progress.requiredChecked}/${progress.requiredCount} required done (${pct}%)</div>
+          <div style="font-size:.9rem;color:var(--muted)">${label}</div>
         </div>
       `;
     }


### PR DESCRIPTION
## Summary
- rewrite the route guide JSON to follow the new palworld_full_route_normal_coop_optional flow with kid-mode summaries and kid/adult step text throughout
- update the route page renderer to pick kid-appropriate titles, reasons, step text, and optional toggle labels while keeping grown-up vocabulary in adult mode
- extend the tech dataset with entries for the structures, gear, and ancient unlocks referenced by the refreshed route so in-app links keep working

## Testing
- python -m json.tool data/route.chapters.json
- python -m json.tool data/palworld_complete_data_enhanced.json

------
https://chatgpt.com/codex/tasks/task_e_68d85989fa248331a1943bf559698e04