### PR TITLE
Add item metadata and route links for stockpile steps

### DIFF
--- a/data/item_details.json
+++ b/data/item_details.json
@@ -137,6 +137,19 @@
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },
+  "circuit_board": {
+    "name": "Circuit Board",
+    "type": "Technology",
+    "description": [
+      "Electronic crafting component for late-game structures and gear.",
+      "Needed for advanced weapons, generators, and automation tech."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/6/64/Circuit_Board_icon.png/revision/latest?cb=20240124122315",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "chikipi_poultry": {
     "name": "Chikipi Poultry",
     "type": "Ingredient",
@@ -316,6 +329,19 @@
     "fromPalworld": true,
     "source": "Palworld.gg"
   },
+  "flour": {
+    "name": "Flour",
+    "type": "Ingredient",
+    "description": [
+      "Ground wheat used for cooking and baking recipes.",
+      "Essential for dishes like Cake and other late-game meals."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/4/4a/Flour_icon.png/revision/latest?cb=20240124060459",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "flame_organ": {
     "name": "Flame Organ",
     "type": "Material",
@@ -399,6 +425,19 @@
     "image": "https://palworld.gg/_ipx/q_80&s_60x60/images/items/T_itemicon_Material_Gunpowder.png",
     "fromPalworld": true,
     "source": "Palworld.gg"
+  },
+  "high_grade_medical_supplies": {
+    "name": "High Grade Medical Supplies",
+    "type": "Consumable",
+    "description": [
+      "Advanced medicine kit for healing serious injuries and status effects.",
+      "Restores more health than low grade supplies and cures harsh debuffs."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/9/9f/High_Grade_Medical_Supplies_icon.png/revision/latest?cb=20240124060906",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
   },
   "high_grade_technical_manual": {
     "name": "High Grade Technical Manual",
@@ -592,6 +631,19 @@
     "fromPalworld": true,
     "source": "Palworld.gg"
   },
+  "legendary_sphere": {
+    "name": "Legendary Sphere",
+    "type": "Capture Gear",
+    "description": [
+      "Ultimate pal-catching sphere with the highest capture rate.",
+      "Reserved for rare encounters due to its steep crafting cost."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/3/32/Legendary_Sphere_icon.png/revision/latest?cb=20240124062318",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "lettuce_seeds": {
     "name": "Lettuce Seeds",
     "type": "Material",
@@ -709,6 +761,19 @@
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },
+  "nail": {
+    "name": "Nail",
+    "type": "Material",
+    "description": [
+      "Metal fastener produced in bulk for building projects.",
+      "Required by many base upgrades and higher-tier crafting benches."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/5/5b/Nail_icon.png/revision/latest?cb=20240124060924",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "ore": {
     "name": "Ore",
     "type": "Material",
@@ -812,6 +877,19 @@
     },
     "recipe": [],
     "image": "https://static.wikia.nocookie.net/palworld/images/f/f0/Precious_Dragon_Stone_icon.png/revision/latest?cb=20240125040206",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
+  "refined_ingot": {
+    "name": "Refined Ingot",
+    "type": "Material",
+    "description": [
+      "High-quality metal ingot smelted in upgraded furnaces.",
+      "Forms the basis of refined weapons, armor, and base tech."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/6/6a/Refined_Ingot_icon.png/revision/latest?cb=20240124060812",
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },
@@ -964,6 +1042,19 @@
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },
+  "stone": {
+    "name": "Stone",
+    "type": "Material",
+    "description": [
+      "Common rock gathered from outcrops and quarry sites.",
+      "Forms the backbone of early crafting, ammo, and base defenses."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/8/88/Stone_icon.png/revision/latest?cb=20240121075257",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "strange_juice": {
     "name": "Strange Juice",
     "type": "Consumable",
@@ -1003,6 +1094,19 @@
     "image": "https://palworld.gg/_ipx/q_80&s_60x60/images/items/T_itemicon_Food_Narcotic.png",
     "fromPalworld": true,
     "source": "Palworld.gg"
+  },
+  "sulfur": {
+    "name": "Sulfur",
+    "type": "Material",
+    "description": [
+      "Volatile mineral mined from volcanic deposits.",
+      "Used to craft gunpowder, ammunition, and explosives."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/7/74/Sulfur_icon.png/revision/latest?cb=20240121075148",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
   },
   "suspicious_juice": {
     "name": "Suspicious Juice",
@@ -1074,6 +1178,19 @@
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },
+  "ultra_sphere": {
+    "name": "Ultra Sphere",
+    "type": "Capture Gear",
+    "description": [
+      "High-grade pal-catching sphere with excellent capture rates.",
+      "Crafted on advanced assembly lines using refined materials."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/0/0c/Ultra_Sphere_icon.png/revision/latest?cb=20240124062237",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
   "venom_gland": {
     "name": "Venom Gland",
     "type": "Material",
@@ -1101,6 +1218,19 @@
     },
     "recipe": [],
     "image": "https://static.wikia.nocookie.net/palworld/images/e/ed/Wheat_Seeds_icon.png/revision/latest?cb=20240121074212",
+    "fromPalworld": false,
+    "source": "Palworld Fandom"
+  },
+  "wood": {
+    "name": "Wood",
+    "type": "Material",
+    "description": [
+      "Basic lumber gathered from trees across Palpagos Island.",
+      "Fuel and structural component for countless early-game recipes."
+    ],
+    "stats": {},
+    "recipe": [],
+    "image": "https://static.wikia.nocookie.net/palworld/images/9/9d/Wood_icon.png/revision/latest?cb=20240121075328",
     "fromPalworld": false,
     "source": "Palworld Fandom"
   },

--- a/data/palworld_complete_data_enhanced.json
+++ b/data/palworld_complete_data_enhanced.json
@@ -14083,6 +14083,36 @@
         }
     },
     "items": {
+        "wood": {
+            "category": "Material"
+        },
+        "stone": {
+            "category": "Material"
+        },
+        "nail": {
+            "category": "Material"
+        },
+        "flour": {
+            "category": "Food"
+        },
+        "circuit_board": {
+            "category": "Technology"
+        },
+        "refined_ingot": {
+            "category": "Material"
+        },
+        "high_grade_medical_supplies": {
+            "category": "Consumable"
+        },
+        "ultra_sphere": {
+            "category": "Equipment"
+        },
+        "legendary_sphere": {
+            "category": "Equipment"
+        },
+        "sulfur": {
+            "category": "Material"
+        },
         "wool": {
             "category": "Misc"
         },

--- a/data/palworld_complete_data_final.json
+++ b/data/palworld_complete_data_final.json
@@ -17912,6 +17912,36 @@
     }
   },
   "items": {
+    "wood": {
+      "category": "Material"
+    },
+    "stone": {
+      "category": "Material"
+    },
+    "nail": {
+      "category": "Material"
+    },
+    "flour": {
+      "category": "Food"
+    },
+    "circuit_board": {
+      "category": "Technology"
+    },
+    "refined_ingot": {
+      "category": "Material"
+    },
+    "high_grade_medical_supplies": {
+      "category": "Consumable"
+    },
+    "ultra_sphere": {
+      "category": "Equipment"
+    },
+    "legendary_sphere": {
+      "category": "Equipment"
+    },
+    "sulfur": {
+      "category": "Material"
+    },
     "wool": {
       "category": "Misc"
     },

--- a/data/route.chapters.json
+++ b/data/route.chapters.json
@@ -170,7 +170,29 @@
                     "id": "ch0-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 200 Wood, 200 Stone, 60 Fiber, 40 Paldium Fragments, and 5 Flame Organs before Chapter 1.",
-                    "textKid": "Collect 200 wood, 200 stone, 60 fiber, 40 paldium bits, and 5 flame organs."
+                    "textKid": "Collect 200 wood, 200 stone, 60 fiber, 40 paldium bits, and 5 flame organs.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "wood"
+                        },
+                        {
+                            "type": "item",
+                            "id": "stone"
+                        },
+                        {
+                            "type": "item",
+                            "id": "fiber"
+                        },
+                        {
+                            "type": "item",
+                            "id": "paldium_fragment"
+                        },
+                        {
+                            "type": "item",
+                            "id": "flame_organ"
+                        }
+                    ]
                 },
                 {
                     "id": "ch0-tip-catch-bonus",
@@ -381,7 +403,25 @@
                     "id": "ch1-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 40 Ingots, 15 Nails, 20 Leather, and 20 Cloth before pushing to Chapter 2.",
-                    "textKid": "Collect 40 ingots, 15 nails, 20 leather, and 20 cloth before the next chapter."
+                    "textKid": "Collect 40 ingots, 15 nails, 20 leather, and 20 cloth before the next chapter.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "nail"
+                        },
+                        {
+                            "type": "item",
+                            "id": "leather"
+                        },
+                        {
+                            "type": "item",
+                            "id": "cloth"
+                        }
+                    ]
                 }
             ]
         },
