### PR TITLE
Reorder glossary layout and refresh element chart

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,9 +33,14 @@
 .type-map::after{content:"";position:absolute;inset:-40%;background:conic-gradient(from 180deg at 50% 50%,rgba(255,255,255,0.12),rgba(255,255,255,0),rgba(255,255,255,0));opacity:.35;pointer-events:none}
 .type-map__connections{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
 .type-map__nodes{position:absolute;inset:0}
-.type-map__node{--type-color:#9aa6c6;--type-color-rgb:154,166,198;position:absolute;top:var(--type-y);left:var(--type-x);transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:6px;padding:14px 18px 12px;border-radius:18px;border:2px solid rgba(255,255,255,0.1);background:linear-gradient(160deg,rgba(12,20,36,0.92),rgba(12,20,36,0.68));color:#f0f4f8;text-transform:uppercase;font-weight:700;font-size:.95rem;letter-spacing:.06em;box-shadow:0 14px 32px rgba(0,0,0,0.45);cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease,background .2s ease;min-width:96px}
+.type-map__node{--type-color:#9aa6c6;--type-color-rgb:154,166,198;position:absolute;top:var(--type-y);left:var(--type-x);transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:8px;padding:16px 20px 14px;border-radius:18px;border:2px solid rgba(255,255,255,0.1);background:linear-gradient(160deg,rgba(12,20,36,0.92),rgba(12,20,36,0.68));color:#f0f4f8;text-transform:uppercase;font-weight:700;font-size:.95rem;letter-spacing:.06em;box-shadow:0 14px 32px rgba(0,0,0,0.45);cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease,background .2s ease;min-width:96px}
 .type-map__node:focus-visible,.type-map__node:hover{transform:translate(-50%,-50%) scale(1.06);box-shadow:0 16px 40px rgba(0,0,0,0.52);border-color:rgba(255,255,255,0.28);outline:none}
 .type-map__node-ring{position:absolute;inset:-18px;background:radial-gradient(circle at 50% 50%,rgba(255,255,255,0.18),rgba(255,255,255,0) 68%);opacity:0;transition:opacity .25s ease;pointer-events:none;border-radius:50%}
+.type-map__node-visual{position:relative;z-index:1;width:62px;height:62px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:linear-gradient(160deg,rgba(8,16,32,0.78),rgba(8,16,32,0.6));box-shadow:0 12px 28px rgba(0,0,0,0.45),inset 0 0 0 1px rgba(255,255,255,0.08)}
+.type-map__node-icon{width:42px;height:42px;object-fit:contain;filter:drop-shadow(0 6px 12px rgba(0,0,0,0.45))}
+.type-map__node--focus .type-map__node-visual{box-shadow:0 16px 36px rgba(0,0,0,0.55),0 0 0 2px rgba(var(--type-color-rgb),0.6)}
+.type-map__node--ally .type-map__node-visual{box-shadow:0 14px 32px rgba(0,0,0,0.5),0 0 0 2px rgba(107,230,126,0.45)}
+.type-map__node--danger .type-map__node-visual{box-shadow:0 14px 32px rgba(0,0,0,0.5),0 0 0 2px rgba(255,114,71,0.4)}
 .type-map__node:hover .type-map__node-ring,.type-map__node:focus-visible .type-map__node-ring,.type-map__node--focus .type-map__node-ring{opacity:.85;background:radial-gradient(circle at 50% 50%,rgba(var(--type-color-rgb),0.6) 0,rgba(255,255,255,0) 72%)}
 .type-map__node-name{position:relative;z-index:1}
 .type-map__node-meta{position:relative;z-index:1;display:flex;gap:8px}
@@ -52,7 +57,8 @@
 .type-map__legend{margin-top:18px;font-size:.95rem;color:rgba(240,244,248,0.78);text-align:center}
 .type-map__detail{background:rgba(8,16,32,0.85);border-radius:24px;border:1px solid rgba(255,255,255,0.08);padding:24px;display:flex;flex-direction:column;gap:18px;box-shadow:0 34px 64px rgba(4,10,26,0.48);color:#f0f4f8;min-height:100%}
 .type-map__detail-header{display:flex;flex-direction:column;gap:6px}
-.type-map__detail-chip{display:inline-flex;align-items:center;justify-content:flex-start;font-size:1.3rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;background:linear-gradient(135deg,rgba(var(--type-color-rgb),0.65),rgba(8,16,32,0.55));border-radius:999px;padding:12px 18px;border:1px solid rgba(var(--type-color-rgb),0.7);box-shadow:0 10px 24px rgba(0,0,0,0.35)}
+.type-map__detail-chip{display:inline-flex;align-items:center;justify-content:flex-start;gap:10px;font-size:1.3rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;background:linear-gradient(135deg,rgba(var(--type-color-rgb),0.65),rgba(8,16,32,0.55));border-radius:999px;padding:12px 18px;border:1px solid rgba(var(--type-color-rgb),0.7);box-shadow:0 10px 24px rgba(0,0,0,0.35)}
+.type-map__detail-icon{width:38px;height:38px;object-fit:contain;filter:drop-shadow(0 6px 12px rgba(0,0,0,0.45))}
 .type-map__detail-sub{font-size:.9rem;color:rgba(240,244,248,0.7);text-transform:uppercase;letter-spacing:.12em}
 .type-map__detail-columns{display:grid;gap:18px}
 @media (min-width:640px){.type-map__detail-columns{grid-template-columns:repeat(2,minmax(0,1fr))}}

--- a/index.html
+++ b/index.html
@@ -5275,185 +5275,6 @@
         return input;
       }
 
-      const passiveDescription = kidMode
-        ? 'All partner traits pals can roll. Tap a trait to read what it does.'
-        : 'Complete alphabetical list of every passive trait. Select any entry for detailed effects.';
-      const passiveSection = createSection('glossary-passives', 'Passive Skills', passiveDescription);
-      const passiveSearch = createSearch(kidMode ? 'Search passive traits…' : 'Filter passive traits…');
-      passiveSection.appendChild(passiveSearch);
-      const passiveCount = document.createElement('p');
-      passiveCount.className = 'glossary-count';
-      passiveSection.appendChild(passiveCount);
-      const passiveWrap = document.createElement('div');
-      passiveWrap.className = 'glossary-chip-grid';
-      passiveSection.appendChild(passiveWrap);
-      const passiveEmpty = document.createElement('p');
-      passiveEmpty.className = 'glossary-empty';
-      passiveEmpty.textContent = kidMode
-        ? 'No passives found. Try a different word.'
-        : 'No passive traits match your search.';
-      passiveEmpty.hidden = true;
-      passiveSection.appendChild(passiveEmpty);
-
-      const passiveEntries = Object.keys(traitsDictionary || {})
-        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
-      passiveEntries.forEach(trait => {
-        const description = typeof traitsDictionary[trait] === 'string' ? traitsDictionary[trait] : '';
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'chip passive';
-        btn.dataset.trait = trait;
-        const slug = slugifyForPalworld(trait);
-        if (slug) {
-          btn.id = `passive-${slug}`;
-        }
-        btn.title = description || trait;
-        btn.textContent = trait;
-        btn.dataset.search = `${trait} ${description}`.toLowerCase();
-        passiveWrap.appendChild(btn);
-      });
-
-      const totalPassives = passiveEntries.length;
-      function filterPassives() {
-        const term = passiveSearch.value.trim().toLowerCase();
-        let visible = 0;
-        passiveWrap.querySelectorAll('.chip.passive').forEach(btn => {
-          const searchable = btn.dataset.search || '';
-          const matches = !term || searchable.includes(term);
-          btn.style.display = matches ? '' : 'none';
-          btn.tabIndex = matches ? 0 : -1;
-          if (matches) visible += 1;
-        });
-        passiveCount.textContent = totalPassives
-          ? (visible === totalPassives
-            ? `${totalPassives} passive traits listed.`
-            : `Showing ${visible} of ${totalPassives} passive traits.`)
-          : 'No passive traits available.';
-        passiveEmpty.hidden = visible !== 0;
-      }
-      filterPassives();
-      passiveSearch.addEventListener('input', filterPassives);
-
-      const activeDescription = kidMode
-        ? 'Every move pals can learn. Search by name, element or effect.'
-        : 'Complete catalogue of partner and weapon skills. Filter by name, element or effect.';
-      const activeSection = createSection('glossary-active', 'Active Skills', activeDescription);
-      const rainbowCallout = document.createElement('div');
-      rainbowCallout.className = 'glossary-callout';
-      rainbowCallout.innerHTML = `<strong>Rainbow skills</strong>Rainbow-fruit moves ignore normal type weaknesses and resistances, so they deal steady damage even when enemies resist your pal’s element. They can be taught to any pal, making them perfect coverage options for favourite partners.`;
-      activeSection.appendChild(rainbowCallout);
-
-      const skillSearch = createSearch(kidMode ? 'Search active skills…' : 'Filter active skills by name, element or effect…');
-      activeSection.appendChild(skillSearch);
-      const skillCount = document.createElement('p');
-      skillCount.className = 'glossary-count';
-      activeSection.appendChild(skillCount);
-      const skillsWrap = document.createElement('div');
-      skillsWrap.className = 'glossary-skill-grid';
-      activeSection.appendChild(skillsWrap);
-      const skillEmpty = document.createElement('p');
-      skillEmpty.className = 'glossary-empty';
-      skillEmpty.textContent = kidMode
-        ? 'No skills found. Try another word or element.'
-        : 'No active skills match your filters.';
-      skillEmpty.hidden = true;
-      activeSection.appendChild(skillEmpty);
-
-      const skillEntriesMap = new Map();
-      Object.entries(normalizedSkillDetails).forEach(([key, info]) => {
-        skillEntriesMap.set(key, {
-          key,
-          displayName: info.name || key,
-          element: info.element || 'Unknown',
-          power: typeof info.power === 'number' ? info.power : null,
-          cooldown: typeof info.ct === 'number' ? info.ct : null,
-          description: info.description || ''
-        });
-      });
-      Object.entries(skillsDictionary || {}).forEach(([rawKey, info = {}]) => {
-        const normalizedKey = rawKey.toLowerCase();
-        const existing = skillEntriesMap.get(normalizedKey);
-        const baseName = info.name || niceName(rawKey);
-        const fallbackPower = typeof info.power === 'number'
-          ? info.power
-          : (() => {
-              const match = (info.damage || '').match(/(\d+)/);
-              return match ? Number(match[1]) : null;
-            })();
-        const description = info.description || existing?.description || '';
-        const element = (existing && existing.element && existing.element !== 'Unknown')
-          ? existing.element
-          : (info.element || info.type || 'Unknown');
-        const cooldown = existing?.cooldown != null ? existing.cooldown : null;
-        const merged = {
-          key: normalizedKey,
-          displayName: baseName,
-          element,
-          power: existing?.power != null ? existing.power : fallbackPower,
-          cooldown,
-          description
-        };
-        skillEntriesMap.set(normalizedKey, { ...existing, ...merged });
-      });
-
-      const skillEntries = Array.from(skillEntriesMap.values())
-        .filter(entry => entry && entry.displayName)
-        .sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }));
-      skillEntries.forEach(entry => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'glossary-skill';
-        btn.dataset.skill = entry.key;
-        const slug = slugifyForPalworld(entry.displayName);
-        if (slug) {
-          btn.id = `move-${slug}`;
-        }
-        const metaBits = [];
-        if (typeof entry.power === 'number' && !Number.isNaN(entry.power)) {
-          metaBits.push(`Power ${entry.power}`);
-        }
-        if (typeof entry.cooldown === 'number' && !Number.isNaN(entry.cooldown)) {
-          metaBits.push(`CT ${entry.cooldown}s`);
-        }
-        const metaText = metaBits.join(' • ');
-        btn.innerHTML = `
-          <span class="glossary-skill__header">
-            <span class="glossary-skill__name">${escapeHTML(entry.displayName)}</span>
-            <span class="glossary-skill__element">${escapeHTML(entry.element || 'Unknown')}</span>
-          </span>
-          ${metaText ? `<span class="glossary-skill__meta">${escapeHTML(metaText)}</span>` : ''}
-          <span class="glossary-skill__description">${escapeHTML(entry.description || 'No description available.')}</span>
-        `;
-        const searchableChunks = [
-          entry.displayName,
-          entry.element,
-          entry.description,
-          metaText
-        ].filter(Boolean);
-        btn.dataset.search = searchableChunks.join(' ').toLowerCase();
-        skillsWrap.appendChild(btn);
-      });
-
-      const totalSkills = skillEntries.length;
-      function filterSkills() {
-        const term = skillSearch.value.trim().toLowerCase();
-        let visible = 0;
-        skillsWrap.querySelectorAll('.glossary-skill').forEach(btn => {
-          const matches = !term || (btn.dataset.search || '').includes(term);
-          btn.style.display = matches ? '' : 'none';
-          btn.tabIndex = matches ? 0 : -1;
-          if (matches) visible += 1;
-        });
-        skillCount.textContent = totalSkills
-          ? (visible === totalSkills
-            ? `${totalSkills} active skills listed.`
-            : `Showing ${visible} of ${totalSkills} active skills.`)
-          : 'No active skills available.';
-        skillEmpty.hidden = visible !== 0;
-      }
-      filterSkills();
-      skillSearch.addEventListener('input', filterSkills);
-
       const elementsDescription = kidMode
         ? 'Check which elements pals are strong or weak against.'
         : 'Reference chart for attack advantages and resistances.';
