### PR TITLE
Improve route item links and tower entrances

### DIFF
--- a/data/route.chapters.json
+++ b/data/route.chapters.json
@@ -319,6 +319,14 @@
                                     112,
                                     -434
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        112,
+                                        -434
+                                    ],
+                                    "note": "Entrance sits beside the Cliffside fast travel statue overlooking the bay."
+                                },
                                 "kid": [
                                     "Glide south from the starting island to the tall storm tower.",
                                     "Bring Ground pals so lightning can't hurt you much."
@@ -450,7 +458,7 @@
                     "textKid": "Bake five cakes and build the Breeding Farm at level 19 to start baby pals.",
                     "links": [
                         {
-                            "type": "tech",
+                            "type": "item",
                             "id": "cake"
                         },
                         {
@@ -571,6 +579,14 @@
                                     185,
                                     28
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        185,
+                                        28
+                                    ],
+                                    "note": "Gate stands inside the Free Pal Alliance outpost reached from the southern bridge."
+                                },
                                 "kid": [
                                     "Ride into the snowy Free Pal base and find the tall crystal tower.",
                                     "Fire moves melt Lily fast."
@@ -716,7 +732,11 @@
                     "links": [
                         {
                             "type": "tech",
-                            "id": "heat-resistant-armor"
+                            "id": "heat-resistant-pelt-armor"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "heat-resistant-metal-armor"
                         }
                     ]
                 },
@@ -768,6 +788,14 @@
                                     -560,
                                     -518
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        -560,
+                                        -518
+                                    ],
+                                    "note": "Climb to the lava plateau on Mount Obsidian to reach the tower doorway."
+                                },
                                 "kid": [
                                     "Sail to the big volcano island and find the glowing lava tower.",
                                     "Ground and Ice pals smash Orserk."
@@ -851,6 +879,14 @@
                                     350,
                                     -200
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        350,
+                                        -200
+                                    ],
+                                    "note": "Enter through the PIDF desert headquarters courtyard at these coordinates."
+                                },
                                 "kid": [
                                     "Zip through the desert base full of robots and find the tall red tower.",
                                     "Water blasts stop Faleris fast."
@@ -910,8 +946,8 @@
                             "id": "electric-furnace"
                         },
                         {
-                            "type": "tech",
-                            "id": "pal-metal-ingot"
+                            "type": "item",
+                            "id": "pal_metal_ingot"
                         }
                     ]
                 },
@@ -973,6 +1009,14 @@
                                     558,
                                     340
                                 ],
+                                "entrance": {
+                                    "label": "Facility Entrance",
+                                    "coords": [
+                                        558,
+                                        340
+                                    ],
+                                    "note": "The research unit doors face the snowy cliffside overlooking the valley."
+                                },
                                 "kid": [
                                     "Fly to the glowing science lab in the snowy cliffs.",
                                     "Your dragons beat Shadowbeak."
@@ -1041,6 +1085,14 @@
                                     640,
                                     120
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        640,
+                                        120
+                                    ],
+                                    "note": "Land on the blossom-covered platform to find the Moonflower Tower doorway."
+                                },
                                 "kid": [
                                     "Glide to the pink island and follow the glowing petals to the tall tower.",
                                     "Watch out for cold blasts from Selyne."
@@ -1130,6 +1182,14 @@
                                     512,
                                     -662
                                 ],
