### PR TITLE
Rebuild element type chart as interactive matchup map

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,3 +25,39 @@
 .step-category--boss{background:rgba(255,116,140,0.24);color:#ffe7ec}
 .pulse{animation:pulse 1.2s ease-out 1}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(105,228,166,.8)}100%{box-shadow:0 0 0 14px rgba(105,228,166,0)}}
+
+.type-map-layout{display:grid;gap:24px;margin-top:20px}
+@media (min-width:960px){.type-map-layout{grid-template-columns:minmax(0,1fr) minmax(0,320px);align-items:stretch}}
+.type-map{position:relative;width:100%;aspect-ratio:1;border-radius:28px;background:radial-gradient(140% 120% at 50% 18%,rgba(129,211,255,0.18),rgba(8,16,32,0.95) 65%),linear-gradient(135deg,rgba(91,53,202,0.32),rgba(255,114,71,0.18));border:1px solid rgba(255,255,255,0.08);overflow:hidden;box-shadow:0 40px 80px rgba(4,10,26,0.5)}
+.type-map::before{content:"";position:absolute;inset:0;background-image:radial-gradient(circle at 50% 50%,rgba(255,255,255,0.08) 0,rgba(255,255,255,0) 52%),linear-gradient(0deg,rgba(255,255,255,0.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,0.05) 1px,transparent 1px);background-size:100% 100%,26px 26px,26px 26px;opacity:.65;mix-blend-mode:screen;pointer-events:none}
+.type-map::after{content:"";position:absolute;inset:-40%;background:conic-gradient(from 180deg at 50% 50%,rgba(255,255,255,0.12),rgba(255,255,255,0),rgba(255,255,255,0));opacity:.35;pointer-events:none}
+.type-map__connections{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+.type-map__nodes{position:absolute;inset:0}
+.type-map__node{--type-color:#9aa6c6;--type-color-rgb:154,166,198;position:absolute;top:var(--type-y);left:var(--type-x);transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:6px;padding:14px 18px 12px;border-radius:18px;border:2px solid rgba(255,255,255,0.1);background:linear-gradient(160deg,rgba(12,20,36,0.92),rgba(12,20,36,0.68));color:#f0f4f8;text-transform:uppercase;font-weight:700;font-size:.95rem;letter-spacing:.06em;box-shadow:0 14px 32px rgba(0,0,0,0.45);cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease,background .2s ease;min-width:96px}
+.type-map__node:focus-visible,.type-map__node:hover{transform:translate(-50%,-50%) scale(1.06);box-shadow:0 16px 40px rgba(0,0,0,0.52);border-color:rgba(255,255,255,0.28);outline:none}
+.type-map__node-ring{position:absolute;inset:-18px;background:radial-gradient(circle at 50% 50%,rgba(255,255,255,0.18),rgba(255,255,255,0) 68%);opacity:0;transition:opacity .25s ease;pointer-events:none;border-radius:50%}
+.type-map__node:hover .type-map__node-ring,.type-map__node:focus-visible .type-map__node-ring,.type-map__node--focus .type-map__node-ring{opacity:.85;background:radial-gradient(circle at 50% 50%,rgba(var(--type-color-rgb),0.6) 0,rgba(255,255,255,0) 72%)}
+.type-map__node-name{position:relative;z-index:1}
+.type-map__node-meta{position:relative;z-index:1;display:flex;gap:8px}
+.type-map__node-pill{display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:26px;border-radius:999px;font-size:.7rem;font-weight:800;letter-spacing:.08em;background:rgba(255,255,255,0.1);color:#f0f4f8;border:1px solid rgba(255,255,255,0.18);box-shadow:inset 0 0 6px rgba(0,0,0,0.35)}
+.type-map__node-pill--strong{background:rgba(var(--type-color-rgb),0.45);border-color:rgba(var(--type-color-rgb),0.7)}
+.type-map__node-pill--weak{background:rgba(255,94,102,0.22);border-color:rgba(255,94,102,0.45)}
+.type-map__node--focus{border-color:rgba(var(--type-color-rgb),0.78);box-shadow:0 20px 46px rgba(0,0,0,0.6),0 0 28px rgba(var(--type-color-rgb),0.6)}
+.type-map__node--ally{box-shadow:0 0 0 2px rgba(107,230,126,0.38) inset}
+.type-map__node--danger{box-shadow:0 0 0 2px rgba(255,114,71,0.35) inset}
+.type-map__link{--type-color:#f0f4f8;--type-color-rgb:240,244,248;fill:none;stroke:var(--type-color);stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;opacity:.35;transition:opacity .3s ease,stroke-width .3s ease,filter .3s ease;pointer-events:none;color:var(--type-color)}
+.type-map__link--active{stroke-width:2.6;opacity:.92;filter:drop-shadow(0 0 10px rgba(var(--type-color-rgb),0.55))}
+.type-map__link--incoming{stroke-dasharray:5 4;opacity:.55}
+.type-map__link--dim{opacity:.14;filter:blur(.4px)}
+.type-map__legend{margin-top:18px;font-size:.95rem;color:rgba(240,244,248,0.78);text-align:center}
+.type-map__detail{background:rgba(8,16,32,0.85);border-radius:24px;border:1px solid rgba(255,255,255,0.08);padding:24px;display:flex;flex-direction:column;gap:18px;box-shadow:0 34px 64px rgba(4,10,26,0.48);color:#f0f4f8;min-height:100%}
+.type-map__detail-header{display:flex;flex-direction:column;gap:6px}
+.type-map__detail-chip{display:inline-flex;align-items:center;justify-content:flex-start;font-size:1.3rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;background:linear-gradient(135deg,rgba(var(--type-color-rgb),0.65),rgba(8,16,32,0.55));border-radius:999px;padding:12px 18px;border:1px solid rgba(var(--type-color-rgb),0.7);box-shadow:0 10px 24px rgba(0,0,0,0.35)}
+.type-map__detail-sub{font-size:.9rem;color:rgba(240,244,248,0.7);text-transform:uppercase;letter-spacing:.12em}
+.type-map__detail-columns{display:grid;gap:18px}
+@media (min-width:640px){.type-map__detail-columns{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.type-map__detail-columns h4{margin:0 0 8px;font-size:1rem;text-transform:uppercase;letter-spacing:.1em;color:rgba(var(--type-color-rgb),0.85)}
+.type-map__detail-list{list-style:none;margin:0;padding:0;display:grid;gap:6px}
+.type-map__detail-list li{background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.12);border-radius:12px;padding:10px 14px;font-weight:600;letter-spacing:.04em}
+.type-map__detail-empty{margin:0;font-style:italic;color:rgba(240,244,248,0.6)}
+.type-map__detail-note{margin:0;font-size:.9rem;color:rgba(240,244,248,0.75);line-height:1.5}

--- a/index.html
+++ b/index.html
@@ -5149,41 +5149,246 @@
         ? 'Check which elements pals are strong or weak against.'
         : 'Reference chart for attack advantages and resistances.';
       const elemSection = createSection('glossary-elements', 'Elements & Type Chart', elementsDescription);
-      const elemTable = document.createElement('table');
-      elemTable.style.width = '100%';
-      elemTable.style.borderCollapse = 'collapse';
-      elemTable.innerHTML = '<tr><th>Element</th><th>Strong Against</th><th>Weak Against</th></tr>';
-      const elementOrder = ['Neutral','Fire','Water','Grass','Electric','Ice','Ground','Dragon','Dark','Air'];
-      const strengths = {
-        Fire: 'Grass, Ice',
-        Water: 'Fire, Ground',
-        Grass: 'Water, Ground',
-        Electric: 'Water, Air',
-        Ice: 'Dragon, Grass',
-        Ground: 'Electric, Fire',
-        Dragon: 'Dark, Dragon',
-        Dark: 'Neutral',
-        Air: 'Grass, Ground',
-        Neutral: 'None'
+
+      const typeRelations = {
+        Neutral: { strong: [], weak: [] },
+        Fire: { strong: ['Grass', 'Ice'], weak: ['Water', 'Ground'] },
+        Water: { strong: ['Fire', 'Ground'], weak: ['Electric', 'Grass'] },
+        Grass: { strong: ['Water', 'Ground'], weak: ['Fire', 'Ice', 'Air'] },
+        Electric: { strong: ['Water', 'Air'], weak: ['Ground'] },
+        Ice: { strong: ['Dragon', 'Grass'], weak: ['Fire', 'Electric'] },
+        Ground: { strong: ['Electric', 'Fire'], weak: ['Water', 'Grass'] },
+        Dragon: { strong: ['Dark', 'Dragon'], weak: ['Dragon', 'Ice'] },
+        Dark: { strong: ['Neutral'], weak: ['Dragon'] },
+        Air: { strong: ['Grass', 'Ground'], weak: ['Electric', 'Ice'] }
       };
-      const weaknesses = {
-        Fire: 'Water, Ground',
-        Water: 'Electric, Grass',
-        Grass: 'Fire, Ice, Air',
-        Electric: 'Ground',
-        Ice: 'Fire, Electric',
-        Ground: 'Water, Grass',
-        Dragon: 'Dragon, Ice',
-        Dark: 'Dragon',
-        Air: 'Electric, Ice',
-        Neutral: 'None'
+
+      const typeColors = {
+        Neutral: '#adb5c7',
+        Fire: '#ff7247',
+        Water: '#3ac7ff',
+        Grass: '#6be67e',
+        Electric: '#ffd166',
+        Ice: '#8ee7ff',
+        Ground: '#e0a15b',
+        Dragon: '#c386ff',
+        Dark: '#7e6bff',
+        Air: '#81d3ff'
       };
-      elementOrder.forEach(t => {
-        const row = document.createElement('tr');
-        row.innerHTML = `<td>${t}</td><td>${strengths[t] || 'Unknown'}</td><td>${weaknesses[t] || 'Unknown'}</td>`;
-        elemTable.appendChild(row);
+
+      function toRGBString(hex) {
+        if (!hex) return '154, 166, 198';
+        const cleaned = hex.replace('#', '').trim();
+        const normalized = cleaned.length === 3
+          ? cleaned.split('').map(ch => ch + ch).join('')
+          : (cleaned + '000000').slice(0, 6);
+        const r = parseInt(normalized.slice(0, 2), 16);
+        const g = parseInt(normalized.slice(2, 4), 16);
+        const b = parseInt(normalized.slice(4, 6), 16);
+        if ([r, g, b].some(num => Number.isNaN(num))) {
+          return '154, 166, 198';
+        }
+        return `${r}, ${g}, ${b}`;
+      }
+
+      const typeColorRGB = {};
+      Object.entries(typeColors).forEach(([type, color]) => {
+        typeColorRGB[type] = toRGBString(color);
       });
-      elemSection.appendChild(elemTable);
+
+      const typeMapLayout = document.createElement('div');
+      typeMapLayout.className = 'type-map-layout';
+      elemSection.appendChild(typeMapLayout);
+
+      const typeMap = document.createElement('div');
+      typeMap.className = 'type-map';
+      typeMapLayout.appendChild(typeMap);
+
+      const svgNS = 'http://www.w3.org/2000/svg';
+      const connections = document.createElementNS(svgNS, 'svg');
+      connections.classList.add('type-map__connections');
+      connections.setAttribute('viewBox', '0 0 100 100');
+      connections.setAttribute('aria-hidden', 'true');
+
+      const defs = document.createElementNS(svgNS, 'defs');
+      const marker = document.createElementNS(svgNS, 'marker');
+      marker.id = 'type-map-arrowhead';
+      marker.setAttribute('viewBox', '0 0 10 10');
+      marker.setAttribute('refX', '10');
+      marker.setAttribute('refY', '5');
+      marker.setAttribute('markerWidth', '6');
+      marker.setAttribute('markerHeight', '6');
+      marker.setAttribute('orient', 'auto');
+      const markerPath = document.createElementNS(svgNS, 'path');
+      markerPath.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+      markerPath.setAttribute('fill', 'currentColor');
+      marker.appendChild(markerPath);
+      defs.appendChild(marker);
+      connections.appendChild(defs);
+
+      const connectionGroup = document.createElementNS(svgNS, 'g');
+      connectionGroup.classList.add('type-map__link-group');
+      connections.appendChild(connectionGroup);
+      typeMap.appendChild(connections);
+
+      const nodesLayer = document.createElement('div');
+      nodesLayer.className = 'type-map__nodes';
+      typeMap.appendChild(nodesLayer);
+
+      const detailPanel = document.createElement('aside');
+      detailPanel.className = 'type-map__detail';
+      detailPanel.setAttribute('aria-live', 'polite');
+      typeMapLayout.appendChild(detailPanel);
+
+      const legend = document.createElement('p');
+      legend.className = 'type-map__legend';
+      legend.textContent = kidMode
+        ? 'Follow the glowing arrows—each line shows which pals hit super hard!'
+        : 'Arrows flow from the attacking element to the element it overwhelms.';
+      elemSection.appendChild(legend);
+
+      const orbitElements = Object.keys(typeRelations).filter(type => type !== 'Neutral');
+      const nodePositions = {};
+      const radius = 38;
+      orbitElements.forEach((type, index) => {
+        const angle = (index / orbitElements.length) * (Math.PI * 2) - Math.PI / 2;
+        const x = 50 + radius * Math.cos(angle);
+        const y = 50 + radius * Math.sin(angle);
+        nodePositions[type] = { x, y };
+      });
+      nodePositions.Neutral = { x: 50, y: 50 };
+
+      const links = [];
+
+      function createPath(start, end) {
+        const midX = (start.x + end.x) / 2;
+        const midY = (start.y + end.y) / 2;
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        const distance = Math.hypot(dx, dy) || 1;
+        const offset = Math.min(12, distance / 3);
+        const controlX = midX + (-dy / distance) * offset;
+        const controlY = midY + (dx / distance) * offset;
+        return `M ${start.x} ${start.y} Q ${controlX} ${controlY} ${end.x} ${end.y}`;
+      }
+
+      Object.entries(typeRelations).forEach(([source, info]) => {
+        const start = nodePositions[source];
+        if (!start) return;
+        (info.strong || []).forEach(target => {
+          if (target === source) return;
+          const end = nodePositions[target];
+          if (!end) return;
+          const path = document.createElementNS(svgNS, 'path');
+          path.classList.add('type-map__link');
+          path.dataset.source = source;
+          path.dataset.target = target;
+          path.setAttribute('d', createPath(start, end));
+          const color = typeColors[source] || '#f0f4f8';
+          const rgb = typeColorRGB[source] || toRGBString(color);
+          path.style.setProperty('--type-color', color);
+          path.style.setProperty('--type-color-rgb', rgb);
+          path.style.color = color;
+          path.setAttribute('marker-end', 'url(#type-map-arrowhead)');
+          connectionGroup.appendChild(path);
+          links.push(path);
+        });
+      });
+
+      const nodeButtons = [];
+
+      function createNode(type) {
+        const pos = nodePositions[type];
+        if (!pos) return;
+        const strong = (typeRelations[type] && typeRelations[type].strong) || [];
+        const weak = (typeRelations[type] && typeRelations[type].weak) || [];
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'type-map__node';
+        button.dataset.type = type;
+        const color = typeColors[type] || '#9aa6c6';
+        const rgb = typeColorRGB[type] || toRGBString(color);
+        button.style.setProperty('--type-color', color);
+        button.style.setProperty('--type-color-rgb', rgb);
+        button.style.setProperty('--type-x', `${pos.x}%`);
+        button.style.setProperty('--type-y', `${pos.y}%`);
+        button.setAttribute('aria-label', `${type} element: strong against ${strong.length ? strong.join(', ') : 'no elements'}; weak against ${weak.length ? weak.join(', ') : 'no elements'}`);
+        button.setAttribute('aria-pressed', 'false');
+        button.innerHTML = `
+          <span class="type-map__node-ring"></span>
+          <span class="type-map__node-name">${escapeHTML(type)}</span>
+          <span class="type-map__node-meta">
+            <span class="type-map__node-pill type-map__node-pill--strong" title="${kidMode ? 'Number of elements you overpower' : 'Advantage count'}">${strong.length}</span>
+            <span class="type-map__node-pill type-map__node-pill--weak" title="${kidMode ? 'Number of elements that overpower you' : 'Weakness count'}">${weak.length}</span>
+          </span>
+        `;
+        button.addEventListener('click', () => selectType(type));
+        nodesLayer.appendChild(button);
+        nodeButtons.push(button);
+      }
+
+      Object.keys(typeRelations).forEach(createNode);
+
+      function renderList(items, empty) {
+        if (!items || items.length === 0) {
+          return `<p class="type-map__detail-empty">${empty}</p>`;
+        }
+        return `
+          <ul class="type-map__detail-list">
+            ${items.map(item => `<li>${escapeHTML(item)}</li>`).join('')}
+          </ul>
+        `;
+      }
+
+      function selectType(type) {
+        const info = typeRelations[type] || { strong: [], weak: [] };
+        const strongSet = new Set(info.strong);
+        const weakSet = new Set(info.weak);
+        nodeButtons.forEach(btn => {
+          const nodeType = btn.dataset.type;
+          const isFocus = nodeType === type;
+          btn.classList.toggle('type-map__node--focus', isFocus);
+          btn.classList.toggle('type-map__node--ally', strongSet.has(nodeType));
+          btn.classList.toggle('type-map__node--danger', weakSet.has(nodeType));
+          btn.setAttribute('aria-pressed', isFocus ? 'true' : 'false');
+        });
+        links.forEach(path => {
+          const fromSelected = path.dataset.source === type;
+          const toSelected = path.dataset.target === type;
+          path.classList.toggle('type-map__link--active', fromSelected);
+          path.classList.toggle('type-map__link--incoming', toSelected);
+          path.classList.toggle('type-map__link--dim', !fromSelected && !toSelected);
+        });
+
+        const strongLabel = kidMode ? 'Super Effective On' : 'Dominates';
+        const weakLabel = kidMode ? 'Takes Big Damage From' : 'Vulnerable To';
+        const noteText = kidMode
+          ? 'Tap another element to see who it blasts or who blasts it.'
+          : 'Select different nodes to trace optimal matchups and counters.';
+        const color = typeColors[type] || '#9aa6c6';
+        const rgb = typeColorRGB[type] || toRGBString(color);
+        detailPanel.style.setProperty('--type-color', color);
+        detailPanel.style.setProperty('--type-color-rgb', rgb);
+        detailPanel.innerHTML = `
+          <header class="type-map__detail-header">
+            <span class="type-map__detail-chip">${escapeHTML(type)}</span>
+            <span class="type-map__detail-sub">${info.strong.length} advantage${info.strong.length === 1 ? '' : 's'} • ${info.weak.length} weakness${info.weak.length === 1 ? '' : 'es'}</span>
+          </header>
+          <div class="type-map__detail-columns">
+            <div>
+              <h4>${strongLabel}</h4>
+              ${renderList(info.strong, kidMode ? 'No super strengths.' : 'No direct advantages recorded.')}
+            </div>
+            <div>
+              <h4>${weakLabel}</h4>
+              ${renderList(info.weak, kidMode ? 'No big threats.' : 'No notable weaknesses recorded.')}
+            </div>
+          </div>
+          <p class="type-map__detail-note">${noteText}</p>
+        `;
+      }
+
+      selectType('Fire');
 
       const workDescription = kidMode
         ? 'These jobs tell you what pals can help with at base.'


### PR DESCRIPTION
## Summary
- replace the static type matchup table with an interactive orbital map that visualizes strengths with directional arrows and animated highlights
- add a detail panel, legend, and responsive styling that derive colors dynamically from each element for an epic presentation

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d8da2eddf083319c75c29845dc6bd1