### PR TITLE
Fix Work Suitabilities pal art fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -5776,7 +5776,6 @@
             const tierInfo = getTierInfo(level);
             const label = getWorkLabel(level);
             const normalizedWidth = Math.min(100, Math.max(0, (level / Math.max(1, highestWorkLevel)) * 100));
-            const art = pal.localImage || pal.image || '';
             const initial = (palName || '?').trim().charAt(0) || '?';
 
             const cardBtn = document.createElement('button');
@@ -5787,24 +5786,59 @@
             cardBtn.dataset.workLevel = String(level);
             cardBtn.setAttribute('aria-label', `${palName} ${label}`);
             cardBtn.title = `${palName} — ${label}`;
-            cardBtn.innerHTML = `
-              <span class="work-pal-card__rank">#${index + 1}</span>
-              <span class="work-pal-card__art">
-                ${art
-                  ? `<img src="${escapeHTML(art)}" alt="${escapeHTML(palName)}" loading="lazy">`
-                  : `<span class="work-pal-card__placeholder">${escapeHTML(initial)}</span>`}
-              </span>
-              <span class="work-pal-card__info">
-                <span class="work-pal-card__head">
-                  <span class="work-pal-card__name">${escapeHTML(palName)}</span>
-                  <span class="${tierInfo.className}">${escapeHTML(tierInfo.badge)}</span>
-                </span>
-                <span class="work-pal-card__skill">${escapeHTML(label)}</span>
-                <span class="work-skill-meter" aria-hidden="true">
-                  <span class="work-skill-meter__fill" style="width: ${normalizedWidth.toFixed(0)}%;"></span>
-                </span>
-              </span>
-            `;
+
+            const rank = document.createElement('span');
+            rank.className = 'work-pal-card__rank';
+            rank.textContent = `#${index + 1}`;
+            cardBtn.appendChild(rank);
+
+            const artWrap = document.createElement('span');
+            artWrap.className = 'work-pal-card__art';
+            const placeholder = document.createElement('span');
+            placeholder.className = 'work-pal-card__placeholder';
+            placeholder.textContent = initial;
+            artWrap.appendChild(placeholder);
+
+            const artImg = document.createElement('img');
+            artImg.alt = palName;
+            artImg.addEventListener('load', () => {
+              placeholder.hidden = true;
+            });
+            applyPalArtwork(artImg, pal, { alt: palName });
+            artWrap.appendChild(artImg);
+            cardBtn.appendChild(artWrap);
+
+            const infoWrap = document.createElement('span');
+            infoWrap.className = 'work-pal-card__info';
+
+            const head = document.createElement('span');
+            head.className = 'work-pal-card__head';
+            const nameEl = document.createElement('span');
+            nameEl.className = 'work-pal-card__name';
+            nameEl.textContent = palName;
+            head.appendChild(nameEl);
+
+            const badge = document.createElement('span');
+            badge.className = tierInfo.className;
+            badge.textContent = tierInfo.badge;
+            head.appendChild(badge);
+            infoWrap.appendChild(head);
+
+            const skill = document.createElement('span');
+            skill.className = 'work-pal-card__skill';
+            skill.textContent = label;
+            infoWrap.appendChild(skill);
+
+            const meter = document.createElement('span');
+            meter.className = 'work-skill-meter';
+            meter.setAttribute('aria-hidden', 'true');
+            const meterFill = document.createElement('span');
+            meterFill.className = 'work-skill-meter__fill';
+            meterFill.style.width = `${normalizedWidth.toFixed(0)}%`;
+            meter.appendChild(meterFill);
+            infoWrap.appendChild(meter);
+
+            cardBtn.appendChild(infoWrap);
             palGrid.appendChild(cardBtn);
           });
         }


### PR DESCRIPTION
## Summary
- rebuild the Work Suitabilities pal card markup to reuse the shared artwork fallback helper and retain placeholders until imagery loads

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d93f85f8f483319a0a4d790d682300