+                                "entrance": {
+                                    "label": "Tower Entrance",
+                                    "coords": [
+                                        512,
+                                        -662
+                                    ],
+                                    "note": "The Feybreak Tower doorway crowns the icy island peak at these coordinates."
+                                },
                                 "kid": [
                                     "Fly to the snowy Feybreak island tower after beating the night pals.",
                                     "Fire pals melt Bastigor fast."

--- a/index.html
+++ b/index.html
@@ -2033,7 +2033,11 @@
       return [];
     }
     function openRouteMapModal(mapInfo = {}, fallbackUrl) {
-      const coords = Array.isArray(mapInfo.coords) ? mapInfo.coords : null;
+      const entrance = mapInfo.entrance || null;
+      const entranceCoords = Array.isArray(mapInfo.entranceCoords)
+        ? mapInfo.entranceCoords
+        : (entrance && Array.isArray(entrance.coords) ? entrance.coords : null);
+      const coords = entranceCoords || (Array.isArray(mapInfo.coords) ? mapInfo.coords : null);
       if (!coords) {
         window.open(mapInfo.url || fallbackUrl || `${PALWORLD_BASE_URL}/map`, '_blank', 'noopener');
         return;
@@ -2049,10 +2053,17 @@
       meta.className = 'map-modal-note';
       const metaBits = [];
       if (mapInfo.region) metaBits.push(mapInfo.region);
-      metaBits.push(`Coordinates: (${coords[0]}, ${coords[1]})`);
+      const primaryLabel = entrance && entrance.label ? entrance.label : (mapInfo.coordsLabel || 'Entrance');
+      metaBits.push(`${primaryLabel}: (${coords[0]}, ${coords[1]})`);
+      if (!entranceCoords && Array.isArray(mapInfo.coords) && mapInfo.coords.length >= 2) {
+        metaBits.push(`Location: (${mapInfo.coords[0]}, ${mapInfo.coords[1]})`);
+      }
       meta.textContent = metaBits.join(' • ');
       wrap.appendChild(meta);
-      const details = mapDescriptionLines(mapInfo);
+      const details = [
+        ...mapDescriptionLines(mapInfo),
+        ...mapDescriptionLines(entrance)
+      ];
       if (details.length) {
         const detailsWrap = document.createElement('div');
         detailsWrap.className = 'map-modal-details';
@@ -2067,13 +2078,16 @@
       canvas.className = 'map-modal-canvas';
       const mapImage = document.createElement('img');
       mapImage.src = 'assets/images/palworld-full-map-2.webp';
-      mapImage.alt = mapInfo.title ? `${mapInfo.title} location on the Palworld map` : 'Palworld map showing the selected route location';
+      const mapAltTitle = entrance && entrance.label
+        ? `${entrance.label} for ${mapInfo.title || 'the selected encounter'}`
+        : (mapInfo.title ? `${mapInfo.title} location on the Palworld map` : 'Palworld map showing the selected route location');
+      mapImage.alt = mapAltTitle;
       canvas.appendChild(mapImage);
       const marker = document.createElement('div');
       marker.className = 'map-marker';
       marker.style.left = `${left}%`;
       marker.style.top = `${top}%`;
-      const markerLabel = mapInfo.label || mapInfo.title;
+      const markerLabel = (entrance && entrance.label) || mapInfo.label || mapInfo.title;
       if (markerLabel) {
         const label = document.createElement('span');
         label.className = 'map-marker-label';
@@ -3665,6 +3679,7 @@
 
     function linkLabel(link){
       if(link.type === 'pal') return capitalize(link.slug);
+      if(link.type === 'item') return niceName(link.id);
       if(link.type === 'passive') return capitalize(link.id);
       if(link.type === 'move') return niceName(link.id);
       if(link.type === 'tech') return niceName(link.id);
@@ -3680,6 +3695,13 @@
           window.viewPal(link.slug || link.id);
         } else {
           focusSearch(link.slug || link.id);
+        }
+      } else if(link.type === 'item'){
+        const itemKey = link.id || link.slug;
+        if(itemKey && ITEMS[itemKey]){
+          openItemDetail(itemKey);
+        } else {
+          focusSearch(itemKey);
         }
       } else if(link.type === 'tech'){
         showTechDetail(link.id);
@@ -3700,7 +3722,7 @@
       const entry = TECH_LOOKUP[slug];
       const displayName = entry?.item?.name || niceName(techId);
       const safeName = escapeHTML(displayName);
-      const searchUrl = `${PALWORLD_BASE_URL}/items?search=${encodeURIComponent(displayName)}`;
+      const techUrl = entry?.item?.url || `${PALWORLD_BASE_URL}/technology-tree?search=${encodeURIComponent(displayName)}`;
       const summaryParts = [];
       if(kidMode){
         summaryParts.push(`<p>Let's get <strong>${safeName}</strong> ready!</p>`);
@@ -3734,15 +3756,15 @@
       } else {
         summaryParts.push(`<p>${kidMode
           ? 'Palmate will peek at Palworld.gg so you can see what it looks like without leaving this checklist.'
-          : 'Palmate opens a Palworld.gg search so you can confirm crafting details without changing pages.'}</p>`);
+          : 'Palmate opens the Palworld.gg technology tree so you can confirm crafting details without changing pages.'}</p>`);
       }
       const note = entry
         ? 'Palmate keeps this tech guide handy so you can stay on the route checklist.'
-        : 'Palmate opens a Palworld.gg search while keeping your route progress on screen.';
+        : 'Palmate opens the Palworld.gg technology tree while keeping your route progress on screen.';
       openPalworldEmbed({
         heading: `${displayName} – Palworld.gg`,
-        url: searchUrl,
-        fallbackUrl: searchUrl,
+        url: techUrl,
+        fallbackUrl: techUrl,
         note,
         summaryHtml: summaryParts.join('')
       });


### PR DESCRIPTION
## Summary
- handle item quick links, point technology embeds at the Palworld technology tree, and make tower maps prefer entrance metadata
- annotate tower entries in the route dataset with entrance details while correcting mislabelled item references (cake and pal metal ingot) and heat armor unlocks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86311ab288331aa6c3c969b98490d