### PR TITLE
Improve search navigation UX and audio handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4859,7 +4859,10 @@
       if (!sound || typeof sound.play !== 'function') return;
       try {
         sound.currentTime = 0;
-        sound.play();
+        const result = sound.play();
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => console.debug('Sound error', err));
+        }
       } catch (err) {
         // Audio play can fail if files are missing or browser policy blocks it
         console.debug('Sound error', err);
@@ -5040,6 +5043,7 @@
           btn.removeAttribute('aria-current');
         }
       });
+      collapseNavIfMobile();
     }
     // Modal controls
     const modal = document.getElementById('modal');
@@ -7573,7 +7577,7 @@
         showPalDetail(byName);
         return;
       }
-      focusSearch(identifier);
+      focusSearch(identifier, { target: 'pals' });
     };
     // Build items page
     function buildItemPage() {
@@ -9343,14 +9347,14 @@
         if(window.viewPal){
           window.viewPal(link.slug || link.id);
         } else {
-          focusSearch(link.slug || link.id);
+          focusSearch(link.slug || link.id, { target: 'pals' });
         }
       } else if(link.type === 'item'){
         const itemKey = link.id || link.slug;
         if(itemKey && ITEMS[itemKey]){
           openItemDetail(itemKey);
         } else {
-          focusSearch(itemKey);
+          focusSearch(itemKey, { target: 'items' });
         }
       } else if(link.type === 'tech'){
         showTechDetail(link.id);
@@ -9449,11 +9453,30 @@
       setTimeout(() => el.classList.remove('pulse'), 1500);
     }
 
-    function focusSearch(term){
-      const input = document.getElementById('palSearch') || document.getElementById('itemSearch');
-      if(input){
-        input.value = term;
+    function focusSearch(term, { target } = {}) {
+      const desiredTarget = target === 'items' ? 'items' : 'pals';
+      const inputId = desiredTarget === 'items' ? 'itemSearch' : 'palSearch';
+      const input = document.getElementById(inputId);
+      if (!input) return;
+      switchPage(desiredTarget);
+      const applySearch = () => {
+        if (typeof input.focus === 'function') {
+          try {
+            input.focus({ preventScroll: true });
+          } catch (err) {
+            input.focus();
+          }
+        }
+        if (typeof input.select === 'function') {
+          input.select();
+        }
+        input.value = term == null ? '' : String(term);
         input.dispatchEvent(new Event('input', { bubbles: true }));
+      };
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(applySearch);
+      } else {
+        applySearch();
       }
     }
 

--- a/js/pages/glossary.js
+++ b/js/pages/glossary.js
@@ -40,7 +40,7 @@ export function renderGlossary(node){
       } else if(typeof window.showGlossaryDetail === 'function'){
         window.showGlossaryDetail(traitId);
       } else if(typeof window.focusSearch === 'function'){
-        window.focusSearch(traitName);
+        window.focusSearch(traitName, { target: 'pals' });
       }
     });
   });

--- a/js/pages/route.js
+++ b/js/pages/route.js
@@ -217,16 +217,16 @@ function navigateLink(l){
   if(!l) return;
   if(l.type==='pal'){
     if(window.viewPal) window.viewPal(l.slug || l.id);
-    else focusSearch(l.slug || l.id);
+    else focusSearch(l.slug || l.id, { target: 'pals' });
   } else if(l.type==='tech'){
     if(window.showTechDetail) window.showTechDetail(l.id);
     else window.open(`https://palworld.gg/items?search=${encodeURIComponent(niceName(l.id))}`,'_blank','noopener');
   } else if(l.type==='passive'){
     if(window.showTraitDetail) window.showTraitDetail(capitalize(l.id));
-    else focusSearch(l.id);
+    else focusSearch(l.id, { target: 'pals' });
   } else if(l.type==='move'){
     if(window.showSkillDetail) window.showSkillDetail(l.id);
-    else focusSearch(niceName(l.id));
+    else focusSearch(niceName(l.id), { target: 'pals' });
   } else if(l.type==='glossary'){
     if(window.showGlossaryDetail) window.showGlossaryDetail(l.id);
     else window.open(`https://palworld.gg/items?search=${encodeURIComponent(niceName(l.id))}`,'_blank','noopener');
@@ -241,12 +241,13 @@ function pulse(el){
   setTimeout(()=>el.classList.remove('pulse'), 1500);
 }
 
-function focusSearch(q){
+function focusSearch(q, options){
   if(typeof window.focusSearch === 'function'){
-    window.focusSearch(q);
+    window.focusSearch(q, options);
     return;
   }
-  const input = document.getElementById('palSearch') || document.getElementById('itemSearch');
+  const target = options?.target === 'items' ? 'items' : 'pals';
+  const input = document.getElementById(target === 'items' ? 'itemSearch' : 'palSearch');
   if(input){
     input.value = q;
     input.dispatchEvent(new Event('input', {bubbles:true}));


### PR DESCRIPTION
## Summary
- guard modal click/open/close sounds so browsers that block autoplay no longer throw console errors
- switch programmatic navigation helpers to open the correct page, focus the search box, and pre-fill queries for pals or items
- collapse the mobile navigation drawer after page changes and update glossary/route fallbacks to use the refined search helper

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9d99621108331be7f49f13c7695aa