### PR TITLE
Add partner skill glossary and data pipeline

### DIFF
--- a/data/partner_skills.json
+++ b/data/partner_skills.json
@@ -1,0 +1,1488 @@
+[
+  {
+    "id": "fluffy-shield",
+    "number": 1,
+    "name": "Fluffy Shield",
+    "pals": [
+      "Lamball"
+    ],
+    "type": "Combat / Farming",
+    "categories": [
+      "Combat",
+      "Farming"
+    ],
+    "description": "When activated, equips to the player and becomes a shield. Drops Wool when assigned to Ranch."
+  },
+  {
+    "id": "cat-helper",
+    "number": 2,
+    "name": "Cat Helper",
+    "pals": [
+      "Cattiva"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in a team, Cattiva helps carry supplies, increasing the player's max carrying capacity."
+  },
+  {
+    "id": "egg-layer",
+    "number": 3,
+    "name": "Egg Layer",
+    "pals": [
+      "Chikipi"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes lays Eggs when assigned to Ranch."
+  },
+  {
+    "id": "lifmunk-recoil",
+    "number": 4,
+    "name": "Lifmunk Recoil",
+    "pals": [
+      "Lifmunk"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, leaps onto the player's head and uses a submachine gun to follow up player attacks."
+  },
+  {
+    "id": "huggy-fire",
+    "number": 5,
+    "name": "Huggy Fire",
+    "pals": [
+      "Foxparks"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, equips the player and transforms into a flamethrower."
+  },
+  {
+    "id": "surfing-slam",
+    "number": 6,
+    "name": "Surfing Slam",
+    "pals": [
+      "Fuack"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, Fuack body surfs toward an enemy and slams into them."
+  },
+  {
+    "id": "static-electricity",
+    "number": 7,
+    "name": "Static Electricity",
+    "pals": [
+      "Sparkit"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, increases the attack power of ElectricPals."
+  },
+  {
+    "id": "cheery-rifle",
+    "number": 8,
+    "name": "Cheery Rifle",
+    "pals": [
+      "Tanzee"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, Tanzee will mercilessly fire an assault rifle at nearby enemies."
+  },
+  {
+    "id": "tiny-spark",
+    "number": 9,
+    "name": "Tiny Spark",
+    "pals": [
+      "Rooby"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, increases attack power of FirePals."
+  },
+  {
+    "id": "pengullet-cannon",
+    "number": 10,
+    "name": "Pengullet Cannon",
+    "pals": [
+      "Pengullet"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, the player equips a Rocket Launcher and fires Pengullet as ammunition. Pengullet explodes on contact and is incapacitated."
+  },
+  {
+    "id": "brave-sailor",
+    "number": 11,
+    "name": "Brave Sailor",
+    "pals": [
+      "Penking"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, FirePals drop more items when defeated."
+  },
+  {
+    "id": "biribiri-bombs",
+    "number": 12,
+    "name": "Biribiri Bombs",
+    "pals": [
+      "Jolthog"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, equips Jolthog in hand, to be thrown at enemies and cause a lightning explosion upon impact."
+  },
+  {
+    "id": "logging-assistance",
+    "number": 13,
+    "name": "Logging Assistance",
+    "pals": [
+      "Gumoss"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, improves efficiency of cutting trees."
+  },
+  {
+    "id": "dig-here",
+    "number": 14,
+    "name": "Dig Here!",
+    "pals": [
+      "Vixy"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes digs up items from the ground when assigned to Ranch"
+  },
+  {
+    "id": "dark-knowledge",
+    "number": 15,
+    "name": "Dark Knowledge",
+    "pals": [
+      "Hoocrates"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, increase attack power of DarkPals."
+  },
+  {
+    "id": "soothing-shower",
+    "number": 16,
+    "name": "Soothing Shower",
+    "pals": [
+      "Teafant"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, spouts mysterious water that soothes wounds and restores the playerHP."
+  },
+  {
+    "id": "caffeine-inoculation",
+    "number": 17,
+    "name": "Caffeine Inoculation",
+    "pals": [
+      "Depresso"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, Depresso chugs a bunch of energy drinks, drastically increasing its movement speed for a certain time."
+  },
+  {
+    "id": "fluffy-wool",
+    "number": 18,
+    "name": "Fluffy Wool",
+    "pals": [
+      "Cremis"
+    ],
+    "type": "Combat / Farming",
+    "categories": [
+      "Combat",
+      "Farming"
+    ],
+    "description": "While in team, increases attack power of NeutralPals. Sometimes drops Wool when assigned to Ranch."
+  },
+  {
+    "id": "dream-chaser",
+    "number": 19,
+    "name": "Dream Chaser",
+    "pals": [
+      "Daedream"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "While in team, appears near the player. Follows up player attacks with magic bullets."
+  },
+  {
+    "id": "hard-head",
+    "number": 20,
+    "name": "Hard Head",
+    "pals": [
+      "Rushoar"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Increases efficiency of destroying boulders while mounted."
+  },
+  {
+    "id": "kuudere",
+    "number": 21,
+    "name": "Kuudere",
+    "pals": [
+      "Nox"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When fighting together, applies Dark damage to the player's attacks."
+  },
+  {
+    "id": "ore-detector",
+    "number": 22,
+    "name": "Ore Detector",
+    "pals": [
+      "Fuddler"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, generates subtle vibrations to detect nearby ore."
+  },
+  {
+    "id": "fried-squid",
+    "number": 23,
+    "name": "Fried Squid",
+    "pals": [
+      "Killamari"
+    ],
+    "type": "Mount (Glider)",
+    "categories": [
+      "Mount (Glider)"
+    ],
+    "description": "While in team, can be summoned and used instead of a glider. Can float for long periods of time while gliding."
+  },
+  {
+    "id": "gold-digger",
+    "number": 24,
+    "name": "Gold Digger",
+    "pals": [
+      "Mau"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes digs up Gold Coin when assigned to a Ranch."
+  },
+  {
+    "id": "zephyr-glider",
+    "number": 25,
+    "name": "Zephyr Glider",
+    "pals": [
+      "Celaray"
+    ],
+    "type": "Mount (Glider)",
+    "categories": [
+      "Mount (Glider)"
+    ],
+    "description": "While in team, can be summoned and used instead of a glider. Allows you to move quickly for long periods of time while gliding with this Pal."
+  },
+  {
+    "id": "direhowl-rider",
+    "number": 26,
+    "name": "Direhowl Rider",
+    "pals": [
+      "Direhowl"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Moves slightly faster than most mounts"
+  },
+  {
+    "id": "eggbomb-launcher",
+    "number": 27,
+    "name": "Eggbomb Launcher",
+    "pals": [
+      "Tocotoco"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, equips to the player and transforms into an egg launcher."
+  },
+  {
+    "id": "helper-bunny",
+    "number": 28,
+    "name": "Helper Bunny",
+    "pals": [
+      "Flopie"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, appears near the player. Automatically picks up nearby items."
+  },
+  {
+    "id": "milk-maker",
+    "number": 29,
+    "name": "Milk Maker",
+    "pals": [
+      "Mozzarina"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes produces Milk when assigned to a Ranch."
+  },
+  {
+    "id": "princess-gaze",
+    "number": 30,
+    "name": "Princess Gaze",
+    "pals": [
+      "Bristla"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, increases the power of GrassPals."
+  },
+  {
+    "id": "angry-shark",
+    "number": 31,
+    "name": "Angry Shark",
+    "pals": [
+      "Gobfin"
+    ],
+    "type": "Combat / Utility",
+    "categories": [
+      "Combat",
+      "Utility"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Aqua Gun. While in team, increases player's attack power."
+  },
+  {
+    "id": "flying-trapeze",
+    "number": 32,
+    "name": "Flying Trapeze",
+    "pals": [
+      "Hangyu"
+    ],
+    "type": "Mount (Glider)",
+    "categories": [
+      "Mount (Glider)"
+    ],
+    "description": "While in team, can be summoned and used instead of a glider. Carries the player high up while gliding."
+  },
+  {
+    "id": "grenadier-panda",
+    "number": 33,
+    "name": "Grenadier Panda",
+    "pals": [
+      "Mossanda"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can rapidly fire a grenade launcher while mounted."
+  },
+  {
+    "id": "candy-pop",
+    "number": 34,
+    "name": "Candy Pop",
+    "pals": [
+      "Woolipop"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes drop Cotton Candy when assigned to ranch."
+  },
+  {
+    "id": "berry-picker",
+    "number": 35,
+    "name": "Berry Picker",
+    "pals": [
+      "Caprity"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes drops Red Berries from its back when assigned to Ranch."
+  },
+  {
+    "id": "pecapaca-wool",
+    "number": 36,
+    "name": "Pecapaca Wool",
+    "pals": [
+      "Melpaca"
+    ],
+    "type": "Mount / Farming",
+    "categories": [
+      "Farming",
+      "Mount"
+    ],
+    "description": "Can be Ridden. Sometimes drop Wool when assigned to Ranch."
+  },
+  {
+    "id": "guardian-of-the-forest",
+    "number": 37,
+    "name": "Guardian of the Forest",
+    "pals": [
+      "Eikthyrdeer"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can perform a double jump while mounted. Increases efficiency of cutting trees."
+  },
+  {
+    "id": "travel-companion",
+    "number": 38,
+    "name": "Travel Companion",
+    "pals": [
+      "Nitewing"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount."
+  },
+  {
+    "id": "skilled-fingers",
+    "number": 39,
+    "name": "Skilled Fingers",
+    "pals": [
+      "Ribbuny"
+    ],
+    "type": "Combat / Utility",
+    "categories": [
+      "Combat",
+      "Utility"
+    ],
+    "description": "While in team, increases attack power of Neutral Pals. While at base, increases work efficiency if working at Weapon Workbench."
+  },
+  {
+    "id": "flameclaw-hunter",
+    "number": 40,
+    "name": "Flameclaw Hunter",
+    "pals": [
+      "Incineram"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Hellfire Claw."
+  },
+  {
+    "id": "mysterious-scales",
+    "number": 41,
+    "name": "Mysterious Scales",
+    "pals": [
+      "Cinnamoth"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with Poison Fog."
+  },
+  {
+    "id": "warm-body",
+    "number": 42,
+    "name": "Warm Body",
+    "pals": [
+      "Arsox"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Keeps the rider warm in cold environments."
+  },
+  {
+    "id": "soil-improver",
+    "number": 43,
+    "name": "Soil Improver",
+    "pals": [
+      "Dumud"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "While in team, increases attack power of GroundPals."
+  },
+  {
+    "id": "telepeck",
+    "number": 44,
+    "name": "Telepeck",
+    "pals": [
+      "Cawgnito"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Phantom Peck."
+  },
+  {
+    "id": "sixth-sense",
+    "number": 45,
+    "name": "Sixth Sense",
+    "pals": [
+      "Leezpunk"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, utilizes its sixth sense to detect nearby dungeons."
+  },
+  {
+    "id": "claws-glistening-in-the-dark",
+    "number": 46,
+    "name": "Claws Glistening in the Dark",
+    "pals": [
+      "Loupmoon"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Jumping Claw."
+  },
+  {
+    "id": "galeclaw-rider",
+    "number": 47,
+    "name": "Galeclaw Rider",
+    "pals": [
+      "Galeclaw"
+    ],
+    "type": "Mount (Glider)",
+    "categories": [
+      "Mount (Glider)"
+    ],
+    "description": "While in team, can be summoned and used instead of a Gliders. Allows you to fire a gun while gliding with this Pal."
+  },
+  {
+    "id": "hawk-eye",
+    "number": 48,
+    "name": "Hawk Eye",
+    "pals": [
+      "Robinquill"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, allows you to deal more damage to weak points."
+  },
+  {
+    "id": "full-power-gorilla-mode",
+    "number": 49,
+    "name": "Full-power Gorilla Mode",
+    "pals": [
+      "Gorirat"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, unleashes a primal fury that increases Gorirat's attack power."
+  },
+  {
+    "id": "worker-bee",
+    "number": 50,
+    "name": "Worker Bee",
+    "pals": [
+      "Beegarde"
+    ],
+    "type": "Utility / Farming",
+    "categories": [
+      "Farming",
+      "Utility"
+    ],
+    "description": "Sometimes drop Honey when assigned to Ranch. While in team, Elizabee's stats will be increased."
+  },
+  {
+    "id": "queen-bee-command",
+    "number": 51,
+    "name": "Queen Bee Command",
+    "pals": [
+      "Elizabee"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When fighting together, stats will increase the more Beegarde are in your team."
+  },
+  {
+    "id": "plump-body",
+    "number": 52,
+    "name": "Plump Body",
+    "pals": [
+      "Grintale"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Increases Neutral attacks while mounted."
+  },
+  {
+    "id": "fluffy",
+    "number": 53,
+    "name": "Fluffy",
+    "pals": [
+      "Swee"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, Sweepa's stats will be increased."
+  },
+  {
+    "id": "king-of-fluff",
+    "number": 54,
+    "name": "King of Fluff",
+    "pals": [
+      "Sweepa"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. When fighting together, stats will increase the more Swee are in your team."
+  },
+  {
+    "id": "wriggling-weasel",
+    "number": 55,
+    "name": "Wriggling Weasel",
+    "pals": [
+      "Chillet"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Applies Dragon damage to the player's attacks while mounted."
+  },
+  {
+    "id": "swift-deity",
+    "number": 56,
+    "name": "Swift Deity",
+    "pals": [
+      "Univolt"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Applies Electric damage to the player's attack while mounted."
+  },
+  {
+    "id": "aurora-guide",
+    "number": 57,
+    "name": "Aurora Guide",
+    "pals": [
+      "Foxcicle"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "While in a team, increases attack power of Ice pals."
+  },
+  {
+    "id": "red-hare",
+    "number": 58,
+    "name": "Red Hare",
+    "pals": [
+      "Pyrin"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Applies Fire damage to the player's attacks while mounted."
+  },
+  {
+    "id": "cool-body",
+    "number": 59,
+    "name": "Cool Body",
+    "pals": [
+      "Reindrix"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Keeps the rider cool in hot environments."
+  },
+  {
+    "id": "jumping-force",
+    "number": 60,
+    "name": "Jumping Force",
+    "pals": [
+      "Rayhound"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can double jump while mounted."
+  },
+  {
+    "id": "clear-mind",
+    "number": 61,
+    "name": "Clear Mind",
+    "pals": [
+      "Kitsun"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Unaffected by the cold or heat while riding this Pal."
+  },
+  {
+    "id": "lady-of-lightning",
+    "number": 62,
+    "name": "Lady of Lightning",
+    "pals": [
+      "Dazzi"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "While in team, appears near the player. Follows up player attacks with lightning bolts."
+  },
+  {
+    "id": "antigravity",
+    "number": 63,
+    "name": "Antigravity",
+    "pals": [
+      "Lunaris"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While in team, Lunaris manipulates gravity, increasing the player's max carrying capacity."
+  },
+  {
+    "id": "fragrant-dragon",
+    "number": 64,
+    "name": "Fragrant Dragon",
+    "pals": [
+      "Dinossom"
+    ],
+    "type": "Combat / Mount",
+    "categories": [
+      "Combat",
+      "Mount"
+    ],
+    "description": "Can be ridden. Enhances Grassattacks while mounted."
+  },
+  {
+    "id": "swift-swimmer",
+    "number": 65,
+    "name": "Swift Swimmer",
+    "pals": [
+      "Surfent"
+    ],
+    "type": "Mount (Swimmer)",
+    "categories": [
+      "Mount (Swimmer)"
+    ],
+    "description": "Can be ridden to travel on water. While mounted, prevents Stamina depletion while moving over water."
+  },
+  {
+    "id": "messenger-of-death",
+    "number": 66,
+    "name": "Messenger of Death",
+    "pals": [
+      "Maraith"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Applies Dark damage to the player's attacks while mounted."
+  },
+  {
+    "id": "drill-crusher",
+    "number": 67,
+    "name": "Drill Crusher",
+    "pals": [
+      "Digtoise"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "Performs Shell Spin, follows the player while spinning and mines ores efficiently."
+  },
+  {
+    "id": "ultrasonic-sensor",
+    "number": 68,
+    "name": "Ultrasonic Sensor",
+    "pals": [
+      "Tombat"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, uses ultrasonic waves to detect the presence of nearby Pals."
+  },
+  {
+    "id": "heart-drain",
+    "number": 69,
+    "name": "Heart Drain",
+    "pals": [
+      "Lovander"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, grants the player and Loveander the life steal effect which absorbs some of the received damage and restores Health."
+  },
+  {
+    "id": "magma-tears",
+    "number": 70,
+    "name": "Magma Tears",
+    "pals": [
+      "Flambelle"
+    ],
+    "type": "Farming",
+    "categories": [
+      "Farming"
+    ],
+    "description": "Sometimes produces Flame Organ when assigned to Ranch."
+  },
+  {
+    "id": "aerial-marauder",
+    "number": 71,
+    "name": "Aerial Marauder",
+    "pals": [
+      "Vanwyrm"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Increases damage player deals to enemy weak points while mounted."
+  },
+  {
+    "id": "brandish-blade",
+    "number": 72,
+    "name": "Brandish Blade",
+    "pals": [
+      "Bushi"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Iaigiri."
+  },
+  {
+    "id": "flash-blade",
+    "number": 72,
+    "name": "Flash Blade",
+    "pals": [
+      "Bushi Noct"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Iaigiri."
+  },
+  {
+    "id": "thunderous",
+    "number": 73,
+    "name": "Thunderous",
+    "pals": [
+      "Beakon"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Applies Electric damage to the player's attacks while mounted."
+  },
+  {
+    "id": "flame-wing",
+    "number": 74,
+    "name": "Flame Wing",
+    "pals": [
+      "Ragnahawk"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Applies Fire damage to the player's attacks while mounted."
+  },
+  {
+    "id": "grimoire-collector",
+    "number": 75,
+    "name": "Grimoire Collector",
+    "pals": [
+      "Katress"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When fighting together, Neutral Pals drop more items when defeated."
+  },
+  {
+    "id": "lord-fox",
+    "number": 76,
+    "name": "Lord Fox",
+    "pals": [
+      "Wixen"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When fighting together, applies Fire damage to the player's attacks."
+  },
+  {
+    "id": "grassland-speedster",
+    "number": 77,
+    "name": "Grassland Speedster",
+    "pals": [
+      "Verdash"
+    ],
+    "type": "Utility / Combat",
+    "categories": [
+      "Combat",
+      "Utility"
+    ],
+    "description": "When fighting together, increases player's movement speed and applies Grass damage to the player's attacks."
+  },
+  {
+    "id": "purification-of-gaia",
+    "number": 78,
+    "name": "Purification of Gaia",
+    "pals": [
+      "Vaelet"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, Ground Pals drop more items when defeated."
+  },
+  {
+    "id": "silk-maker",
+    "number": 79,
+    "name": "Silk Maker",
+    "pals": [
+      "Sibelyx"
+    ],
+    "type": "Combat / Farming",
+    "categories": [
+      "Combat",
+      "Farming"
+    ],
+    "description": "When activated, attacks targeted enemy with a powerful Blizzard Spike. Sometimes produces High Quality Cloth when assigned to Ranch."
+  },
+  {
+    "id": "amicable-holy-dragon",
+    "number": 80,
+    "name": "Amicable Holy Dragon",
+    "pals": [
+      "Elphidran"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as an aerial mount. While fighting together, DarkPals drop more items when defeated."
+  },
+  {
+    "id": "aqua-spout",
+    "number": 81,
+    "name": "Aqua Spout",
+    "pals": [
+      "Kelpsea"
+    ],
+    "type": "Utility / Farming",
+    "categories": [
+      "Farming",
+      "Utility"
+    ],
+    "description": "While in team, increases the attack power of WaterPals. Sometimes produces Pal Fluids when assigned to Ranch."
+  },
+  {
+    "id": "waterwing-dance",
+    "number": 82,
+    "name": "Waterwing Dance",
+    "pals": [
+      "Azurobe"
+    ],
+    "type": "Combat / Mount",
+    "categories": [
+      "Combat",
+      "Mount"
+    ],
+    "description": "Can be ridden to travel on water. Applies Water damage to the playerattacks while mounted."
+  },
+  {
+    "id": "dragon-hunter",
+    "number": 83,
+    "name": "Dragon Hunter",
+    "pals": [
+      "Cryolinx"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, DragonPals drop more items when defeated."
+  },
+  {
+    "id": "hellflame-lion",
+    "number": 84,
+    "name": "Hellflame Lion",
+    "pals": [
+      "Blazehowl"
+    ],
+    "type": "Mount / Utility",
+    "categories": [
+      "Mount",
+      "Utility"
+    ],
+    "description": "Can be ridden. While fighting together, GrassPals drop more items when defeated."
+  },
+  {
+    "id": "missile-turret",
+    "number": 85,
+    "name": "Missile Turret",
+    "pals": [
+      "Relaxaurus"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Allows the the player to use a missile turret."
+  },
+  {
+    "id": "overaffectionate",
+    "number": 86,
+    "name": "Overaffectionate",
+    "pals": [
+      "Broncherry"
+    ],
+    "type": "Mount / Utility",
+    "categories": [
+      "Mount",
+      "Utility"
+    ],
+    "description": "Can be ridden. While in team, Broncherry helps carry supplies, increasing the player's max carrying capacity."
+  },
+  {
+    "id": "blessing-of-the-flower-spirit",
+    "number": 87,
+    "name": "Blessing of the Flower Spirit",
+    "pals": [
+      "Petallia"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When activated, uses medicinal flowers to restore the player's Health."
+  },
+  {
+    "id": "ore-loving-beast",
+    "number": 88,
+    "name": "Ore-loving Beast",
+    "pals": [
+      "Reptyro"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Improves efficiency of mining ores while mounted."
+  },
+  {
+    "id": "king-of-muscles",
+    "number": 89,
+    "name": "King of Muscles",
+    "pals": [
+      "Kingpaca"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "While in a team, Kingpaca helps carry supplies, increasing the player's max carrying capacity."
+  },
+  {
+    "id": "gaia-crusher",
+    "number": 90,
+    "name": "Gaia Crusher",
+    "pals": [
+      "Mammorest"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Improves efficiency of cutting trees and mining ores while mounted."
+  },
+  {
+    "id": "guardian-of-the-snowy-mountain",
+    "number": 91,
+    "name": "Guardian of the Snowy Mountain",
+    "pals": [
+      "Wumpo"
+    ],
+    "type": "Mount / Utility",
+    "categories": [
+      "Mount",
+      "Utility"
+    ],
+    "description": "Can be ridden. While in team, Wumpo helps carry supplies, increasing the player's max carrying capacity."
+  },
+  {
+    "id": "hard-armor",
+    "number": 92,
+    "name": "Hard Armor",
+    "pals": [
+      "Warsect"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When fighting together, increases player's defense and Fire resistance."
+  },
+  {
+    "id": "wind-and-clouds",
+    "number": 93,
+    "name": "Wind and Clouds",
+    "pals": [
+      "Fenglope"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can double jump while mounted."
+  },
+  {
+    "id": "life-steal",
+    "number": 94,
+    "name": "Life Steal",
+    "pals": [
+      "Felbat"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "While fighting together, grants the player and Felbat the life steal effect which absorbs some of the received damage and restores Health."
+  },
+  {
+    "id": "sky-dragons-affection",
+    "number": 95,
+    "name": "Sky Dragon's Affection",
+    "pals": [
+      "Quivern"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Enhances Dragonattacks while mounted."
+  },
+  {
+    "id": "grass-dragons-affection",
+    "number": 95,
+    "name": "Grass Dragon's Affection",
+    "pals": [
+      "Quivern Botan"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Enhances Grassattacks while mounted."
+  },
+  {
+    "id": "magma-kaiser",
+    "number": 96,
+    "name": "Magma Kaiser",
+    "pals": [
+      "Blazamut"
+    ],
+    "type": "Mount (Ridden)",
+    "categories": [
+      "Mount (Ridden)"
+    ],
+    "description": "Can be ridden. Enhances Fire attacks while mounted."
+  },
+  {
+    "id": "wings-of-death",
+    "number": 97,
+    "name": "Wings of Death",
+    "pals": [
+      "Helzephyr"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Applies Dark damage to the player's attacks while mounted."
+  },
+  {
+    "id": "black-ankylosaur",
+    "number": 98,
+    "name": "Black Ankylosaur",
+    "pals": [
+      "Astegon"
+    ],
+    "type": "Utility / Mount (Flying)",
+    "categories": [
+      "Mount (Flying)",
+      "Utility"
+    ],
+    "description": "Can be ridden as a flying mount. Increases damage dealt to ore while mounted."
+  },
+  {
+    "id": "steel-scorpion",
+    "number": 99,
+    "name": "Steel Scorpion",
+    "pals": [
+      "Menasting"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "When fighting together, increases the player's defense and ElectricPals drop more items when defeated."
+  },
+  {
+    "id": "guardian-of-the-desert",
+    "number": 100,
+    "name": "Guardian of the Desert",
+    "pals": [
+      "Anubis"
+    ],
+    "type": "Combat",
+    "categories": [
+      "Combat"
+    ],
+    "description": "When fighting together, applies Ground damage to the player's attacks. Sometimes dodges attacks with a high speed sidestep in battle."
+  },
+  {
+    "id": "stormbringer-sea-dragon",
+    "number": 101,
+    "name": "Stormbringer Sea Dragon",
+    "pals": [
+      "Jormuntide"
+    ],
+    "type": "Mount (Swimmer)",
+    "categories": [
+      "Mount (Swimmer)"
+    ],
+    "description": "Can be ridden to travel on water. While mounted, prevents stamina depletion while moving over water."
+  },
+  {
+    "id": "wings-of-flame",
+    "number": 102,
+    "name": "Wings of Flame",
+    "pals": [
+      "Suzaku"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Enhances Fireattacks while mounted."
+  },
+  {
+    "id": "yellow-tank",
+    "number": 103,
+    "name": "Yellow Tank",
+    "pals": [
+      "Grizzbolt"
+    ],
+    "type": "Combat / Mount",
+    "categories": [
+      "Combat",
+      "Mount"
+    ],
+    "description": "Can be ridden. Can rapidly fire a minigun while mounted."
+  },
+  {
+    "id": "harvest-goddess",
+    "number": 104,
+    "name": "Harvest Goddess",
+    "pals": [
+      "Lyleen"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "When activated, the queen's soothing graces greatly restore the player's health."
+  },
+  {
+    "id": "scorching-predator",
+    "number": 105,
+    "name": "Scorching Predator",
+    "pals": [
+      "Faleris"
+    ],
+    "type": "Mount (Flying) / Utility",
+    "categories": [
+      "Mount (Flying)",
+      "Utility"
+    ],
+    "description": "Can be ridden as an aerial mount. While fighting together, Ice Pals drop more items when defeated."
+  },
+  {
+    "id": "ferocious-thunder-dragon",
+    "number": 106,
+    "name": "Ferocious Thunder Dragon",
+    "pals": [
+      "Orserk"
+    ],
+    "type": "Utility",
+    "categories": [
+      "Utility"
+    ],
+    "description": "While fighting together, Water Pals drop more items when defeated."
+  },
+  {
+    "id": "modified-dna",
+    "number": 107,
+    "name": "Modified DNA",
+    "pals": [
+      "Shadowbeak"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden. Enhances Dark attacks while mounted."
+  },
+  {
+    "id": "holy-knight-of-the-firmament",
+    "number": 108,
+    "name": "Holy Knight of the Firmament",
+    "pals": [
+      "Paladius"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can triple jump while mounted."
+  },
+  {
+    "id": "dark-knight-of-the-abyss",
+    "number": 109,
+    "name": "Dark Knight of the Abyss",
+    "pals": [
+      "Necromus"
+    ],
+    "type": "Mount",
+    "categories": [
+      "Mount"
+    ],
+    "description": "Can be ridden. Can double jump while mounted."
+  },
+  {
+    "id": "ice-steed",
+    "number": 110,
+    "name": "Ice Steed",
+    "pals": [
+      "Frostallion"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Changes the player's attack type to Ice, enhances Iceattacks while mounted."
+  },
+  {
+    "id": "aerial-missile",
+    "number": 111,
+    "name": "Aerial Missile",
+    "pals": [
+      "Jetragon"
+    ],
+    "type": "Mount (Flying)",
+    "categories": [
+      "Mount (Flying)"
+    ],
+    "description": "Can be ridden as a flying mount. Can rapidly fire a missile launcher while mounted."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -496,6 +496,173 @@
       letter-spacing: 0.04em;
       text-transform: uppercase;
     }
+    .glossary-callout ul {
+      margin: 8px 0 0;
+      padding-left: 20px;
+      color: rgba(224, 225, 221, 0.78);
+      line-height: 1.45;
+    }
+    .glossary-callout li {
+      margin-bottom: 4px;
+    }
+    .partner-filter-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 0 0 16px;
+    }
+    .partner-filter {
+      border-radius: 999px;
+      border: 1px solid rgba(119, 141, 169, 0.32);
+      background: rgba(12, 26, 42, 0.65);
+      color: var(--text);
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 7px 16px;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+    .partner-filter:hover,
+    .partner-filter:focus-visible {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+      transform: translateY(-1px);
+    }
+    .partner-filter[aria-pressed="true"] {
+      background: linear-gradient(135deg, rgba(35, 68, 107, 0.78), rgba(57, 102, 147, 0.72));
+      border-color: var(--accent);
+      box-shadow: 0 10px 24px rgba(7, 19, 38, 0.5);
+    }
+    .partner-skill-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+    .partner-skill-card {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      border: 1px solid rgba(119, 141, 169, 0.26);
+      border-radius: 18px;
+      padding: 20px;
+      background: linear-gradient(165deg, rgba(14, 28, 44, 0.92), rgba(26, 52, 78, 0.78));
+      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.38);
+      transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    }
+    .partner-skill-card:hover,
+    .partner-skill-card:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 40px rgba(0, 0, 0, 0.42);
+      transform: translateY(-2px);
+      outline: none;
+    }
+    .partner-skill-card__header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .partner-skill-card__name {
+      font-size: 1.15rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      flex: 1 1 auto;
+    }
+    .partner-skill-card__number {
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      background: rgba(119, 141, 169, 0.2);
+      border-radius: 999px;
+      padding: 4px 10px;
+      color: rgba(224, 225, 221, 0.75);
+      flex: 0 0 auto;
+    }
+    .partner-skill-card__tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .partner-skill-card__tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      border-radius: 999px;
+      padding: 4px 10px;
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(119, 141, 169, 0.22);
+      color: rgba(224, 225, 221, 0.86);
+    }
+    .partner-skill-card__tag--mount {
+      background: rgba(129, 199, 245, 0.22);
+      color: rgba(224, 242, 255, 0.9);
+    }
+    .partner-skill-card__tag--damage {
+      background: rgba(255, 138, 101, 0.22);
+      color: rgba(255, 214, 186, 0.92);
+    }
+    .partner-skill-card__tag--drops {
+      background: rgba(144, 238, 144, 0.22);
+      color: rgba(226, 255, 226, 0.88);
+    }
+    .partner-skill-card__description {
+      font-size: 0.92rem;
+      line-height: 1.55;
+      color: rgba(224, 225, 221, 0.88);
+    }
+    .partner-skill-card__pals {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: auto;
+    }
+    .partner-skill-card__pal {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(119, 141, 169, 0.32);
+      background: rgba(12, 24, 38, 0.7);
+      color: inherit;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+    }
+    .partner-skill-card__pal:hover,
+    .partner-skill-card__pal:focus-visible {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.38);
+      transform: translateY(-1px);
+    }
+    .partner-skill-card__pal[aria-disabled="true"] {
+      cursor: default;
+      opacity: 0.7;
+      border-style: dashed;
+    }
+    .partner-skill-card__pal-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      overflow: hidden;
+      background: rgba(119, 141, 169, 0.25);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+    }
+    .partner-skill-card__pal-avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
     .work-tier-legend {
       display: flex;
       flex-wrap: wrap;
@@ -3939,6 +4106,7 @@
     let SKILL_DETAILS = {};
     let PASSIVE_DETAILS = {};
     let ITEM_DETAILS = {};
+    let PARTNER_SKILLS = [];
     // Map of items to pals that drop them.  Populated after data load.
     let DROPS_MAP = {};
     // Map pal names to IDs for quick lookup when clicking breeding
@@ -5003,6 +5171,7 @@
     const ITEM_DETAILS_SOURCES = ['data/item_details.json'];
     const ITEM_DETAILS_FALLBACK_SCRIPT = 'data/item_details_fallback.js';
     const ITEM_DETAILS_GLOBAL = '__PALMATE_ITEM_DETAILS__';
+    const PARTNER_SKILL_SOURCES = ['data/partner_skills.json'];
     let embeddedDataPromise = null;
     let itemDetailsEmbeddedPromise = null;
 
@@ -5081,6 +5250,24 @@
       if (fallback) return fallback;
       console.warn('Item detail dataset unavailable. Item cards will use minimal info.');
       return {};
+    }
+    async function loadPartnerSkillDataset() {
+      for (const source of PARTNER_SKILL_SOURCES) {
+        try {
+          const response = await fetch(source);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          const payload = await response.json();
+          if (Array.isArray(payload)) {
+            return payload;
+          }
+          console.warn(`Partner skill payload from ${source} was not an array.`);
+        } catch (err) {
+          console.warn(`Failed to load partner skills from ${source}`, err);
+        }
+      }
+      return [];
     }
     // Type icon mapping (relative file paths)
     const iconMap = {
@@ -5475,6 +5662,32 @@
         ],
         url: `${PALWORLD_BASE_URL}/items?search=${encodeURIComponent('Skill Fruit')}`,
         note: 'Palmate keeps this move info handy so you can stay on track.'
+      },
+      'pal-essence-condenser': {
+        title: 'Pal Essence Condenser',
+        kid: [
+          'A special machine that eats extra pals to give your favorite buddy shiny stars.',
+          'Those stars make their partner skill stronger and can even help with base jobs.'
+        ],
+        grown: [
+          'Consumes 4, 16, 32 and 64 duplicates (116 total) to raise a partner skill to level 5.',
+          'Each star boosts base stats and the 4★ upgrade grants +1 to every work suitability.'
+        ],
+        url: `${PALWORLD_BASE_URL}/items?search=${encodeURIComponent('Pal Essence Condenser')}`,
+        note: 'Palmate keeps condensation tips nearby so you never lose the route context.'
+      },
+      'pal-condensation': {
+        title: 'Pal Condensation',
+        kid: [
+          'Feeding the condenser pals makes partner moves power up one star at a time.',
+          'Four stars also give that buddy better job levels back at base.'
+        ],
+        grown: [
+          'Every condenser star increases partner skill level by one (to Lv.5) while adding base stat boosts.',
+          'Damage-focused mounts scale hard with these ranks—watch for mount tags that boost player and pal damage.'
+        ],
+        url: `${PALWORLD_BASE_URL}/items?search=${encodeURIComponent('Pal Essence Condenser')}`,
+        note: 'Review condensation effects without leaving your tower or route notes.'
       }
     };
     // Palworld's in-game coordinates are not symmetrical on the X/Y axes.
@@ -7676,6 +7889,7 @@
         SKILL_DETAILS = payload.skillsDetails || {};
         PASSIVE_DETAILS = payload.passiveDetails || {};
         ITEM_DETAILS = await loadItemDetails();
+        PARTNER_SKILLS = await loadPartnerSkillDataset();
         // Build name‑to‑ID lookup map
         PAL_NAME_TO_ID = {};
         PAL_SLUG_TO_ID = {};
@@ -11080,6 +11294,308 @@
 
       workSection.appendChild(workGrid);
 
+      const partnerSkillsData = Array.isArray(PARTNER_SKILLS) ? PARTNER_SKILLS.slice() : [];
+      const partnerDescription = kidMode
+        ? 'Press the Partner Skill button to trigger these buddy powers.'
+        : 'Every ability you unlock with the Partner button, from mount bonuses to farming helpers.';
+      const partnerSection = createSection('glossary-partners', 'Partner Skills', partnerDescription);
+
+      const partnerSummary = document.createElement('div');
+      partnerSummary.className = 'glossary-callout';
+      const partnerCountLabel = kidMode
+        ? `Palmate now tracks ${partnerSkillsData.length} partner skills.`
+        : `${partnerSkillsData.length} partner skills catalogued across the full roster.`;
+      partnerSummary.innerHTML = kidMode
+        ? `<strong>Partner skill quick facts</strong><ul><li>${partnerCountLabel}—that’s even more than the 94 skills Palworld launched with.</li><li>Mount badges mark pals that boost you while you ride—look for the Damage Boost tag when you want your own attacks to hit harder.</li><li>Utility and farming pals are flagged so you can find harvest bonuses fast.</li></ul>`
+        : `<strong>Partner skill quick reference</strong><ul><li>${partnerCountLabel} (the roster has already grown past the ~94 launch abilities). Use the filters to zero in on combat, mount or production buffs.</li><li>The Damage Boost tag highlights mounts that amplify player or pal damage while ridden.</li><li>Utility and Ranch labels surface weight carriers, harvest multipliers and other base-side perks.</li></ul>`;
+      partnerSection.appendChild(partnerSummary);
+
+      const condenserCallout = document.createElement('div');
+      condenserCallout.className = 'glossary-callout';
+      condenserCallout.innerHTML = kidMode
+        ? `<strong>Power Condenser bonuses</strong><ul><li>Feed extra pals into the Power Condenser to add blue stars—each star raises the partner skill level.</li><li>Stars also boost a pal's stats, and the fourth star gives every job +1 level.</li><li>It takes 4 + 16 + 32 + 64 pals (116 total) to reach five stars, so mark your favorites before condensing.</li></ul>`
+        : `<strong>Power Condenser benefits</strong><ul><li>The Pal Essence Condenser consumes 4, 16, 32 and 64 duplicates (116 total) to push a partner skill to Lv.5.</li><li>Each condensation star raises base stats; the 4★ upgrade grants +1 to every work suitability.</li><li>Damage-focused partner skills scale with those levels—mount element swaps and active skill multipliers can double or better by rank 5.</li></ul>`;
+      partnerSection.appendChild(condenserCallout);
+
+      const partnerSearch = createSearch(kidMode ? 'Search partner skills…' : 'Filter partner skills by name, pal or effect…');
+      partnerSection.appendChild(partnerSearch);
+
+      const partnerFilterBar = document.createElement('div');
+      partnerFilterBar.className = 'partner-filter-bar';
+      partnerSection.appendChild(partnerFilterBar);
+
+      const partnerFilterState = { category: 'all', damageOnly: false };
+      const partnerCategoryButtons = [];
+      const partnerCategoryOptions = [
+        { key: 'all', kid: 'All', grown: 'All roles' },
+        { key: 'mount', kid: 'Mounts', grown: 'Mount bonuses' },
+        { key: 'combat', kid: 'Battle', grown: 'Combat' },
+        { key: 'utility', kid: 'Helpers', grown: 'Utility' },
+        { key: 'farming', kid: 'Ranch', grown: 'Farming' }
+      ];
+      partnerCategoryOptions.forEach(option => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'partner-filter';
+        btn.dataset.category = option.key;
+        btn.textContent = kidMode ? option.kid : option.grown;
+        btn.setAttribute('aria-pressed', option.key === partnerFilterState.category ? 'true' : 'false');
+        btn.addEventListener('click', () => {
+          if (partnerFilterState.category === option.key) return;
+          partnerFilterState.category = option.key;
+          updatePartnerCategoryButtons();
+          renderPartnerSkills();
+        });
+        partnerCategoryButtons.push(btn);
+        partnerFilterBar.appendChild(btn);
+      });
+
+      const damageToggle = document.createElement('button');
+      damageToggle.type = 'button';
+      damageToggle.className = 'partner-filter';
+      damageToggle.dataset.filter = 'damage';
+      damageToggle.textContent = kidMode ? 'Damage boost' : 'Damage boosts';
+      damageToggle.setAttribute('aria-pressed', partnerFilterState.damageOnly ? 'true' : 'false');
+      damageToggle.addEventListener('click', () => {
+        partnerFilterState.damageOnly = !partnerFilterState.damageOnly;
+        damageToggle.setAttribute('aria-pressed', partnerFilterState.damageOnly ? 'true' : 'false');
+        renderPartnerSkills();
+      });
+      partnerFilterBar.appendChild(damageToggle);
+
+      const partnerCount = document.createElement('p');
+      partnerCount.className = 'glossary-count';
+      partnerSection.appendChild(partnerCount);
+
+      const partnerGrid = document.createElement('div');
+      partnerGrid.className = 'partner-skill-grid';
+      partnerSection.appendChild(partnerGrid);
+
+      const partnerEmpty = document.createElement('p');
+      partnerEmpty.className = 'glossary-empty';
+      partnerEmpty.textContent = kidMode
+        ? 'No partner skills found. Try a different word or filter.'
+        : 'No partner skills match the current filters.';
+      partnerEmpty.hidden = true;
+      partnerSection.appendChild(partnerEmpty);
+
+      const categoryLabels = {
+        'Combat': { kid: 'Battle', grown: 'Combat' },
+        'Utility': { kid: 'Helper', grown: 'Utility' },
+        'Farming': { kid: 'Ranch', grown: 'Farming' },
+        'Mount': { kid: 'Ride', grown: 'Mount' },
+        'Mount (Flying)': { kid: 'Fly', grown: 'Flying Mount' },
+        'Mount (Glider)': { kid: 'Glide', grown: 'Glider Mount' },
+        'Mount (Swimmer)': { kid: 'Swim', grown: 'Swim Mount' },
+        'Mount (Ridden)': { kid: 'Ground', grown: 'Ground Mount' }
+      };
+
+      const decoratedPartnerSkills = partnerSkillsData.map(skill => {
+        const categories = Array.isArray(skill.categories) ? skill.categories.slice() : [];
+        const normalizedCategories = new Set();
+        const hasSpecializedMount = categories.some(cat => /^Mount \(/i.test(cat));
+        categories.forEach(cat => {
+          const lower = String(cat || '').toLowerCase();
+          if (!lower) return;
+          if (lower.includes('combat')) normalizedCategories.add('combat');
+          if (lower.includes('utility')) normalizedCategories.add('utility');
+          if (lower.includes('farming')) normalizedCategories.add('farming');
+          if (lower.startsWith('mount')) {
+            normalizedCategories.add('mount');
+            if (lower.includes('flying')) normalizedCategories.add('mount-flying');
+            if (lower.includes('glider')) normalizedCategories.add('mount-glider');
+            if (lower.includes('swimmer')) normalizedCategories.add('mount-swimmer');
+            if (lower.includes('ridden')) normalizedCategories.add('mount-ridden');
+          }
+        });
+        const description = typeof skill.description === 'string' ? skill.description : '';
+        const descLower = description.toLowerCase();
+        const modifiesPlayerDamage = descLower.includes('player') && descLower.includes('mounted') && (descLower.includes('damage') || descLower.includes('attack'));
+        const modifiesPalDamage = descLower.includes('pal') && descLower.includes('mounted') && descLower.includes('damage');
+        const modifiesAnyDamage = (descLower.includes('damage') || descLower.includes('attack')) && descLower.includes('mounted');
+        const dropBoost = descLower.includes('drop') || descLower.includes('harvest') || descLower.includes('ranch');
+        const workBoost = descLower.includes('work') || descLower.includes('carry') || descLower.includes('weight');
+        const speedBoost = descLower.includes('speed') && descLower.includes('mount');
+        const mountCategory = categories.find(cat => /^Mount/i.test(cat));
+        const palEntries = (Array.isArray(skill.pals) ? skill.pals : []).map(name => {
+          const palId = PAL_NAME_TO_ID[name];
+          const pal = palId != null ? PALS[palId] : null;
+          return { name, pal, palId };
+        });
+        const searchText = [
+          skill.name || '',
+          description,
+          skill.type || '',
+          (Array.isArray(skill.pals) ? skill.pals.join(' ') : '')
+        ].join(' ').toLowerCase();
+        return {
+          ...skill,
+          categories,
+          normalizedCategories,
+          hasSpecializedMount,
+          mountCategory,
+          modifiesPlayerDamage,
+          modifiesPalDamage,
+          modifiesAnyDamage,
+          dropBoost,
+          workBoost,
+          speedBoost,
+          palEntries,
+          searchText,
+          descLower
+        };
+      });
+
+      function updatePartnerCategoryButtons() {
+        partnerCategoryButtons.forEach(btn => {
+          const active = btn.dataset.category === partnerFilterState.category;
+          btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+        });
+      }
+
+      function renderPartnerSkills() {
+        const totalSkills = decoratedPartnerSkills.length;
+        if (!totalSkills) {
+          partnerGrid.innerHTML = '';
+          partnerCount.textContent = kidMode
+            ? 'Partner skill data is loading…'
+            : 'Partner skill dataset unavailable.';
+          partnerEmpty.hidden = false;
+          partnerEmpty.textContent = kidMode
+            ? 'Partner skill list will appear once the data loads.'
+            : 'Partner skill dataset is unavailable.';
+          return;
+        }
+        const term = partnerSearch.value.trim().toLowerCase();
+        const category = partnerFilterState.category;
+        const requireDamage = partnerFilterState.damageOnly;
+        partnerGrid.innerHTML = '';
+        let visible = 0;
+        decoratedPartnerSkills.forEach(skill => {
+          const matchesTerm = !term || skill.searchText.includes(term);
+          const matchesCategory = category === 'all' || skill.normalizedCategories.has(category);
+          const matchesDamage = !requireDamage || skill.modifiesAnyDamage;
+          if (!matchesTerm || !matchesCategory || !matchesDamage) {
+            return;
+          }
+          visible += 1;
+          const card = document.createElement('article');
+          card.className = 'partner-skill-card';
+          card.dataset.skillId = skill.id || '';
+
+          const header = document.createElement('header');
+          header.className = 'partner-skill-card__header';
+          const nameEl = document.createElement('h4');
+          nameEl.className = 'partner-skill-card__name';
+          nameEl.textContent = skill.name || 'Partner Skill';
+          const numberEl = document.createElement('span');
+          numberEl.className = 'partner-skill-card__number';
+          numberEl.textContent = skill.number != null ? String(skill.number).padStart(3, '0') : '—';
+          header.appendChild(nameEl);
+          header.appendChild(numberEl);
+          card.appendChild(header);
+
+          const tags = document.createElement('div');
+          tags.className = 'partner-skill-card__tags';
+          const shownTags = new Set();
+          const hasMountSpecialisation = skill.hasSpecializedMount;
+          skill.categories.forEach(cat => {
+            if (!cat) return;
+            if (cat === 'Mount' && hasMountSpecialisation) return;
+            const mapping = categoryLabels[cat];
+            const label = mapping ? (kidMode ? mapping.kid : mapping.grown) : cat;
+            const tagKey = `cat:${label}`;
+            if (shownTags.has(tagKey)) return;
+            shownTags.add(tagKey);
+            const tag = document.createElement('span');
+            tag.className = 'partner-skill-card__tag';
+            if (/^Mount/i.test(cat)) {
+              tag.classList.add('partner-skill-card__tag--mount');
+            }
+            tag.textContent = label;
+            tags.appendChild(tag);
+          });
+          if (skill.modifiesAnyDamage) {
+            const tag = document.createElement('span');
+            tag.className = 'partner-skill-card__tag partner-skill-card__tag--damage';
+            tag.textContent = kidMode
+              ? (skill.modifiesPlayerDamage ? 'You hit harder' : 'Pal hits harder')
+              : (skill.modifiesPlayerDamage ? 'Player damage' : 'Pal damage');
+            tags.appendChild(tag);
+          }
+          if (skill.dropBoost) {
+            const tag = document.createElement('span');
+            tag.className = 'partner-skill-card__tag partner-skill-card__tag--drops';
+            tag.textContent = kidMode ? 'More drops' : 'Drop bonus';
+            tags.appendChild(tag);
+          }
+          if (skill.workBoost) {
+            const tag = document.createElement('span');
+            tag.className = 'partner-skill-card__tag';
+            tag.textContent = kidMode ? 'Helper boost' : 'Support bonus';
+            tags.appendChild(tag);
+          }
+          if (skill.speedBoost) {
+            const tag = document.createElement('span');
+            tag.className = 'partner-skill-card__tag';
+            tag.textContent = kidMode ? 'Faster ride' : 'Speed boost';
+            tags.appendChild(tag);
+          }
+          if (tags.childElementCount) {
+            card.appendChild(tags);
+          }
+
+          const description = document.createElement('p');
+          description.className = 'partner-skill-card__description';
+          description.textContent = skill.description || (kidMode ? 'Partner skill info unavailable.' : 'No description available.');
+          card.appendChild(description);
+
+          if (skill.palEntries.length) {
+            const palWrap = document.createElement('div');
+            palWrap.className = 'partner-skill-card__pals';
+            skill.palEntries.forEach(entry => {
+              const palBtn = document.createElement('button');
+              palBtn.type = 'button';
+              palBtn.className = 'partner-skill-card__pal';
+              const palId = entry.palId;
+              if (palId != null) {
+                palBtn.dataset.palId = String(palId);
+              } else {
+                palBtn.setAttribute('aria-disabled', 'true');
+                palBtn.disabled = true;
+              }
+              const avatar = document.createElement('span');
+              avatar.className = 'partner-skill-card__pal-avatar';
+              if (entry.pal) {
+                const img = document.createElement('img');
+                img.alt = '';
+                applyPalArtwork(img, entry.pal, { alt: '' });
+                avatar.appendChild(img);
+              } else {
+                avatar.textContent = entry.name ? entry.name.charAt(0).toUpperCase() : '?';
+              }
+              const label = document.createElement('span');
+              label.textContent = entry.name || (kidMode ? 'Pal' : 'Unknown Pal');
+              palBtn.appendChild(avatar);
+              palBtn.appendChild(label);
+              palWrap.appendChild(palBtn);
+            });
+            card.appendChild(palWrap);
+          }
+
+          partnerGrid.appendChild(card);
+        });
+
+        partnerCount.textContent = visible === totalSkills
+          ? `${visible} partner skills listed.`
+          : `Showing ${visible} of ${totalSkills} partner skills.`;
+        partnerEmpty.hidden = visible !== 0;
+      }
+
+      updatePartnerCategoryButtons();
+      partnerSearch.addEventListener('input', renderPartnerSkills);
+      renderPartnerSkills();
+
       const passiveDescription = kidMode
         ? 'All partner traits pals can roll. Tap a trait to read what it does.'
         : 'Complete alphabetical list of every passive trait. Select any entry for detailed effects.';
@@ -11272,6 +11788,15 @@
           if (workPalCard && workPalCard.dataset.palId) {
             e.preventDefault();
             showPalDetail(workPalCard.dataset.palId);
+            return;
+          }
+          const partnerPalBtn = e.target.closest('.partner-skill-card__pal');
+          if (partnerPalBtn) {
+            e.preventDefault();
+            const palId = partnerPalBtn.dataset.palId;
+            if (palId) {
+              showPalDetail(palId);
+            }
             return;
           }
           const moveBtn = e.target.closest('.glossary-skill');

--- a/scripts/generate_partner_skills.py
+++ b/scripts/generate_partner_skills.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fetch partner skill data from the Palworld wiki and refresh data/partner_skills.json."""
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+SOURCE_URL = "https://palworld.wiki.gg/wiki/Partner_Skills"
+FETCH_URL = "https://r.jina.ai/https://palworld.wiki.gg/wiki/Partner_Skills"
+OUTPUT_PATH = Path(__file__).resolve().parents[1] / "data" / "partner_skills.json"
+
+
+def fetch_markdown() -> str:
+    request = urllib.request.Request(
+        FETCH_URL,
+        headers={"User-Agent": "Palmate partner skill synchroniser"},
+    )
+    with urllib.request.urlopen(request) as response:  # noqa: S310
+        payload = response.read()
+    return payload.decode("utf-8")
+
+
+def slugify(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text.lower())
+    cleaned = "".join(ch for ch in normalized if ch.isalnum() or ch in {" ", "-", "_"})
+    cleaned = cleaned.replace("_", " ")
+    return re.sub(r"\s+", "-", cleaned).strip("-")
+
+
+def clean_markdown(text: str) -> str:
+    text = re.sub(r"!\[[^\]]*\]\([^)]*\)", "", text)
+    text = re.sub(r"\[\]\([^)]*\)", "", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def parse_partner_skills(markdown: str) -> List[Dict]:
+    rows: Dict[str, Dict] = {}
+    link_pattern = re.compile(r"\[(?!\!)([^\]]+?)\]\(https://palworld.wiki.gg/wiki/[^)]+\)")
+    for line in markdown.splitlines():
+        if not line.startswith("|"):
+            continue
+        parts = [part.strip() for part in line.strip("|").split("|")]
+        if len(parts) < 5 or parts[0] in {"Skill Name", "---"}:
+            continue
+        number = parts[2]
+        if not number.isdigit():
+            continue
+        skill_name = parts[0]
+        pal_names = [name for name in link_pattern.findall(parts[1]) if name.lower() != "pal"]
+        type_text = clean_markdown(parts[3])
+        description = clean_markdown(parts[4])
+        record = rows.setdefault(
+            skill_name,
+            {
+                "id": slugify(skill_name),
+                "number": int(number),
+                "name": skill_name,
+                "pals": set(),
+                "type": type_text,
+                "categories": set(),
+                "description": description,
+            },
+        )
+        record["pals"].update(pal_names)
+        for chunk in type_text.split("/"):
+            label = chunk.strip()
+            if label:
+                record["categories"].add(label)
+    output: List[Dict] = []
+    for entry in rows.values():
+        output.append(
+            {
+                "id": entry["id"],
+                "number": entry["number"],
+                "name": entry["name"],
+                "pals": sorted(entry["pals"]),
+                "type": entry["type"],
+                "categories": sorted(entry["categories"], key=str.lower),
+                "description": entry["description"],
+            }
+        )
+    output.sort(key=lambda item: item["number"])
+    return output
+
+
+def main() -> None:
+    markdown = fetch_markdown()
+    records = parse_partner_skills(markdown)
+    OUTPUT_PATH.write_text(json.dumps(records, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(records)} partner skills to {OUTPUT_PATH.relative_to(Path.cwd())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a generated partner_skills.json dataset that records every known partner ability and the pals that share it
- extend the glossary UI with a styled Partner Skills section featuring filters, damage boost tagging, and Power Condenser guidance
- provide a regeneration script that scrapes the Palworld wiki partner skill table through r.jina.ai

## Testing
- Manual QA: not run (pending manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68dbbe5443cc8331bf69f5ad727b60f6