### PR TITLE
Fix base intel note layout overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -2804,13 +2804,14 @@
     }
     .base-intel-notes {
       position: relative;
+      display: grid;
       min-height: 180px;
       padding-top: 6px;
       overflow-wrap: anywhere;
     }
     .base-note {
-      position: absolute;
-      inset: 0;
+      position: relative;
+      grid-area: 1 / 1;
       border-radius: 18px;
       padding: 16px;
       background: rgba(10, 21, 34, 0.68);


### PR DESCRIPTION
## Summary
- allow the base intel notes container to use a grid layout so the card can expand with its text
- stack individual base intel notes in the grid so longer suggestions remain contained

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d99ace763c8331916190977dd5d8f5