@@ -5504,6 +5325,14 @@
       Object.entries(typeColors).forEach(([type, color]) => {
         typeColorRGB[type] = toRGBString(color);
       });
+
+      function getTypeIconSource(type) {
+        const source = iconMap[type];
+        if (typeof source === 'string' && source.trim().length) {
+          return source;
+        }
+        return iconMap['Neutral'] || 'assets/icons/neutral.png';
+      }
 
       const typeMapLayout = document.createElement('div');
       typeMapLayout.className = 'type-map-layout';
@@ -5623,8 +5452,12 @@
         button.style.setProperty('--type-y', `${pos.y}%`);
         button.setAttribute('aria-label', `${type} element: strong against ${strong.length ? strong.join(', ') : 'no elements'}; weak against ${weak.length ? weak.join(', ') : 'no elements'}`);
         button.setAttribute('aria-pressed', 'false');
+        const iconSrc = getTypeIconSource(type);
         button.innerHTML = `
           <span class="type-map__node-ring"></span>
+          <span class="type-map__node-visual">
+            <img src="${escapeHTML(iconSrc)}" alt="" loading="lazy" class="type-map__node-icon" aria-hidden="true">
+          </span>
           <span class="type-map__node-name">${escapeHTML(type)}</span>
           <span class="type-map__node-meta">
             <span class="type-map__node-pill type-map__node-pill--strong" title="${kidMode ? 'Number of elements you overpower' : 'Advantage count'}">${strong.length}</span>
@@ -5676,11 +5509,15 @@
           : 'Select different nodes to trace optimal matchups and counters.';
         const color = typeColors[type] || '#9aa6c6';
         const rgb = typeColorRGB[type] || toRGBString(color);
+        const iconSrc = getTypeIconSource(type);
         detailPanel.style.setProperty('--type-color', color);
         detailPanel.style.setProperty('--type-color-rgb', rgb);
         detailPanel.innerHTML = `
           <header class="type-map__detail-header">
