### PR TITLE
Fix base planner ranch library regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -3528,6 +3528,7 @@
     const goodTraits = ['Diligent', 'Runner', 'Strong', 'Loyal'];
     const badTraits = ['Coward', 'Lazy', 'Gullible'];
 
+    const PALWORLD_BASE_URL = 'https://palworld.gg';
     const WORK_TYPE_DETAILS = {
       handiwork: { label: 'Handiwork', kidLabel: 'Building crew', icon: '🛠️' },
       transporting: { label: 'Transporting', kidLabel: 'Hauling crew', icon: '📦' },
@@ -4900,7 +4901,6 @@
       modalBody.innerHTML = '';
       playSound(closeSound);
     }
-    const PALWORLD_BASE_URL = 'https://palworld.gg';
     const PALWORLD_PAL_SLUG_OVERRIDES = {
       // Reserved for pals whose Palworld.gg slug does not match the default slugification.
     };


### PR DESCRIPTION
## Summary
- define `PALWORLD_BASE_URL` before the ranch item library initializes
- prevent the ranch planner constants from accessing the URL constant before it is ready so the SPA can boot again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d992c4b4f083318de7356efe715b64