### PR TITLE
Fix route guide link chips and optional focusing

### DIFF
--- a/index.html
+++ b/index.html
@@ -8694,9 +8694,14 @@
       if(!pendingRouteFocus) return;
       const routePage = document.getElementById('routePage');
       if(!routePage) return;
-      const target = routePage.querySelector(`input[data-step="${pendingRouteFocus}"]`);
-      if(!target) return;
       const stepId = pendingRouteFocus;
+      const target = routePage.querySelector(`input[data-step="${stepId}"]`);
+      if(!target){
+        if(ensureRouteOptionalVisible(stepId)){
+          requestAnimationFrame(applyQueuedRouteFocus);
+        }
+        return;
+      }
       pendingRouteFocus = null;
       requestAnimationFrame(() => {
         target.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -8710,6 +8715,26 @@
           }
         }
       });
+    }
+
+    function ensureRouteOptionalVisible(stepId){
+      if(!routeHideOptional || !stepId || !routeGuideData) return false;
+      const chapters = Array.isArray(routeGuideData.chapters) ? routeGuideData.chapters : [];
+      for(const chapter of chapters){
+        const steps = Array.isArray(chapter?.steps) ? chapter.steps : [];
+        const step = steps.find(entry => entry && entry.id === stepId);
+        if(step && step.optional){
+          routeHideOptional = false;
+          const routePage = document.getElementById('routePage');
+          const toggleBtn = routePage ? routePage.querySelector('#toggleOptional') : null;
+          if(toggleBtn){
+            toggleBtn.textContent = routeOptionalToggleLabel(routeHideOptional);
+          }
+          chapters.forEach(ch => rerenderChapter(ch));
+          return true;
+        }
+      }
+      return false;
     }
 
     function renderChapterCard(chapter, openByDefault){
@@ -9288,13 +9313,21 @@
     function renderLinks(links){
       if(!links || !links.length) return '';
       return `<span class="badges">${links.map(link => {
-        const payload = JSON.stringify(link).replace(/"/g, '&quot;');
+        const payload = JSON.stringify(link)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
         return `<a href="#" class="chip link" data-link="${payload}" role="button">${escapeHTML(linkLabel(link))}</a>`;
       }).join('')}</span>`;
     }
 
     function linkLabel(link){
-      if(link.type === 'pal') return capitalize(link.slug);
+      if(link.type === 'pal'){
+        const source = link.slug || link.id || link.name;
+        return capitalize(source);
+      }
       if(link.type === 'item') return niceName(link.id);
       if(link.type === 'passive') return capitalize(link.id);
       if(link.type === 'move') return niceName(link.id);

--- a/js/pages/route.js
+++ b/js/pages/route.js
@@ -200,7 +200,10 @@ function isKidMode(){
 }
 
 function linkLabel(l){
-  if(l.type==='pal') return capitalize(l.slug);
+  if(l.type==='pal'){
+    const source = l.slug || l.id || l.name;
+    return capitalize(source);
+  }
   if(l.type==='passive') return capitalize(l.id);
   if(l.type==='move') return niceName(l.id);
   if(l.type==='tech') return techName(l.id);
@@ -239,7 +242,11 @@ function pulse(el){
 }
 
 function focusSearch(q){
-  const input = document.querySelector('#q');
+  if(typeof window.focusSearch === 'function'){
+    window.focusSearch(q);
+    return;
+  }
+  const input = document.getElementById('palSearch') || document.getElementById('itemSearch');
   if(input){
     input.value = q;
     input.dispatchEvent(new Event('input', {bubbles:true}));


### PR DESCRIPTION
## Summary
- ensure route guide focus requests reveal optional steps instead of failing silently
- harden route link chips by escaping dataset payloads and falling back to ids or names for pal labels
- align the standalone route module with the main search inputs when focusing from link shortcuts

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d99e23456c8331a34fd582cb444edd