-            <span class="type-map__detail-chip">${escapeHTML(type)}</span>
+            <span class="type-map__detail-chip">
+              <img src="${escapeHTML(iconSrc)}" alt="" loading="lazy" class="type-map__detail-icon" aria-hidden="true">
+              ${escapeHTML(type)}
+            </span>
             <span class="type-map__detail-sub">${info.strong.length} advantage${info.strong.length === 1 ? '' : 's'} • ${info.weak.length} weakness${info.weak.length === 1 ? '' : 'es'}</span>
           </header>
           <div class="type-map__detail-columns">
@@ -5907,6 +5744,185 @@
       });
 
       workSection.appendChild(workGrid);
+
+      const passiveDescription = kidMode
+        ? 'All partner traits pals can roll. Tap a trait to read what it does.'
+        : 'Complete alphabetical list of every passive trait. Select any entry for detailed effects.';
+      const passiveSection = createSection('glossary-passives', 'Passive Skills', passiveDescription);
+      const passiveSearch = createSearch(kidMode ? 'Search passive traits…' : 'Filter passive traits…');
+      passiveSection.appendChild(passiveSearch);
+      const passiveCount = document.createElement('p');
+      passiveCount.className = 'glossary-count';
+      passiveSection.appendChild(passiveCount);
+      const passiveWrap = document.createElement('div');
+      passiveWrap.className = 'glossary-chip-grid';
+      passiveSection.appendChild(passiveWrap);
+      const passiveEmpty = document.createElement('p');
+      passiveEmpty.className = 'glossary-empty';
+      passiveEmpty.textContent = kidMode
+        ? 'No passives found. Try a different word.'
+        : 'No passive traits match your search.';
+      passiveEmpty.hidden = true;
+      passiveSection.appendChild(passiveEmpty);
+
+      const passiveEntries = Object.keys(traitsDictionary || {})
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+      passiveEntries.forEach(trait => {
+        const description = typeof traitsDictionary[trait] === 'string' ? traitsDictionary[trait] : '';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'chip passive';
+        btn.dataset.trait = trait;
+        const slug = slugifyForPalworld(trait);
+        if (slug) {
+          btn.id = `passive-${slug}`;
+        }
+        btn.title = description || trait;
+        btn.textContent = trait;
+        btn.dataset.search = `${trait} ${description}`.toLowerCase();
+        passiveWrap.appendChild(btn);
+      });
+
+      const totalPassives = passiveEntries.length;
+      function filterPassives() {
+        const term = passiveSearch.value.trim().toLowerCase();
+        let visible = 0;
+        passiveWrap.querySelectorAll('.chip.passive').forEach(btn => {
+          const searchable = btn.dataset.search || '';
+          const matches = !term || searchable.includes(term);
+          btn.style.display = matches ? '' : 'none';
+          btn.tabIndex = matches ? 0 : -1;
+          if (matches) visible += 1;
+        });
+        passiveCount.textContent = totalPassives
+          ? (visible === totalPassives
+            ? `${totalPassives} passive traits listed.`
+            : `Showing ${visible} of ${totalPassives} passive traits.`)
+          : 'No passive traits available.';
+        passiveEmpty.hidden = visible !== 0;
+      }
+      filterPassives();
+      passiveSearch.addEventListener('input', filterPassives);
+
+      const activeDescription = kidMode
+        ? 'Every move pals can learn. Search by name, element or effect.'
+        : 'Complete catalogue of partner and weapon skills. Filter by name, element or effect.';
+      const activeSection = createSection('glossary-active', 'Active Skills', activeDescription);
+      const rainbowCallout = document.createElement('div');
+      rainbowCallout.className = 'glossary-callout';
+      rainbowCallout.innerHTML = `<strong>Rainbow skills</strong>Rainbow-fruit moves ignore normal type weaknesses and resistances, so they deal steady damage even when enemies resist your pal’s element. They can be taught to any pal, making them perfect coverage options for favourite partners.`;
+      activeSection.appendChild(rainbowCallout);
+
+      const skillSearch = createSearch(kidMode ? 'Search active skills…' : 'Filter active skills by name, element or effect…');
+      activeSection.appendChild(skillSearch);
+      const skillCount = document.createElement('p');
+      skillCount.className = 'glossary-count';
+      activeSection.appendChild(skillCount);
+      const skillsWrap = document.createElement('div');
+      skillsWrap.className = 'glossary-skill-grid';
+      activeSection.appendChild(skillsWrap);
+      const skillEmpty = document.createElement('p');
+      skillEmpty.className = 'glossary-empty';
+      skillEmpty.textContent = kidMode
+        ? 'No skills found. Try another word or element.'
+        : 'No active skills match your filters.';
+      skillEmpty.hidden = true;
+      activeSection.appendChild(skillEmpty);
+
+      const skillEntriesMap = new Map();
+      Object.entries(normalizedSkillDetails).forEach(([key, info]) => {
+        skillEntriesMap.set(key, {
+          key,
+          displayName: info.name || key,
+          element: info.element || 'Unknown',
+          power: typeof info.power === 'number' ? info.power : null,
+          cooldown: typeof info.ct === 'number' ? info.ct : null,
+          description: info.description || ''
+        });
+      });
+      Object.entries(skillsDictionary || {}).forEach(([rawKey, info = {}]) => {
+        const normalizedKey = rawKey.toLowerCase();
+        const existing = skillEntriesMap.get(normalizedKey);
+        const baseName = info.name || niceName(rawKey);
+        const fallbackPower = typeof info.power === 'number'
+          ? info.power
+          : (() => {
+              const match = (info.damage || '').match(/(\d+)/);
+              return match ? Number(match[1]) : null;
+            })();
+        const description = info.description || existing?.description || '';
+        const element = (existing && existing.element && existing.element !== 'Unknown')
+          ? existing.element
+          : (info.element || info.type || 'Unknown');
+        const cooldown = existing?.cooldown != null ? existing.cooldown : null;
+        const merged = {
+          key: normalizedKey,
+          displayName: baseName,
+          element,
+          power: existing?.power != null ? existing.power : fallbackPower,
+          cooldown,
+          description
+        };
+        skillEntriesMap.set(normalizedKey, { ...existing, ...merged });
+      });
+
+      const skillEntries = Array.from(skillEntriesMap.values())
+        .filter(entry => entry && entry.displayName)
+        .sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }));
+      skillEntries.forEach(entry => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'glossary-skill';
+        btn.dataset.skill = entry.key;
+        const slug = slugifyForPalworld(entry.displayName);
+        if (slug) {
+          btn.id = `move-${slug}`;
+        }
+        const metaBits = [];
+        if (typeof entry.power === 'number' && !Number.isNaN(entry.power)) {
+          metaBits.push(`Power ${entry.power}`);
+        }
+        if (typeof entry.cooldown === 'number' && !Number.isNaN(entry.cooldown)) {
+          metaBits.push(`CT ${entry.cooldown}s`);
+        }
+        const metaText = metaBits.join(' • ');
+        btn.innerHTML = `
+          <span class="glossary-skill__header">
+            <span class="glossary-skill__name">${escapeHTML(entry.displayName)}</span>
+            <span class="glossary-skill__element">${escapeHTML(entry.element || 'Unknown')}</span>
+          </span>
+          ${metaText ? `<span class="glossary-skill__meta">${escapeHTML(metaText)}</span>` : ''}
+          <span class="glossary-skill__description">${escapeHTML(entry.description || 'No description available.')}</span>
+        `;
+        const searchableChunks = [
+          entry.displayName,
+          entry.element,
+          entry.description,
+          metaText
+        ].filter(Boolean);
+        btn.dataset.search = searchableChunks.join(' ').toLowerCase();
+        skillsWrap.appendChild(btn);
+      });
+
+      const totalSkills = skillEntries.length;
+      function filterSkills() {
+        const term = skillSearch.value.trim().toLowerCase();
+        let visible = 0;
+        skillsWrap.querySelectorAll('.glossary-skill').forEach(btn => {
+          const matches = !term || (btn.dataset.search || '').includes(term);
+          btn.style.display = matches ? '' : 'none';
+          btn.tabIndex = matches ? 0 : -1;
+          if (matches) visible += 1;
+        });
+        skillCount.textContent = totalSkills
+          ? (visible === totalSkills
+            ? `${totalSkills} active skills listed.`
+            : `Showing ${visible} of ${totalSkills} active skills.`)
+          : 'No active skills available.';
+        skillEmpty.hidden = visible !== 0;
+      }
+      filterSkills();
+      skillSearch.addEventListener('input', filterSkills);
 
       if (!container.dataset.listenerBound) {
         container.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- move the elements and work sections ahead of passives and active skills in the glossary navigation
- enhance the element matchup chart with type icons and refreshed styling for the node and detail views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92dec8e708331be900f7c36ddd66e