@@ -664,7 +704,41 @@
                     "id": "ch2-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 400 Ore, 120 Coal, 40 Leather, 20 Honey, 20 Milk, 20 Eggs, 20 Flour, and bake 5 Cakes.",
-                    "textKid": "Collect 400 ore, 120 coal, 40 leather, 20 honey, 20 milk, 20 eggs, 20 flour, and bake five cakes."
+                    "textKid": "Collect 400 ore, 120 coal, 40 leather, 20 honey, 20 milk, 20 eggs, 20 flour, and bake five cakes.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "ore"
+                        },
+                        {
+                            "type": "item",
+                            "id": "coal"
+                        },
+                        {
+                            "type": "item",
+                            "id": "leather"
+                        },
+                        {
+                            "type": "item",
+                            "id": "honey"
+                        },
+                        {
+                            "type": "item",
+                            "id": "milk"
+                        },
+                        {
+                            "type": "item",
+                            "id": "egg"
+                        },
+                        {
+                            "type": "item",
+                            "id": "flour"
+                        },
+                        {
+                            "type": "item",
+                            "id": "cake"
+                        }
+                    ]
                 }
             ]
         },
@@ -838,7 +912,29 @@
                     "id": "ch3-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 200 Ingots, 50 Refined Ingots, 20 Polymer, 10 Circuit Boards, and 40 Carbon Fiber before Chapter 4.",
