### PR TITLE
Improve base planner suggestions for early progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -4974,9 +4974,58 @@
       }
       return note;
     }
-    function suggestPalsForWork(key, { crew } = {}) {
+    function suggestPalsForWork(key, { crew, baseConfig, stageSnapshot } = {}) {
       const result = { kid: [], grown: [] };
       const seen = new Set();
+      const snapshot = stageSnapshot || determineGuideStageSnapshot();
+      const stageIndex = typeof snapshot?.stageIndex === 'number' && snapshot.stageIndex >= 0 ? snapshot.stageIndex : 0;
+      let config = baseConfig;
+      if (!config) {
+        const autoInfo = calculateAutoBaseLevelDetail();
+        const manualLevel = clampToRange(
+          Number.isFinite(basePlannerState?.manualLevel) ? Math.round(basePlannerState.manualLevel) : autoInfo.level,
+          1,
+          BASE_LEVEL_CONFIG.length || 1
+        );
+        const activeLevel = basePlannerState?.mode === 'manual' ? manualLevel : autoInfo.level;
+        config = getBaseLevelConfig(activeLevel);
+      }
+      const preferredRarity = Number(config?.preferredRarity);
+      const rarityBaseline = Number.isFinite(preferredRarity) ? preferredRarity : 2;
+      const rarityCap = Math.max(1, rarityBaseline + Math.max(0, Math.floor(stageIndex / 2)));
+      const priceCap = 1800 + stageIndex * 1400;
+      const STARTER_SPAWN_KEYWORDS = ['plains', 'forest', 'coast', 'plateau', 'grass', 'field', 'hill', 'valley', 'beach', 'lake'];
+      const MID_SPAWN_KEYWORDS = ['desert', 'marsh', 'swamp', 'canyon', 'highland', 'mountain'];
+      const LATE_SPAWN_KEYWORDS = ['volcano', 'tundra', 'snow', 'ice', 'ruins', 'abyss', 'sanctuary', 'dungeon', 'frost'];
+      const evaluateAccessibility = pal => {
+        const rarity = Number(pal?.rarity) || 0;
+        const price = Number(pal?.price) || 0;
+        const areas = Array.isArray(pal?.spawnAreas) ? pal.spawnAreas : [];
+        const normalizedAreas = areas.map(area => String(area || '').toLowerCase());
+        const hasStarterArea = normalizedAreas.some(area => STARTER_SPAWN_KEYWORDS.some(keyword => area.includes(keyword)));
+        const hasMidArea = normalizedAreas.some(area => MID_SPAWN_KEYWORDS.some(keyword => area.includes(keyword)));
+        const hasLateArea = normalizedAreas.some(area => LATE_SPAWN_KEYWORDS.some(keyword => area.includes(keyword)));
+        let spawnPenalty = 1.5;
+        if (!normalizedAreas.length) {
+          spawnPenalty = 2;
+        } else if (hasStarterArea) {
+          spawnPenalty = 0;
+        } else if (hasLateArea) {
+          spawnPenalty = stageIndex >= 4 ? 1.5 : 4;
+        } else if (hasMidArea) {
+          spawnPenalty = stageIndex >= 2 ? 1.2 : 2.6;
+        } else {
+          spawnPenalty = 1.2;
+        }
+        const rarityPenalty = Math.max(0, rarity - rarityCap);
+        const pricePenalty = priceCap > 0 ? Math.max(0, price - priceCap) / priceCap : 0;
+        const accessible =
+          rarity <= rarityCap &&
+          (price === 0 || price <= priceCap) &&
+          (spawnPenalty <= 2 || stageIndex >= 3);
+        const accessibilityScore = rarityPenalty * 6 + pricePenalty * 4 + spawnPenalty + (accessible ? 0 : 15);
+        return { accessible, accessibilityScore };
+      };
       if (crew && Array.isArray(crew.selections)) {
         crew.selections.forEach(entry => {
           if (!entry || !entry.pal) return;
@@ -4998,13 +5047,27 @@
       if (result.kid.length < 2 || result.grown.length < 2) {
         const dataset = Object.values(PALS || {})
           .filter(pal => pal?.work && Number(pal.work[key]) > 0)
+          .map(pal => {
+            const { accessible, accessibilityScore } = evaluateAccessibility(pal);
+            return {
+              pal,
+              accessible,
+              accessibilityScore,
+              workLevel: Number(pal.work[key]) || 0
+            };
+          })
           .sort((a, b) => {
-            const levelA = Number(a.work[key]) || 0;
-            const levelB = Number(b.work[key]) || 0;
-            if (levelB !== levelA) return levelB - levelA;
-            return (a.rarity || 0) - (b.rarity || 0);
+            if (b.workLevel !== a.workLevel) return b.workLevel - a.workLevel;
+            if (a.accessible !== b.accessible) return a.accessible ? -1 : 1;
+            if (a.accessibilityScore !== b.accessibilityScore) return a.accessibilityScore - b.accessibilityScore;
+            const rarityDiff = (a.pal.rarity || 0) - (b.pal.rarity || 0);
+            if (rarityDiff !== 0) return rarityDiff;
+            const priceDiff = (a.pal.price || 0) - (b.pal.price || 0);
+            if (priceDiff !== 0) return priceDiff;
+            return a.pal.name.localeCompare(b.pal.name);
           });
-        dataset.forEach(pal => {
+        dataset.forEach(entry => {
+          const pal = entry.pal;
           if (!pal?.name || seen.has(pal.name)) return;
           if (result.kid.length < 2) {
             result.kid.push(pal.name);
@@ -5061,7 +5124,7 @@
       }
       return weights;
     }
-    function generateCoverageNotes({ config, crew, weights }) {
+    function generateCoverageNotes({ config, crew, weights, stageSnapshot }) {
       const notes = [];
       if (!crew || !crew.coverage) return notes;
       const entries = Object.entries(weights || config?.workWeights || {})
@@ -5085,7 +5148,7 @@
       });
       gaps.slice(0, 2).forEach(entry => {
         const detail = getWorkTypeDetail(entry.key);
-        const helperNames = suggestPalsForWork(entry.key, { crew });
+        const helperNames = suggestPalsForWork(entry.key, { crew, baseConfig: config, stageSnapshot });
         const kidTargets = helperNames.kid.slice(0, 2);
         const grownTargets = helperNames.grown.slice(0, 2);
         const kidLines = [
@@ -5226,7 +5289,7 @@
         const kindlingCoverage = crew?.coverage?.kindling || 0;
         const expected = Math.max(1, crew?.slotCount || 1) * Math.max(1, MAX_WORK_LEVEL);
         if (kindlingCoverage < expected * 0.6) {
-          const helpers = suggestPalsForWork('kindling', { crew });
+          const helpers = suggestPalsForWork('kindling', { crew, baseConfig: config, stageSnapshot });
           const kidTargets = helpers.kid.slice(0, 2).join(' or ') || 'strong fire pals';
           const grownTargets = helpers.grown.slice(0, 2).join(' or ') || 'dedicated Kindling specialists';
           notes.push({
@@ -5271,7 +5334,7 @@
       } else {
         addNote(createStageOverviewNote(snapshot));
       }
-      generateCoverageNotes({ config, crew, weights }).forEach(addNote);
+      generateCoverageNotes({ config, crew, weights, stageSnapshot: snapshot }).forEach(addNote);
       generateCatchNotes(crew).forEach(addNote);
       generateTechPriorityNotes({ config, crew, weights, stageSnapshot: snapshot }).forEach(addNote);
       if (!notes.length) {


### PR DESCRIPTION
## Summary
- refine the base planner helper suggestions to consider stage progress, rarity, cost, and spawn locations so early guidance prioritises attainable pals
- update coverage and tech recommendation notes to use the progression-aware helper selection

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9846e7ffc833182ef1fe88a3cc54d