### PR TITLE
Fix skill lookup slug mismatch in pal updater

### DIFF
--- a/scripts/add_missing_pals.py
+++ b/scripts/add_missing_pals.py
@@ -128,8 +128,11 @@ def build_skill_lookup(existing: Dict[str, dict]) -> Dict[str, Dict[str, float]]
     for pal in existing.values():
         for skill in pal.get('skills', []):
             name = skill.get('name')
-            if name and name not in lookup:
-                lookup[name] = {
+            if not name:
+                continue
+            slug = slugify(name)
+            if slug not in lookup:
+                lookup[slug] = {
                     'power': skill.get('power'),
                     'cooldown': skill.get('cooldown'),
                 }


### PR DESCRIPTION
## Summary
- normalise skill names with slugify when building the lookup table in add_missing_pals.py
- prevent duplicate entries when newly scraped skills use slug names that differ from the stored display name

## Testing
- python -m compileall scripts/add_missing_pals.py

------
https://chatgpt.com/codex/tasks/task_e_68d9860be9508331bf8fe22a549ffa75