-                    "textKid": "Collect 200 ingots, 50 refined ingots, 20 polymer, 10 circuit boards, and 40 carbon fiber."
+                    "textKid": "Collect 200 ingots, 50 refined ingots, 20 polymer, 10 circuit boards, and 40 carbon fiber.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "refined_ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "polymer"
+                        },
+                        {
+                            "type": "item",
+                            "id": "circuit_board"
+                        },
+                        {
+                            "type": "item",
+                            "id": "carbon_fiber"
+                        }
+                    ]
                 }
             ]
         },
@@ -937,7 +1033,21 @@
                     "id": "ch4-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 50+ Ultra Spheres, favorite ammo types, and both heat and cold outfits.",
-                    "textKid": "Make 50 Ultra Spheres, gather ammo you like, and pack hot and cold outfits."
+                    "textKid": "Make 50 Ultra Spheres, gather ammo you like, and pack hot and cold outfits.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "ultra_sphere"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "heat-resistant-metal-armor"
+                        },
+                        {
+                            "type": "tech",
+                            "id": "cold-resistant-metal-armor"
+                        }
+                    ]
                 }
             ]
         },
@@ -992,7 +1102,13 @@
                     "id": "ch5-prep-ultra-spheres",
                     "category": "Prep",
                     "text": "Carry plenty of Ultra Spheres to snag strong volcano spawns en route.",
