### PR TITLE
Implement full technology tree rendering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,35 @@
 .chip{display:inline-flex;align-items:center;justify-content:center;padding:8px 14px;border-radius:999px;background:rgba(119,141,169,0.18);color:var(--text,#f0f4f8);font-size:0.9rem;font-weight:600;text-decoration:none;border:1px solid rgba(119,141,169,0.4);min-height:40px}
 .chip.link{cursor:pointer;background:rgba(119,141,169,0.24)}
 .chip.link:hover{background:rgba(119,141,169,0.4)}
+.tech-tiers{display:flex;flex-direction:column;gap:32px;margin-top:24px}
+.tech-tier{border:1px solid rgba(255,255,255,0.08);border-radius:24px;background:rgba(8,16,32,0.85);box-shadow:0 24px 48px rgba(4,1
+0,26,0.45);padding:24px}
+.tech-tier__header{display:flex;align-items:center;gap:12px;margin-bottom:18px}
+.tech-tier__label{font-size:.75rem;letter-spacing:.12em;text-transform:uppercase;color:rgba(224,225,221,0.7)}
+.tech-tier__header h3{margin:0;font-size:1.8rem;color:var(--text,#f0f4f8)}
+.tech-tier__columns{display:grid;gap:24px}
+@media (min-width:768px){.tech-tier__columns{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.tech-column h4{margin:0 0 12px;font-size:1.1rem;color:rgba(224,225,221,0.85)}
+.tech-empty{margin:0;font-style:italic;color:rgba(224,225,221,0.6)}
+.tech-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+.tech-card{display:flex;gap:16px;background:rgba(12,24,44,0.88);border:1px solid rgba(255,255,255,0.08);border-radius:18px;pad
+ding:16px;box-shadow:0 16px 36px rgba(0,0,0,0.4)}
+.tech-image{flex:0 0 72px;height:72px;border-radius:16px;background:rgba(0,0,0,0.3);display:flex;align-items:center;justify-con
+tent:center;overflow:hidden}
+.tech-image img{width:100%;height:100%;object-fit:contain}
+.tech-image--placeholder{font-size:1.8rem;color:rgba(224,225,221,0.75)}
+.tech-body{display:flex;flex-direction:column;gap:8px}
+.tech-name{margin:0;font-size:1.05rem}
+.tech-badges{display:flex;flex-wrap:wrap;gap:8px}
+.tech-badge{display:inline-flex;align-items:center;justify-content:center;padding:4px 10px;border-radius:999px;font-size:.75rem
+;letter-spacing:.08em;text-transform:uppercase;background:rgba(119,141,169,0.22);color:rgba(224,225,221,0.85);border:1px solid r
+gba(119,141,169,0.45)}
+.tech-cost{margin:0;font-weight:600;color:var(--accent,#778da9)}
+.tech-description{margin:0;color:rgba(224,225,221,0.8);line-height:1.4}
+.tech-materials{list-style:none;margin:0;padding:0;display:grid;gap:6px;font-size:.9rem}
+.tech-materials li{display:flex;justify-content:space-between;gap:12px;padding:6px 10px;border-radius:10px;background:rgba(0,0,0,
+0.25);border:1px solid rgba(255,255,255,0.08)}
+.tech-materials span:last-child{font-variant-numeric:tabular-nums;font-weight:600;color:rgba(224,225,221,0.95)}
 .step-group{margin:12px 0}
 .step-list{display:grid;gap:10px;margin:12px 0}
 .step{display:flex;align-items:flex-start;gap:12px;padding:10px;border:1px solid #22314A;border-radius:12px;background:#101828}

--- a/js/pages/tech.js
+++ b/js/pages/tech.js
@@ -1,8 +1,155 @@
-import tech from '../../data/tech.sample.json' assert { type:'json' };
-export function renderTech(node){
-  node.innerHTML = `<h2>Technology</h2>` + tech.map(t=>`
-    <div class="card" id="tech-${t.id}">
-      <strong>Lv ${t.level}</strong> — ${t.name}
+import dataset from '../../data/palworld_complete_data_final.json' assert { type: 'json' };
+
+const techLevels = Array.isArray(dataset?.tech)
+  ? dataset.tech
+      .filter(level => level && typeof level.level === 'number')
+      .map(level => ({
+        level: level.level,
+        items: Array.isArray(level.items) ? level.items.filter(Boolean) : []
+      }))
+      .sort((a, b) => a.level - b.level)
+  : [];
+
+const htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+};
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, character => htmlEscapes[character] || character);
+}
+
+function normaliseMaterials(materials) {
+  if (!materials || typeof materials !== 'object') return [];
+  return Object.entries(materials)
+    .filter(([, qty]) => qty !== null && qty !== undefined)
+    .map(([name, qty]) => ({
+      name: String(name),
+      quantity: Number(qty)
+    }))
+    .filter(entry => entry.name.trim().length && Number.isFinite(entry.quantity) && entry.quantity >= 0);
+}
+
+function renderMaterials(materials) {
+  const entries = normaliseMaterials(materials);
+  if (!entries.length) return '';
+  const rows = entries
+    .map(entry => `<li><span>${escapeHtml(entry.name)}</span><span>${entry.quantity}</span></li>`)
+    .join('');
+  return `<ul class="tech-materials" aria-label="Required materials">${rows}</ul>`;
+}
+
+function renderBadges(item) {
+  const badges = [];
+  if (item.category) badges.push(item.category);
+  if (item.group && item.group !== item.category) badges.push(item.group);
+  if (item.branch && item.branch !== 'Technology') badges.push(item.branch);
+  if (!badges.length) return '';
+  return `
+    <div class="tech-badges">
+      ${badges
+        .map(label => `<span class="tech-badge">${escapeHtml(label)}</span>`)
+        .join('')}
     </div>
-  `).join('');
+  `;
+}
+
+function formatCost(item) {
+  const points = typeof item.techPoints === 'number' ? item.techPoints : null;
+  if (points === null) return '';
+  if (points === 0) {
+    return `<p class="tech-cost">Free unlock</p>`;
+  }
+  const label = item.isAncient ? 'Ancient Points' : 'Tech Points';
+  return `<p class="tech-cost">${escapeHtml(points)} ${label}</p>`;
+}
+
+function renderImage(item) {
+  if (!item.image) {
+    return '<div class="tech-image tech-image--placeholder" aria-hidden="true">⚙️</div>';
+  }
+  const alt = `${item.name} illustration`;
+  return `
+    <div class="tech-image">
+      <img src="${escapeHtml(item.image)}" alt="${escapeHtml(alt)}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+    </div>
+  `;
+}
+
+function renderDescription(item) {
+  const description = item.description
+    ? escapeHtml(item.description)
+    : `Unlocks the ${escapeHtml(item.name)} blueprint.`;
+  return `<p class="tech-description">${description}</p>`;
+}
+
+function renderItemCard(item) {
+  if (!item || !item.name) return '';
+  const techId = item.id || item.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return `
+    <article class="tech-card" id="tech-${escapeHtml(techId)}">
+      ${renderImage(item)}
+      <div class="tech-body">
+        <h5 class="tech-name">${escapeHtml(item.name)}</h5>
+        ${renderBadges(item)}
+        ${formatCost(item)}
+        ${renderDescription(item)}
+        ${renderMaterials(item.materials)}
+      </div>
+    </article>
+  `;
+}
+
+function renderColumn(title, items) {
+  const safeTitle = escapeHtml(title);
+  if (!items.length) {
+    return `
+      <div class="tech-column">
+        <h4>${safeTitle}</h4>
+        <p class="tech-empty">No unlocks at this tier.</p>
+      </div>
+    `;
+  }
+  return `
+    <div class="tech-column">
+      <h4>${safeTitle}</h4>
+      <div class="tech-grid">
+        ${items.map(renderItemCard).join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderLevel(level) {
+  const standard = level.items.filter(item => !item?.isAncient);
+  const ancient = level.items.filter(item => item?.isAncient);
+  return `
+    <section class="tech-tier" aria-labelledby="tech-tier-${level.level}">
+      <header class="tech-tier__header">
+        <span class="tech-tier__label">Level</span>
+        <h3 id="tech-tier-${level.level}">${escapeHtml(level.level)}</h3>
+      </header>
+      <div class="tech-tier__columns">
+        ${renderColumn('Technology', standard)}
+        ${renderColumn('Ancient Technology', ancient)}
+      </div>
+    </section>
+  `;
+}
+
+export function renderTech(node) {
+  if (!node) return;
+  if (!techLevels.length) {
+    node.innerHTML = '<p class="tech-empty">Technology data is unavailable.</p>';
+    return;
+  }
+  node.innerHTML = `
+    <h2>Technology Tree</h2>
+    <div class="tech-tiers">
+      ${techLevels.map(renderLevel).join('')}
+    </div>
+  `;
 }


### PR DESCRIPTION
## Summary
- replace the placeholder technology view with a dataset-driven tree that shows every unlock and its details
- add presentation styles for the new technology tier and card layout so the full tree remains readable

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68da01972cc483318292656d3a90913e