-                    "textKid": "Bring lots of Ultra Spheres to catch strong pals on the volcano trip."
+                    "textKid": "Bring lots of Ultra Spheres to catch strong pals on the volcano trip.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "ultra_sphere"
+                        }
+                    ]
                 },
                 {
                     "id": "sheet-axel",
@@ -1061,7 +1177,25 @@
                     "id": "ch5-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 150 Refined Ingots, 60 Polymer, 120 Carbon Fiber, and 200 Sulfur for ammo and bombs.",
-                    "textKid": "Collect 150 refined ingots, 60 polymer, 120 carbon fiber, and 200 sulfur for ammo and bombs."
+                    "textKid": "Collect 150 refined ingots, 60 polymer, 120 carbon fiber, and 200 sulfur for ammo and bombs.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "refined_ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "polymer"
+                        },
+                        {
+                            "type": "item",
+                            "id": "carbon_fiber"
+                        },
+                        {
+                            "type": "item",
+                            "id": "sulfur"
+                        }
+                    ]
                 }
             ]
         },
@@ -1194,7 +1328,25 @@
                     "id": "ch6-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 200 Refined Ingots, 80 Polymer, 20 Circuit Boards, and 160 Carbon Fiber for Pal Metal gear.",
-                    "textKid": "Collect 200 refined ingots, 80 polymer, 20 circuit boards, and 160 carbon fiber."
+                    "textKid": "Collect 200 refined ingots, 80 polymer, 20 circuit boards, and 160 carbon fiber.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "refined_ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "polymer"
+                        },
+                        {
+                            "type": "item",
+                            "id": "circuit_board"
+                        },
+                        {
+                            "type": "item",
+                            "id": "carbon_fiber"
+                        }
+                    ]
                 }
             ]
         },
@@ -1328,7 +1480,21 @@
                     "id": "ch7-stockpile",
                     "category": "Prep",
                     "text": "Stockpile 75 Pal Metal Ingots, 200 Carbon Fiber, and 100 Polymer before Chapter 8.",
-                    "textKid": "Collect 75 Pal Metal Ingots, 200 carbon fiber, and 100 polymer."
+                    "textKid": "Collect 75 Pal Metal Ingots, 200 carbon fiber, and 100 polymer.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "pal_metal_ingot"
+                        },
+                        {
+                            "type": "item",
+                            "id": "carbon_fiber"
+                        },
+                        {
+                            "type": "item",
+                            "id": "polymer"
+                        }
+                    ]
                 }
             ]
         },
@@ -1421,7 +1587,21 @@
                     "id": "ch8-stockpile",
                     "category": "Prep",
                     "text": "Stockpile top-tier meds, food, Ultra/Legendary Spheres, and preferred ammo before the finale.",
-                    "textKid": "Pack best food, medicine, Ultra or Legendary Spheres, and ammo you like."
+                    "textKid": "Pack best food, medicine, Ultra or Legendary Spheres, and ammo you like.",
+                    "links": [
+                        {
+                            "type": "item",
+                            "id": "high_grade_medical_supplies"
+                        },
+                        {
+                            "type": "item",
+                            "id": "ultra_sphere"
+                        },
+                        {
+                            "type": "item",
+                            "id": "legendary_sphere"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- Add item chips to stockpile and prep steps in the route guide so required resources link to item details.
- Extend the final and enhanced datasets with metadata for the newly linked items such as wood, refined ingots, and spheres.
- Provide item detail entries for the new resources to ensure the item modal renders meaningful information.

## Testing
- python -m json.tool data/route.chapters.json
- python -m json.tool data/palworld_complete_data_final.json
- python -m json.tool data/palworld_complete_data_enhanced.json
- python -m json.tool data/item_details.json

------
https://chatgpt.com/codex/tasks/task_e_68d8724428b8833198f4848acb78b04f