### PR TITLE
Refine route suggestions layout and visuals

### DIFF
--- a/assets/images/route-icons/boss.svg
+++ b/assets/images/route-icons/boss.svg
@@ -1,0 +1,31 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="18" fill="url(#boss-bg)"/>
+  <g filter="url(#boss-glow)">
+    <path d="M18 48L24 22L34 34L40 20L46 34L56 22L62 48L18 48Z" fill="url(#boss-crown)" stroke="#0d0b24" stroke-width="3" stroke-linejoin="round"/>
+    <rect x="24" y="48" width="32" height="10" rx="5" fill="url(#boss-base)"/>
+    <circle cx="40" cy="36" r="6" fill="#0d0b24"/>
+    <circle cx="40" cy="36" r="3" fill="url(#boss-gem)"/>
+  </g>
+  <defs>
+    <linearGradient id="boss-bg" x1="12" y1="12" x2="70" y2="68" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e7b9ff"/>
+      <stop offset="1" stop-color="#b084ff"/>
+    </linearGradient>
+    <linearGradient id="boss-crown" x1="24" y1="20" x2="60" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f9f1ff"/>
+      <stop offset="1" stop-color="#d9c4ff"/>
+    </linearGradient>
+    <linearGradient id="boss-base" x1="24" y1="48" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#d9c4ff"/>
+      <stop offset="1" stop-color="#bda0ff"/>
+    </linearGradient>
+    <linearGradient id="boss-gem" x1="37" y1="33" x2="43" y2="39" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffe4f5"/>
+      <stop offset="1" stop-color="#ff9ed9"/>
+    </linearGradient>
+    <filter id="boss-glow" x="12" y="14" width="56" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.4" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/assets/images/route-icons/item.svg
+++ b/assets/images/route-icons/item.svg
@@ -1,0 +1,28 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="18" fill="url(#item-bg)"/>
+  <g filter="url(#item-glow)">
+    <path d="M28 24H52L58 40L48 58H32L22 40L28 24Z" fill="url(#item-bag)" stroke="#261a02" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M28 24C30 20 34 18 40 18C46 18 50 20 52 24" stroke="#261a02" stroke-width="3" stroke-linecap="round"/>
+    <path d="M32 44H48" stroke="#261a02" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="40" cy="36" r="5" fill="#261a02"/>
+    <circle cx="40" cy="36" r="2.5" fill="url(#item-gem)"/>
+  </g>
+  <defs>
+    <linearGradient id="item-bg" x1="16" y1="12" x2="68" y2="68" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffd166"/>
+      <stop offset="1" stop-color="#f4972c"/>
+    </linearGradient>
+    <linearGradient id="item-bag" x1="24" y1="22" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fff1c2"/>
+      <stop offset="1" stop-color="#ffd189"/>
+    </linearGradient>
+    <linearGradient id="item-gem" x1="37" y1="33" x2="43" y2="39" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fffbe0"/>
+      <stop offset="1" stop-color="#ffe27a"/>
+    </linearGradient>
+    <filter id="item-glow" x="18" y="14" width="44" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.4" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/assets/images/route-icons/npc.svg
+++ b/assets/images/route-icons/npc.svg
@@ -1,0 +1,24 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="18" fill="url(#npc-bg)"/>
+  <g filter="url(#npc-glow)">
+    <path d="M24 28C24 21.3726 29.3726 16 36 16H44C50.6274 16 56 21.3726 56 28V34C56 40.6274 50.6274 46 44 46H36C29.3726 46 24 40.6274 24 34V28Z" fill="url(#npc-bubble)"/>
+    <path d="M32 50L25 58L34 57L37 64L44 54" stroke="#0b1526" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="35" cy="32" r="4" fill="#0b1526"/>
+    <circle cx="45" cy="32" r="4" fill="#0b1526"/>
+    <path d="M36 40C37.5 42.2 42.5 42.2 44 40" stroke="#0b1526" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="npc-bg" x1="16" y1="12" x2="68" y2="68" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffb3c6"/>
+      <stop offset="1" stop-color="#ff6f91"/>
+    </linearGradient>
+    <linearGradient id="npc-bubble" x1="26" y1="18" x2="54" y2="44" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fff5f9"/>
+      <stop offset="1" stop-color="#ffc9de"/>
+    </linearGradient>
+    <filter id="npc-glow" x="18" y="12" width="44" height="56" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.2" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/assets/images/route-icons/pal.svg
+++ b/assets/images/route-icons/pal.svg
@@ -1,0 +1,29 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="18" fill="url(#pal-bg)"/>
+  <g filter="url(#pal-glow)">
+    <circle cx="40" cy="44" r="20" fill="url(#pal-body)"/>
+    <circle cx="28" cy="30" r="10" fill="url(#pal-ear)"/>
+    <circle cx="52" cy="30" r="10" fill="url(#pal-ear)"/>
+    <circle cx="32" cy="44" r="4.5" fill="#0d1b2a"/>
+    <circle cx="48" cy="44" r="4.5" fill="#0d1b2a"/>
+    <path d="M34 55C36.4 58.2 43.6 58.2 46 55" stroke="#0d1b2a" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="pal-bg" x1="12" y1="12" x2="68" y2="68" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4ecdc4"/>
+      <stop offset="1" stop-color="#3498db"/>
+    </linearGradient>
+    <linearGradient id="pal-body" x1="24" y1="28" x2="56" y2="60" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fff8d6"/>
+      <stop offset="1" stop-color="#ffe0a3"/>
+    </linearGradient>
+    <linearGradient id="pal-ear" x1="22" y1="22" x2="34" y2="34" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffe9f3"/>
+      <stop offset="1" stop-color="#ffc8dd"/>
+    </linearGradient>
+    <filter id="pal-glow" x="8" y="8" width="64" height="64" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/assets/images/route-icons/technology.svg
+++ b/assets/images/route-icons/technology.svg
@@ -1,0 +1,31 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="18" fill="url(#tech-bg)"/>
+  <g filter="url(#tech-glow)">
+    <circle cx="40" cy="40" r="22" fill="url(#tech-core)"/>
+    <path d="M40 23L44.2 26.4L51.4 25.6L52.8 32.8L58.2 36L55.8 42.8L58.2 49.6L52.8 52.8L51.4 60L44.2 59.2L40 62.6L35.8 59.2L28.6 60L27.2 52.8L21.8 49.6L24.2 42.8L21.8 36L27.2 32.8L28.6 25.6L35.8 26.4L40 23Z" stroke="#0d1b2a" stroke-width="3" stroke-linejoin="round" fill="url(#tech-gear)"/>
+    <circle cx="40" cy="40" r="8" fill="#0d1b2a"/>
+    <circle cx="40" cy="40" r="4" fill="url(#tech-core-light)"/>
+  </g>
+  <defs>
+    <linearGradient id="tech-bg" x1="14" y1="10" x2="66" y2="70" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8e9eff"/>
+      <stop offset="1" stop-color="#5b6cfb"/>
+    </linearGradient>
+    <linearGradient id="tech-core" x1="24" y1="24" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#d7f3ff"/>
+      <stop offset="1" stop-color="#a8caff"/>
+    </linearGradient>
+    <linearGradient id="tech-gear" x1="28" y1="28" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#b9c6ff"/>
+      <stop offset="1" stop-color="#8093ff"/>
+    </linearGradient>
+    <linearGradient id="tech-core-light" x1="36" y1="36" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#93f5ff"/>
+      <stop offset="1" stop-color="#55d8ff"/>
+    </linearGradient>
+    <filter id="tech-glow" x="10" y="10" width="60" height="60" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.2" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/css/styles.css
+++ b/css/styles.css
@@ -139,10 +139,19 @@ gba(119,141,169,0.45)}
 .route-recommendations__header{display:grid;gap:6px}
 .route-recommendations__header h3{margin:0}
 .route-recommendations__intro{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem}
-.route-recommendations__list{display:grid;gap:14px}
+.route-recommendations__collapsible{border-radius:18px;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.28);overflow:hidden;box-shadow:0 18px 32px rgba(0,0,0,0.38)}
+.route-recommendations__collapsible summary{display:flex;align-items:center;gap:10px;list-style:none;padding:14px 18px;font-weight:600;color:var(--accent,#778da9);cursor:pointer}
+.route-recommendations__collapsible summary::-webkit-details-marker{display:none}
+.route-recommendations__collapsible[open] summary{border-bottom:1px solid rgba(119,141,169,0.28)}
+.route-recommendations__collapsible[data-empty="true"] summary{color:rgba(224,225,221,0.6);cursor:default}
+.route-recommendations__list{display:grid;gap:14px;padding:18px}
 .route-recommendation{display:grid;gap:12px;padding:16px;border-radius:16px;background:rgba(12,24,40,0.65);border:1px solid rgba(119,141,169,0.24);box-shadow:0 16px 32px rgba(0,0,0,0.35)}
-.route-recommendation__header{display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.route-recommendation__header{display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap;align-items:flex-start}
+.route-recommendation__title{display:flex;align-items:flex-start;gap:12px}
+.route-recommendation__icon{flex:0 0 auto;width:44px;height:44px;border-radius:14px;background:rgba(0,0,0,0.32);display:grid;place-items:center;box-shadow:0 10px 20px rgba(0,0,0,0.38)}
+.route-recommendation__icon img{width:32px;height:32px;object-fit:contain}
 .route-recommendation__header h4{margin:0}
+.route-recommendation__text{display:flex;flex-direction:column;gap:4px;min-width:0}
 .route-recommendation__meta{margin:4px 0 0;color:var(--muted,rgba(224,225,221,0.7));font-size:.9rem}
 .route-recommendation__tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px}
 .route-recommendation__tag{font-size:.75rem;padding:4px 10px;background:rgba(119,141,169,0.24);border:1px solid rgba(119,141,169,0.35)}
@@ -151,42 +160,71 @@ gba(119,141,169,0.45)}
 .route-recommendation__actions{display:flex;justify-content:flex-start}
 .route-recommendations__empty,.route-recommendation__fallback{margin:0;color:var(--muted,rgba(224,225,221,0.7));font-size:.9rem}
 
-.route-suggestions-card{display:grid;gap:18px}
+.route-suggestions-card{display:grid;gap:20px}
 .route-suggestions__header{display:grid;gap:6px}
 .route-suggestions__header h3{margin:0}
 .route-suggestions__intro{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem}
-.route-suggestions__list{display:grid;gap:12px}
-@media (min-width:720px){.route-suggestions__list{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}}
+.route-suggestions__workspace{display:grid;gap:20px}
+@media (min-width:960px){.route-suggestions__workspace{grid-template-columns:minmax(220px,280px) minmax(0,1fr);align-items:start}}
+.route-suggestions__filters{display:grid;gap:18px;padding:18px;border-radius:18px;background:rgba(10,20,34,0.82);border:1px solid rgba(119,141,169,0.32);box-shadow:0 16px 32px rgba(0,0,0,0.38)}
+.route-suggestions__filters-empty{margin:0;color:var(--muted,rgba(224,225,221,0.72));text-align:center;font-size:.9rem}
+.route-suggestions__filter-group{display:grid;gap:12px}
+.route-suggestions__filter-label{font-size:.75rem;letter-spacing:.12em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
+.route-type-chip-row{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(120px,1fr))}
+.route-type-chip{display:flex;align-items:center;gap:10px;padding:10px 14px;border-radius:14px;background:rgba(17,34,52,0.7);border:1px solid rgba(119,141,169,0.28);color:var(--text,#f0f4f8);font-weight:600;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+.route-type-chip__art{width:36px;height:36px;border-radius:12px;background:rgba(0,0,0,0.35);display:grid;place-items:center;box-shadow:0 10px 18px rgba(0,0,0,0.35)}
+.route-type-chip__art img{width:26px;height:26px;object-fit:contain}
+.route-type-chip__label{font-size:.85rem;color:rgba(224,225,221,0.88)}
+.route-type-chip--active{border-color:var(--accent,#778da9);box-shadow:0 16px 28px rgba(0,0,0,0.4);transform:translateY(-2px);background:rgba(24,46,68,0.85)}
+.route-suggestions__filter-bar{display:flex;flex-direction:column;gap:12px}
+.route-suggestions__toggle{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:12px;background:rgba(17,34,52,0.65);border:1px solid rgba(119,141,169,0.28)}
+.route-suggestions__toggle input{width:20px;height:20px;accent-color:var(--accent,#778da9)}
+.route-suggestions__toggle span{font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.88)}
+.route-suggestions__search{display:flex;align-items:center;padding:0 12px;border-radius:12px;background:rgba(17,34,52,0.65);border:1px solid rgba(119,141,169,0.28)}
+.route-suggestions__search input{flex:1;border:none;background:none;color:var(--text,#f0f4f8);padding:10px 0;font-size:.95rem}
+.route-suggestions__search input:focus{outline:none}
+.route-suggestions__content{display:grid;gap:18px}
+.route-suggestions__list{display:grid;gap:14px}
+@media (min-width:720px){.route-suggestions__list{grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}}
 .route-suggestions__empty,.route-suggestions__placeholder{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem;text-align:center;padding:12px}
-.route-suggestion-card{position:relative;display:grid;gap:12px;align-items:flex-start;padding:18px;border-radius:20px;background:rgba(12,24,40,0.75);border:1px solid rgba(119,141,169,0.28);color:var(--text,#f0f4f8);box-shadow:0 20px 36px rgba(0,0,0,0.4);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(12,24,40,0.78)),rgba(12,24,40,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center)}
-.route-suggestion-card::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.4));pointer-events:none}
-.route-suggestion-card__body{position:relative;z-index:1;display:grid;gap:12px}
+.route-suggestion-card{display:grid;gap:14px;padding:18px;border-radius:18px;background:rgba(12,24,40,0.72);border:1px solid rgba(119,141,169,0.28);color:var(--text,#f0f4f8);box-shadow:0 16px 30px rgba(0,0,0,0.38);cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+.route-suggestion-card__body{display:grid;gap:12px}
 .route-suggestion-card__top{display:flex;align-items:flex-start;gap:12px}
-.route-suggestion-card__icon{flex:0 0 auto;width:44px;height:44px;border-radius:14px;background:rgba(0,0,0,0.32);display:grid;place-items:center;font-size:1.2rem;color:var(--route-suggestion-accent,#9bd4ff);box-shadow:0 10px 20px rgba(0,0,0,0.4)}
+.route-suggestion-card__picture{flex:0 0 auto;width:52px;height:52px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.14),rgba(10,20,34,0.68));display:grid;place-items:center;box-shadow:0 12px 22px rgba(0,0,0,0.4)}
+.route-suggestion-card__picture img{width:38px;height:38px;object-fit:contain}
 .route-suggestion-card__text{display:flex;flex-direction:column;gap:4px}
-.route-suggestion-card__title{margin:0;font-size:1.05rem;line-height:1.2}
-.route-suggestion-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.78)}
-.route-suggestion-card__score{margin-left:auto;font-weight:700;font-size:1.1rem;color:var(--route-suggestion-accent,#9bd4ff)}
+.route-suggestion-card__title{margin:0;font-size:1.05rem;line-height:1.25}
+.route-suggestion-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.75)}
+.route-suggestion-card__score{margin-left:auto;font-weight:700;font-size:1.1rem;color:var(--accent,#778da9)}
 .route-suggestion-card__progress{display:flex;align-items:center;gap:10px}
 .route-suggestion-card__progress-bar{flex:1;height:6px;border-radius:999px;background:rgba(255,255,255,0.16);overflow:hidden}
-.route-suggestion-card__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-suggestion-accent,#9bd4ff),rgba(255,255,255,0.85))}
-.route-suggestion-card__progress-label{font-size:.85rem;color:rgba(224,225,221,0.86)}
-.route-suggestion-card__reason{margin:0;font-size:.85rem;color:rgba(224,225,221,0.88)}
-.route-suggestion-card:hover{transform:translateY(-4px);box-shadow:0 26px 48px rgba(0,0,0,0.48);border-color:rgba(255,255,255,0.35)}
-.route-suggestion-card--active{border-color:var(--route-suggestion-accent,#9bd4ff);box-shadow:0 28px 52px rgba(0,0,0,0.52);transform:translateY(-4px)}
-.route-suggestions__detail{position:relative;display:grid;gap:0;border-radius:24px;background:rgba(8,16,32,0.8);border:1px solid rgba(119,141,169,0.28);overflow:hidden;box-shadow:0 26px 52px rgba(0,0,0,0.5)}
-.route-suggestion-detail__hero{position:relative;display:grid;gap:12px;padding:24px;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(8,16,32,0.85)),rgba(8,16,32,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center)}
-.route-suggestion-detail__badge{justify-self:flex-start;padding:6px 12px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.24);font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,0.78)}
-.route-suggestion-detail__title{margin:0;font-size:1.4rem}
-.route-suggestion-detail__meta{margin:0;font-size:.92rem;color:rgba(224,225,221,0.84)}
-.route-suggestion-detail__progress{display:flex;flex-wrap:wrap;align-items:center;gap:10px}
-.route-suggestion-detail__progress-bar{flex:1;min-width:140px;height:8px;border-radius:999px;background:rgba(255,255,255,0.2);overflow:hidden}
-.route-suggestion-detail__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-suggestion-accent,#9bd4ff),rgba(255,255,255,0.85))}
-.route-suggestion-detail__progress-label{font-size:.9rem;font-weight:600;color:rgba(255,255,255,0.9)}
-.route-suggestion-detail__reasons{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.9rem;color:rgba(255,255,255,0.88)}
-.route-suggestion-detail__reason{margin:0;font-size:.9rem;color:rgba(255,255,255,0.88)}
-.route-suggestion-detail__actions{display:flex;flex-wrap:wrap;gap:10px}
-.route-suggestion-detail__body{padding:20px;background:rgba(10,20,34,0.9)}
+.route-suggestion-card__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--accent,#778da9),rgba(255,255,255,0.82))}
+.route-suggestion-card__progress-label{font-size:.82rem;color:rgba(224,225,221,0.82)}
+.route-suggestion-card__reason{margin:0;font-size:.9rem;color:rgba(224,225,221,0.88)}
+.route-suggestion-card__cta{font-size:.8rem;font-weight:600;color:var(--accent,#778da9)}
+.route-suggestion-card:hover{transform:translateY(-4px);box-shadow:0 22px 38px rgba(0,0,0,0.45);border-color:rgba(255,255,255,0.3)}
+.route-suggestion-card--selected{border-color:var(--accent,#778da9);box-shadow:0 26px 44px rgba(0,0,0,0.5);transform:translateY(-2px)}
+.route-suggestions__selection{display:grid;gap:16px;padding:20px;border-radius:20px;background:rgba(8,16,32,0.82);border:1px solid rgba(119,141,169,0.3);box-shadow:0 22px 40px rgba(0,0,0,0.45);min-height:220px}
+.route-selection{display:grid;gap:0;border-radius:18px;overflow:hidden;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.32);box-shadow:0 18px 32px rgba(0,0,0,0.42)}
+.route-selection__hero{display:grid;gap:14px;padding:20px;background-image:linear-gradient(160deg,var(--route-selection-overlay,rgba(8,16,32,0.9)),rgba(8,16,32,0.92)),var(--route-selection-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-selection-position,center)}
+.route-selection__heading{display:flex;align-items:flex-start;gap:12px}
+.route-selection__icon{flex:0 0 auto;width:52px;height:52px;border-radius:16px;background:rgba(0,0,0,0.35);display:grid;place-items:center;box-shadow:0 12px 24px rgba(0,0,0,0.45)}
+.route-selection__icon img{width:38px;height:38px;object-fit:contain}
+.route-selection__title{display:flex;flex-direction:column;gap:6px}
+.route-selection__title h4{margin:0;font-size:1.2rem}
+.route-selection__badge{align-self:flex-start;padding:4px 10px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.24);font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,0.78)}
+.route-selection__meta{margin:0;font-size:.9rem;color:rgba(224,225,221,0.82)}
+.route-selection__remove{margin-left:auto;background:none;border:none;color:rgba(255,255,255,0.7);font-size:1.5rem;line-height:1;cursor:pointer;padding:0 4px}
+.route-selection__remove:hover{color:rgba(255,255,255,0.95)}
+.route-selection__progress{display:flex;align-items:center;gap:12px}
+.route-selection__progress-bar{flex:1;height:8px;border-radius:999px;background:rgba(255,255,255,0.22);overflow:hidden}
+.route-selection__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-selection-accent,#778da9),rgba(255,255,255,0.88))}
+.route-selection__progress-label{font-size:.85rem;font-weight:600;color:rgba(255,255,255,0.9)}
+.route-selection__reasons{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.9rem;color:rgba(255,255,255,0.88)}
+.route-selection__reason{margin:0;font-size:.9rem;color:rgba(255,255,255,0.88)}
+.route-selection__actions{display:flex;flex-wrap:wrap;gap:10px}
+.route-selection__body{padding:18px 20px;background:rgba(6,14,24,0.92)}
+.route-selection + .route-selection{margin-top:12px}
 
 .route-overview{display:flex;flex-direction:column;gap:16px}
 .route-overview__header{display:flex;flex-direction:column;gap:16px}

--- a/index.html
+++ b/index.html
@@ -5498,6 +5498,16 @@
           btn.removeAttribute('aria-pressed');
         }
       });
+      if(typeof renderRouteSuggestionFiltersUI === 'function' && typeof reapplyRouteSuggestionFilters === 'function'){
+        setTimeout(() => {
+          try {
+            renderRouteSuggestionFiltersUI();
+            reapplyRouteSuggestionFilters();
+          } catch(err){
+            console.warn('Route filter refresh failed', err);
+          }
+        }, 0);
+      }
     }
 
     function bindRouteActionButtons(){
@@ -9407,17 +9417,64 @@
     let routeContext = loadRouteContext();
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
+    let currentRouteRecommendations = [];
+    let routeSuggestionsAbort = null;
+    const selectedRouteSuggestionIds = new Set();
+    let selectedRouteSuggestionOrder = [];
+    const routeSuggestionFilters = {
+      types: new Set(),
+      showCompleted: false,
+      search: ''
+    };
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
+    const ROUTE_ICON_LIBRARY = {
+      pal: {
+        image: 'assets/images/route-icons/pal.svg',
+        accent: '#9bd4ff',
+        kidLabel: 'Pal adventures',
+        adultLabel: 'Pal routes'
+      },
+      boss: {
+        image: 'assets/images/route-icons/boss.svg',
+        accent: '#d1b8ff',
+        kidLabel: 'Boss battles',
+        adultLabel: 'Boss routes'
+      },
+      technology: {
+        image: 'assets/images/route-icons/technology.svg',
+        accent: '#c8bfff',
+        kidLabel: 'Tech unlocks',
+        adultLabel: 'Tech routes'
+      },
+      npc: {
+        image: 'assets/images/route-icons/npc.svg',
+        accent: '#ffb3c1',
+        kidLabel: 'Friend quests',
+        adultLabel: 'NPC quests'
+      },
+      item: {
+        image: 'assets/images/route-icons/item.svg',
+        accent: '#ffe599',
+        kidLabel: 'Item hunts',
+        adultLabel: 'Item routes'
+      }
+    };
     const ROUTE_ART_LIBRARY = {
       boss: { overlay: 'rgba(126, 87, 255, 0.62)', accent: '#d1b8ff', icon: 'fa-chess-king', position: 'center 18%' },
       tower: { overlay: 'rgba(126, 87, 255, 0.62)', accent: '#d1b8ff', icon: 'fa-chess-king', position: 'center 18%' },
       farming: { overlay: 'rgba(42, 157, 143, 0.58)', accent: '#a7f2d2', icon: 'fa-seedling', position: 'center 68%' },
       gather: { overlay: 'rgba(42, 157, 143, 0.58)', accent: '#a7f2d2', icon: 'fa-seedling', position: 'center 68%' },
       capture: { overlay: 'rgba(255, 170, 102, 0.6)', accent: '#ffd6a5', icon: 'fa-paw', position: 'center 58%' },
+      pal: { overlay: 'rgba(255, 170, 102, 0.6)', accent: '#ffd6a5', icon: 'fa-paw', position: 'center 58%' },
       exploration: { overlay: 'rgba(118, 206, 255, 0.6)', accent: '#9bd4ff', icon: 'fa-compass', position: 'center 32%' },
       travel: { overlay: 'rgba(118, 206, 255, 0.6)', accent: '#9bd4ff', icon: 'fa-compass', position: 'center 32%' },
       craft: { overlay: 'rgba(255, 214, 102, 0.58)', accent: '#ffe599', icon: 'fa-hammer', position: 'center 44%' },
-      base: { overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' }
+      technology: { overlay: 'rgba(90, 126, 255, 0.58)', accent: '#c8bfff', icon: 'fa-gear', position: 'center 38%' },
+      tech: { overlay: 'rgba(90, 126, 255, 0.58)', accent: '#c8bfff', icon: 'fa-gear', position: 'center 38%' },
+      base: { overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' },
+      npc: { overlay: 'rgba(255, 159, 181, 0.58)', accent: '#ffb3c1', icon: 'fa-people-group', position: 'center 48%' },
+      story: { overlay: 'rgba(255, 159, 181, 0.58)', accent: '#ffb3c1', icon: 'fa-people-group', position: 'center 48%' },
+      item: { overlay: 'rgba(255, 214, 102, 0.58)', accent: '#ffe599', icon: 'fa-sack', position: 'center 60%' }
     };
     const ROUTE_ART_VARIANTS = [
       { overlay: 'rgba(148, 187, 233, 0.55)', accent: '#9bd4ff', icon: 'fa-route', position: 'center 40%' },
@@ -9425,6 +9482,7 @@
       { overlay: 'rgba(92, 225, 230, 0.52)', accent: '#bde7f8', icon: 'fa-compass', position: 'center 28%' },
       { overlay: 'rgba(255, 196, 77, 0.5)', accent: '#ffd6a5', icon: 'fa-sun', position: 'center 52%' }
     ];
+    const ROUTE_SUGGESTION_TYPE_ORDER = ['pal', 'boss', 'technology', 'npc', 'item'];
     const DEFAULT_RECOMMENDER_WEIGHTS = {
       prerequisites_met: 6,
       level_fit: 5,
@@ -9448,8 +9506,6 @@
       tower_alignment: 3
     };
     let currentRouteSuggestionEntries = [];
-    let activeSuggestedRouteId = null;
-    let routeSuggestionsAbort = null;
 
     function rebuildTechLookup(){
       TECH_LOOKUP = {};
@@ -9850,6 +9906,35 @@
       return strict ? '' : fallback;
     }
 
+    function classifyRouteGuideType(route){
+      const category = (route?.category || '').toLowerCase();
+      const tags = Array.isArray(route?.tags) ? route.tags.map(tag => String(tag || '').toLowerCase()) : [];
+      const objectives = Array.isArray(route?.objectives) ? route.objectives.map(obj => String(obj || '').toLowerCase()) : [];
+      const bucket = [category, ...tags, ...objectives];
+      const matchesAny = (patterns) => bucket.some(entry => patterns.some(pattern => entry.includes(pattern)));
+      if(matchesAny(['boss', 'tower', 'guardian', 'alpha', 'dungeon'])) return 'boss';
+      if(matchesAny(['pal', 'capture', 'tame', 'egg', 'breed'])) return 'pal';
+      if(matchesAny(['tech', 'technology', 'craft', 'build', 'upgrade', 'workbench', 'weapon', 'armor'])) return 'technology';
+      if(matchesAny(['npc', 'quest', 'story', 'mission', 'rescue', 'friend'])) return 'npc';
+      if(matchesAny(['item', 'resource', 'material', 'farm', 'gather', 'harvest', 'loot', 'supply'])) return 'item';
+      if(category === 'support' || category === 'resource') return 'item';
+      return 'pal';
+    }
+
+    function routeIconFor(route){
+      const type = classifyRouteGuideType(route);
+      const entry = ROUTE_ICON_LIBRARY[type] || ROUTE_ICON_LIBRARY.pal || Object.values(ROUTE_ICON_LIBRARY)[0] || {};
+      const label = kidMode ? (entry.kidLabel || entry.adultLabel || capitalize(type)) : (entry.adultLabel || entry.kidLabel || capitalize(type));
+      const image = entry.image || (ROUTE_ICON_LIBRARY.pal ? ROUTE_ICON_LIBRARY.pal.image : 'assets/images/route-icons/pal.svg');
+      return {
+        type,
+        image,
+        accent: entry.accent,
+        label,
+        alt: label || 'Guide icon'
+      };
+    }
+
     function routeArtFor(route){
       const category = (route?.category || '').toLowerCase();
       const tags = Array.isArray(route?.tags) ? route.tags.map(tag => (tag || '').toLowerCase()) : [];
@@ -9874,7 +9959,17 @@
         const variant = variants[Math.abs(hashString(route?.id || 'route')) % variants.length] || variants[0];
         art = variant;
       }
-      return { image: ROUTE_ART_IMAGE, ...art };
+      const icon = routeIconFor(route);
+      const accent = icon.accent || art.accent;
+      return {
+        image: ROUTE_ART_IMAGE,
+        ...art,
+        accent,
+        iconImage: icon.image,
+        iconAlt: icon.alt,
+        iconLabel: icon.label,
+        iconType: icon.type
+      };
     }
 
     function routeProgressBreakdown(route){
@@ -9912,137 +10007,206 @@
       const effectiveSummary = summary || calculateGuideProgressSummary();
       const effectiveLevel = levelEstimate || estimatePlayerLevel(routeContext);
       const effectiveRecommendations = recommendations || computeRouteRecommendations(routeGuideData, routeContext, effectiveLevel);
+      currentRouteRecommendations = effectiveRecommendations;
       const suggestionCount = renderRouteSuggestions(effectiveRecommendations);
       renderRouteRecommendationsList(effectiveRecommendations, { offset: suggestionCount });
       updateRouteOverviewUI(effectiveSummary);
       renderBossRouteTimeline();
     }
 
+    function routeSuggestionCtaLabel(selected){
+      if(kidMode){
+        return selected ? 'Pinned below' : 'Tap to pin below';
+      }
+      return selected ? 'Pinned to planner' : 'Pin to planner';
+    }
+
+    function selectSuggestedRoute(routeId){
+      if(!routeId || selectedRouteSuggestionIds.has(routeId)) return;
+      selectedRouteSuggestionIds.add(routeId);
+      selectedRouteSuggestionOrder.push(routeId);
+    }
+
+    function deselectSuggestedRoute(routeId){
+      if(!routeId) return;
+      if(selectedRouteSuggestionIds.delete(routeId)){
+        selectedRouteSuggestionOrder = selectedRouteSuggestionOrder.filter(id => id !== routeId);
+      }
+    }
+
+    function applyRouteSuggestionFilters(recommendations){
+      if(!Array.isArray(recommendations) || !recommendations.length) return [];
+      const term = routeSuggestionFilters.search ? routeSuggestionFilters.search.trim().toLowerCase() : '';
+      return recommendations.filter(entry => {
+        const route = entry?.route;
+        if(!route) return false;
+        if(!routeSuggestionFilters.showCompleted && isRouteComplete(route)){
+          return false;
+        }
+        if(routeSuggestionFilters.types.size){
+          const type = classifyRouteGuideType(route);
+          if(!routeSuggestionFilters.types.has(type)){
+            return false;
+          }
+        }
+        if(term){
+          const haystack = [
+            route.title,
+            route.category,
+            route.progression_role,
+            Array.isArray(route.tags) ? route.tags.join(' ') : '',
+            Array.isArray(route.objectives) ? route.objectives.join(' ') : ''
+          ].join(' ').toLowerCase();
+          if(!haystack.includes(term)){
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+
+    function updateRouteSuggestionCardStates(){
+      const list = document.getElementById('routeSuggestionsList');
+      if(!list) return;
+      list.querySelectorAll('[data-suggestion-route]').forEach(card => {
+        const id = card.dataset.suggestionRoute;
+        const selected = selectedRouteSuggestionIds.has(id);
+        card.classList.toggle('route-suggestion-card--selected', selected);
+        card.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        const cta = card.querySelector('[data-role="suggestion-cta"]');
+        if(cta){
+          cta.textContent = routeSuggestionCtaLabel(selected);
+        }
+      });
+    }
+
     function renderRouteSuggestions(recommendations){
       const card = document.getElementById('routeSuggestionsCard');
       const list = card ? card.querySelector('#routeSuggestionsList') : null;
-      const detail = card ? card.querySelector('#routeSuggestionDetail') : null;
       if(routeSuggestionsAbort){
         routeSuggestionsAbort.abort();
       }
-      const entries = Array.isArray(recommendations) ? recommendations.slice(0, 3) : [];
+      const filtered = applyRouteSuggestionFilters(recommendations);
+      const entries = filtered.slice(0, 6);
       currentRouteSuggestionEntries = entries;
+      const availableIds = new Set(entries.map(entry => entry?.route?.id).filter(Boolean));
+      selectedRouteSuggestionOrder = selectedRouteSuggestionOrder.filter(id => availableIds.has(id));
+      Array.from(selectedRouteSuggestionIds).forEach(id => {
+        if(!availableIds.has(id)){
+          selectedRouteSuggestionIds.delete(id);
+        }
+      });
+      if(!selectedRouteSuggestionIds.size && entries.length){
+        const firstId = entries[0].route?.id;
+        if(firstId){
+          selectSuggestedRoute(firstId);
+        }
+      }
       if(!entries.length){
-        activeSuggestedRouteId = null;
         if(list){
           list.innerHTML = `<p class="route-suggestions__empty">${escapeHTML(kidMode
             ? 'Adjust the context above to unlock personalised picks.'
             : 'Fine-tune the context above to surface tailored paths.')}</p>`;
         }
-        if(detail){
-          detail.innerHTML = `<p class="route-suggestions__placeholder">${escapeHTML(kidMode
-            ? 'Highlight a suggestion to preview the guide here.'
-            : 'Highlight a suggestion to preview the full walkthrough here.')}</p>`;
-          detail.removeAttribute('data-chapter-id');
-          detail.removeAttribute('data-route-id');
-          ['--route-suggestion-image', '--route-suggestion-overlay', '--route-suggestion-accent', '--route-suggestion-position'].forEach(prop => detail.style.removeProperty(prop));
-        }
+        renderRouteSelectionPanel();
         return 0;
       }
-      if(activeSuggestedRouteId && !entries.some(entry => entry.route.id === activeSuggestedRouteId)){
-        activeSuggestedRouteId = null;
-      }
-      if(!activeSuggestedRouteId){
-        activeSuggestedRouteId = entries[0].route.id;
-      }
       if(list){
-        list.innerHTML = entries.map(entry => renderRouteSuggestionCard(entry, entry.route.id === activeSuggestedRouteId)).join('');
+        list.innerHTML = entries.map(entry => renderRouteSuggestionCard(entry, selectedRouteSuggestionIds.has(entry.route.id))).join('');
       }
       routeSuggestionsAbort = new AbortController();
       const { signal } = routeSuggestionsAbort;
       if(list){
-        const handleSelect = event => {
+        list.addEventListener('click', event => {
           const cardEl = event.target.closest('[data-suggestion-route]');
           if(!cardEl) return;
           const routeId = cardEl.dataset.suggestionRoute;
-          const entry = currentRouteSuggestionEntries.find(item => item.route.id === routeId);
-          if(entry){
-            setActiveRouteSuggestion(routeId, entry);
+          if(!routeId) return;
+          if(selectedRouteSuggestionIds.has(routeId)){
+            deselectSuggestedRoute(routeId);
+          } else {
+            selectSuggestedRoute(routeId);
           }
-        };
-        list.addEventListener('click', handleSelect, { signal });
-        list.addEventListener('mouseenter', handleSelect, { signal });
-        list.addEventListener('focusin', handleSelect, { signal });
-      }
-      if(detail){
-        const detailHandler = event => {
-          const routeBtn = event.target.closest('[data-route-focus]');
-          if(routeBtn){
-            event.preventDefault();
-            const routeId = routeBtn.dataset.routeFocus;
-            const route = routeGuideData?.routeLookup?.[routeId];
-            const nextStep = route ? findFirstIncompleteStepForRoute(route, { includeOptional: true }) : null;
-            if(nextStep){
-              queueRouteFocus(nextStep.id);
-            } else if(route && route.chapter?.steps?.[0]){
-              queueRouteFocus(route.chapter.steps[0].id);
+          if(!selectedRouteSuggestionIds.size && entries.length){
+            const fallbackId = entries[0].route?.id;
+            if(fallbackId){
+              selectSuggestedRoute(fallbackId);
             }
-            switchPage('route');
-            playSound(clickSound);
-            return;
           }
-          const stepBtn = event.target.closest('[data-step-focus]');
-          if(stepBtn){
-            event.preventDefault();
-            const stepId = stepBtn.dataset.stepFocus;
-            if(stepId){
-              queueRouteFocus(stepId);
-              switchPage('route');
-              playSound(clickSound);
-            }
-            return;
-          }
-          handleRouteClick(event);
-        };
-        detail.addEventListener('click', detailHandler, { signal });
-        detail.addEventListener('change', handleRouteCheckboxChange, { signal });
+          updateRouteSuggestionCardStates();
+          renderRouteSelectionPanel();
+          playSound(clickSound);
+        }, { signal });
       }
-      setActiveRouteSuggestion(activeSuggestedRouteId, entries.find(entry => entry.route.id === activeSuggestedRouteId));
+      updateRouteSuggestionCardStates();
+      renderRouteSelectionPanel();
       return entries.length;
     }
 
-    function setActiveRouteSuggestion(routeId, entry){
-      if(!routeId) return;
-      activeSuggestedRouteId = routeId;
-      const list = document.getElementById('routeSuggestionsList');
-      if(list){
-        list.querySelectorAll('[data-suggestion-route]').forEach(card => {
-          const isActive = card.dataset.suggestionRoute === routeId;
-          card.classList.toggle('route-suggestion-card--active', isActive);
-          card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
-      }
-      const targetEntry = entry || currentRouteSuggestionEntries.find(item => item.route.id === routeId);
-      if(targetEntry){
-        renderRouteSuggestionDetail(targetEntry);
-      }
-    }
-
-    function renderRouteSuggestionDetail(entry){
-      const detail = document.getElementById('routeSuggestionDetail');
-      if(!detail) return;
-      if(!entry || !entry.route){
-        detail.innerHTML = `<p class="route-suggestions__placeholder">${escapeHTML(kidMode
-          ? 'Highlight a suggestion to preview the guide here.'
-          : 'Highlight a suggestion to preview the full walkthrough here.')}</p>`;
-        detail.removeAttribute('data-chapter-id');
-        detail.removeAttribute('data-route-id');
-        ['--route-suggestion-image', '--route-suggestion-overlay', '--route-suggestion-accent', '--route-suggestion-position'].forEach(prop => detail.style.removeProperty(prop));
-        return;
-      }
+    function renderRouteSuggestionCard(entry, selected){
       const route = entry.route;
       const art = routeArtFor(route);
-      detail.dataset.chapterId = route.chapter?.id || '';
-      detail.dataset.routeId = route.id || '';
-      detail.style.setProperty('--route-suggestion-image', `url('${art.image}')`);
-      detail.style.setProperty('--route-suggestion-overlay', art.overlay);
-      detail.style.setProperty('--route-suggestion-accent', art.accent);
-      detail.style.setProperty('--route-suggestion-position', art.position);
+      const breakdown = routeProgressBreakdown(route);
+      const overallPct = breakdown.total
+        ? Math.round((breakdown.totalDone / breakdown.total) * 100)
+        : (breakdown.requiredTotal ? Math.round((breakdown.requiredDone / breakdown.requiredTotal) * 100) : 0);
+      const range = route?.recommended_level || {};
+      const rangeLabel = (range.min != null || range.max != null)
+        ? `Lv ${range.min != null ? range.min : '?'}-${range.max != null ? range.max : '?'}`
+        : '';
+      const risk = route?.risk_profile ? `${capitalize(route.risk_profile)} risk` : '';
+      const timeLabel = formatTimeLabel(route?.estimated_time_minutes) || '';
+      const metaParts = [rangeLabel, risk, timeLabel].filter(Boolean);
+      const metaLine = metaParts.length ? metaParts.join(' • ') : '';
+      const reasonHighlight = Array.isArray(entry.reasons) && entry.reasons.length
+        ? entry.reasons[0]
+        : (kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.');
+      const scoreLabel = typeof entry.score === 'number' ? entry.score.toFixed(1) : '';
+      const iconAlt = art.iconAlt || art.iconLabel || (kidMode ? 'Adventure icon' : 'Guide icon');
+      return `
+        <button type="button" class="route-suggestion-card${selected ? ' route-suggestion-card--selected' : ''}" data-suggestion-route="${escapeHTML(route.id)}" aria-pressed="${selected ? 'true' : 'false'}">
+          <div class="route-suggestion-card__body">
+            <div class="route-suggestion-card__top">
+              <span class="route-suggestion-card__picture"><img src="${escapeHTML(art.iconImage)}" alt="${escapeHTML(iconAlt)}"></span>
+              <div class="route-suggestion-card__text">
+                <h4 class="route-suggestion-card__title">${escapeHTML(route.title)}</h4>
+                ${metaLine ? `<p class="route-suggestion-card__meta">${escapeHTML(metaLine)}</p>` : ''}
+              </div>
+              ${scoreLabel ? `<span class="route-suggestion-card__score">${escapeHTML(scoreLabel)}</span>` : ''}
+            </div>
+            <div class="route-suggestion-card__progress">
+              <div class="route-suggestion-card__progress-bar"><span style="width:${overallPct}%"></span></div>
+              <span class="route-suggestion-card__progress-label">${escapeHTML(kidMode ? `${overallPct}% ready` : `${overallPct}% complete`)}</span>
+            </div>
+            <p class="route-suggestion-card__reason">${escapeHTML(reasonHighlight)}</p>
+            <span class="route-suggestion-card__cta" data-role="suggestion-cta">${escapeHTML(routeSuggestionCtaLabel(selected))}</span>
+          </div>
+        </button>
+      `;
+    }
+
+    function renderRouteSelectionPanel(){
+      const detail = document.getElementById('routeSuggestionDetail');
+      if(!detail) return;
+      const entryMap = new Map((currentRouteSuggestionEntries || []).map(entry => [entry?.route?.id, entry]));
+      const selectedEntries = selectedRouteSuggestionOrder
+        .map(id => entryMap.get(id))
+        .filter(entry => entry && entry.route);
+      if(!selectedEntries.length){
+        detail.innerHTML = `<p class="route-suggestions__placeholder">${escapeHTML(kidMode
+          ? 'Tap the cards to pin adventures here.'
+          : 'Select the cards to pin guides here.')}</p>`;
+        detail.removeAttribute('data-chapter-id');
+        detail.removeAttribute('data-route-id');
+        return;
+      }
+      detail.innerHTML = selectedEntries.map(renderRouteSelectionCard).join('');
+    }
+
+    function renderRouteSelectionCard(entry){
+      const route = entry.route;
+      if(!route) return '';
+      const art = routeArtFor(route);
       const breakdown = routeProgressBreakdown(route);
       const requiredLabel = breakdown.requiredTotal
         ? `${breakdown.requiredDone}/${breakdown.requiredTotal} ${kidMode ? 'big steps' : 'required'}`
@@ -10067,73 +10231,222 @@
         ? entry.reasons.slice(0, 3).map(reason => `<li>${escapeHTML(reason)}</li>`).join('')
         : '';
       const reasonsHtml = reasons
-        ? `<ul class="route-suggestion-detail__reasons">${reasons}</ul>`
-        : `<p class="route-suggestion-detail__reason">${escapeHTML(kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.')}</p>`;
+        ? `<ul class="route-selection__reasons">${reasons}</ul>`
+        : `<p class="route-selection__reason">${escapeHTML(kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.')}</p>`;
       const focusStep = entry.nextStepId || (findFirstIncompleteStepForRoute(route, { includeOptional: true })?.id || '');
       const roleLabel = route.progression_role ? capitalize(route.progression_role) : capitalize(route.category || 'route');
       const stepButton = focusStep
         ? `<button type="button" class="btn" data-step-focus="${escapeHTML(focusStep)}">${escapeHTML(kidMode ? 'Jump to this step' : 'Jump to this step')}</button>`
         : '';
-      detail.innerHTML = `
-        <div class="route-suggestion-detail__hero">
-          <div class="route-suggestion-detail__badge">${escapeHTML(roleLabel)}</div>
-          <h4 class="route-suggestion-detail__title">${escapeHTML(route.title)}</h4>
-          ${metaLine ? `<p class="route-suggestion-detail__meta">${escapeHTML(metaLine)}</p>` : ''}
-          <div class="route-suggestion-detail__progress">
-            <div class="route-suggestion-detail__progress-bar"><span style="width:${overallPct}%"></span></div>
-            <span class="route-suggestion-detail__progress-label">${escapeHTML(progressLabel)}</span>
+      const overlay = art.overlay || 'rgba(8, 16, 32, 0.85)';
+      const accent = art.accent || '#9bd4ff';
+      const position = art.position || 'center 50%';
+      const iconAlt = art.iconAlt || art.iconLabel || (kidMode ? 'Adventure icon' : 'Guide icon');
+      const style = `--route-selection-image: url('${art.image}'); --route-selection-overlay: ${overlay}; --route-selection-accent: ${accent}; --route-selection-position: ${position};`;
+      return `
+        <article class="route-selection" data-route-id="${escapeHTML(route.id)}" style="${escapeHTML(style)}">
+          <header class="route-selection__hero">
+            <div class="route-selection__heading">
+              <span class="route-selection__icon"><img src="${escapeHTML(art.iconImage)}" alt="${escapeHTML(iconAlt)}"></span>
+              <div class="route-selection__title">
+                <span class="route-selection__badge">${escapeHTML(roleLabel)}</span>
+                <h4>${escapeHTML(route.title)}</h4>
+                ${metaLine ? `<p class="route-selection__meta">${escapeHTML(metaLine)}</p>` : ''}
+              </div>
+              <button type="button" class="route-selection__remove" data-selection-remove="${escapeHTML(route.id)}" aria-label="${escapeHTML(kidMode ? 'Remove adventure' : 'Remove guide')}">&times;</button>
+            </div>
+            <div class="route-selection__progress">
+              <div class="route-selection__progress-bar"><span style="width:${overallPct}%"></span></div>
+              <span class="route-selection__progress-label">${escapeHTML(progressLabel)}</span>
+            </div>
+            ${reasonsHtml}
+            <div class="route-selection__actions">
+              <button type="button" class="btn" data-route-focus="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Open full guide' : 'Open full guide')}</button>
+              ${stepButton}
+            </div>
+          </header>
+          <div class="route-selection__body" data-chapter-id="${escapeHTML(route.chapter?.id || '')}">
+            ${renderSteps(route.chapter, route)}
           </div>
-          ${reasonsHtml}
-          <div class="route-suggestion-detail__actions">
-            <button type="button" class="btn" data-route-focus="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Open full guide' : 'Open full guide')}</button>
-            ${stepButton}
-          </div>
-        </div>
-        <div class="route-suggestion-detail__body" data-chapter-id="${escapeHTML(route.chapter?.id || '')}">
-          ${renderSteps(route.chapter, route)}
-        </div>
+        </article>
       `;
     }
 
-    function renderRouteSuggestionCard(entry, active){
-      const route = entry.route;
-      const art = routeArtFor(route);
-      const breakdown = routeProgressBreakdown(route);
-      const overallPct = breakdown.total
-        ? Math.round((breakdown.totalDone / breakdown.total) * 100)
-        : (breakdown.requiredTotal ? Math.round((breakdown.requiredDone / breakdown.requiredTotal) * 100) : 0);
-      const range = route?.recommended_level || {};
-      const rangeLabel = (range.min != null || range.max != null)
-        ? `Lv ${range.min != null ? range.min : '?'}-${range.max != null ? range.max : '?'}`
-        : '';
-      const risk = route?.risk_profile ? `${capitalize(route.risk_profile)} risk` : '';
-      const timeLabel = formatTimeLabel(route?.estimated_time_minutes) || '';
-      const metaParts = [rangeLabel, risk, timeLabel].filter(Boolean);
-      const metaLine = metaParts.length ? metaParts.join(' • ') : '';
-      const reasonHighlight = Array.isArray(entry.reasons) && entry.reasons.length
-        ? entry.reasons[0]
-        : (kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.');
-      const style = `--route-suggestion-image: url('${art.image}'); --route-suggestion-overlay: ${art.overlay}; --route-suggestion-accent: ${art.accent}; --route-suggestion-position: ${art.position};`;
-      const scoreLabel = typeof entry.score === 'number' ? entry.score.toFixed(1) : '';
-      return `
-        <button type="button" class="route-suggestion-card${active ? ' route-suggestion-card--active' : ''}" data-suggestion-route="${escapeHTML(route.id)}" aria-pressed="${active ? 'true' : 'false'}" style="${escapeHTML(style)}">
-          <div class="route-suggestion-card__body">
-            <div class="route-suggestion-card__top">
-              <span class="route-suggestion-card__icon"><i class="fa-solid ${escapeHTML(art.icon)}"></i></span>
-              <div class="route-suggestion-card__text">
-                <h4 class="route-suggestion-card__title">${escapeHTML(route.title)}</h4>
-                ${metaLine ? `<p class="route-suggestion-card__meta">${escapeHTML(metaLine)}</p>` : ''}
-              </div>
-              ${scoreLabel ? `<span class="route-suggestion-card__score">${escapeHTML(scoreLabel)}</span>` : ''}
-            </div>
-            <div class="route-suggestion-card__progress">
-              <div class="route-suggestion-card__progress-bar"><span style="width:${overallPct}%"></span></div>
-              <span class="route-suggestion-card__progress-label">${escapeHTML(kidMode ? `${overallPct}% ready` : `${overallPct}% complete`)}</span>
-            </div>
-            <p class="route-suggestion-card__reason">${escapeHTML(reasonHighlight)}</p>
-          </div>
-        </button>
+    function bindRouteSelectionPanel(){
+      const detail = document.getElementById('routeSuggestionDetail');
+      if(!detail || detail.dataset.bound) return;
+      detail.addEventListener('click', event => {
+        const removeBtn = event.target.closest('[data-selection-remove]');
+        if(removeBtn){
+          const routeId = removeBtn.dataset.selectionRemove;
+          deselectSuggestedRoute(routeId);
+          if(!selectedRouteSuggestionIds.size && currentRouteSuggestionEntries.length){
+            const fallback = currentRouteSuggestionEntries[0]?.route?.id;
+            if(fallback){
+              selectSuggestedRoute(fallback);
+            }
+          }
+          updateRouteSuggestionCardStates();
+          renderRouteSelectionPanel();
+          playSound(clickSound);
+          event.preventDefault();
+          return;
+        }
+        const routeBtn = event.target.closest('[data-route-focus]');
+        if(routeBtn){
+          event.preventDefault();
+          const routeId = routeBtn.dataset.routeFocus;
+          const route = routeGuideData?.routeLookup?.[routeId];
+          const nextStep = route ? findFirstIncompleteStepForRoute(route, { includeOptional: true }) : null;
+          if(nextStep){
+            queueRouteFocus(nextStep.id);
+          } else if(route && route.chapter?.steps?.[0]){
+            queueRouteFocus(route.chapter.steps[0].id);
+          }
+          switchPage('route');
+          playSound(clickSound);
+          return;
+        }
+        const stepBtn = event.target.closest('[data-step-focus]');
+        if(stepBtn){
+          event.preventDefault();
+          const stepId = stepBtn.dataset.stepFocus;
+          if(stepId){
+            queueRouteFocus(stepId);
+          }
+          switchPage('route');
+          playSound(clickSound);
+          return;
+        }
+        handleRouteClick(event);
+      });
+      detail.addEventListener('change', handleRouteCheckboxChange);
+      detail.dataset.bound = 'true';
+    }
+
+    function renderRouteSuggestionFiltersUI(){
+      const container = document.getElementById('routeSuggestionsFilters');
+      if(!container) return;
+      const labelText = kidMode ? 'Adventure types' : 'Guide types';
+      const showCompletedText = kidMode ? 'Include finished guides' : 'Include completed guides';
+      const searchPlaceholder = kidMode ? 'Search for a guide' : 'Search guides';
+      const chips = ROUTE_SUGGESTION_TYPE_ORDER.map(type => {
+        const info = ROUTE_ICON_LIBRARY[type] || {};
+        const chipLabel = kidMode ? (info.kidLabel || capitalize(type)) : (info.adultLabel || capitalize(type));
+        const image = info.image || (ROUTE_ICON_LIBRARY.pal ? ROUTE_ICON_LIBRARY.pal.image : 'assets/images/route-icons/pal.svg');
+        const alt = `${chipLabel} icon`;
+        return `
+          <button type="button" class="route-type-chip" data-suggestion-type="${escapeHTML(type)}" aria-pressed="false">
+            <span class="route-type-chip__art"><img src="${escapeHTML(image)}" alt="${escapeHTML(alt)}"></span>
+            <span class="route-type-chip__label">${escapeHTML(chipLabel)}</span>
+          </button>`;
+      }).join('');
+      container.innerHTML = `
+        <div class="route-suggestions__filter-group">
+          <span class="route-suggestions__filter-label">${escapeHTML(labelText)}</span>
+          <div class="route-type-chip-row">${chips}</div>
+        </div>
+        <div class="route-suggestions__filter-bar">
+          <label class="route-suggestions__toggle">
+            <input type="checkbox" id="routeSuggestionShowCompleted" />
+            <span>${escapeHTML(showCompletedText)}</span>
+          </label>
+          <label class="route-suggestions__search">
+            <span class="sr-only">${escapeHTML(kidMode ? 'Search adventures' : 'Search guides')}</span>
+            <input type="search" id="routeSuggestionSearch" placeholder="${escapeHTML(searchPlaceholder)}" autocomplete="off" />
+          </label>
+        </div>
       `;
+      if(!container.dataset.bound){
+        container.addEventListener('click', handleRouteSuggestionFilterClick);
+        container.addEventListener('change', handleRouteSuggestionFilterChange);
+        container.addEventListener('input', handleRouteSuggestionFilterInput);
+        container.dataset.bound = 'true';
+      }
+      updateRouteSuggestionFilterUI();
+    }
+
+    function updateRouteSuggestionFilterUI(){
+      const container = document.getElementById('routeSuggestionsFilters');
+      if(!container) return;
+      container.querySelectorAll('[data-suggestion-type]').forEach(button => {
+        const type = button.dataset.suggestionType;
+        const active = routeSuggestionFilters.types.has(type);
+        button.classList.toggle('route-type-chip--active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        const info = ROUTE_ICON_LIBRARY[type] || {};
+        const chipLabel = kidMode ? (info.kidLabel || capitalize(type)) : (info.adultLabel || capitalize(type));
+        const labelNode = button.querySelector('.route-type-chip__label');
+        if(labelNode){
+          labelNode.textContent = chipLabel;
+        }
+      });
+      const labelText = kidMode ? 'Adventure types' : 'Guide types';
+      const label = container.querySelector('.route-suggestions__filter-label');
+      if(label){
+        label.textContent = labelText;
+      }
+      const toggle = container.querySelector('#routeSuggestionShowCompleted');
+      if(toggle){
+        toggle.checked = !!routeSuggestionFilters.showCompleted;
+        const toggleLabel = toggle.parentElement?.querySelector('span');
+        if(toggleLabel){
+          toggleLabel.textContent = kidMode ? 'Include finished guides' : 'Include completed guides';
+        }
+      }
+      const search = container.querySelector('#routeSuggestionSearch');
+      if(search){
+        const { selectionStart, selectionEnd } = search;
+        search.value = routeSuggestionFilters.search || '';
+        search.placeholder = kidMode ? 'Search for a guide' : 'Search guides';
+        if(document.activeElement === search && selectionStart != null && selectionEnd != null){
+          search.setSelectionRange(selectionStart, selectionEnd);
+        }
+      }
+    }
+
+    function handleRouteSuggestionFilterClick(event){
+      const button = event.target.closest('[data-suggestion-type]');
+      if(!button) return;
+      event.preventDefault();
+      const type = button.dataset.suggestionType;
+      if(!type) return;
+      if(routeSuggestionFilters.types.has(type)){
+        routeSuggestionFilters.types.delete(type);
+      } else {
+        routeSuggestionFilters.types.add(type);
+      }
+      playSound(clickSound);
+      reapplyRouteSuggestionFilters();
+    }
+
+    function handleRouteSuggestionFilterChange(event){
+      const target = event.target;
+      if(target && target.id === 'routeSuggestionShowCompleted'){
+        routeSuggestionFilters.showCompleted = target.checked;
+        reapplyRouteSuggestionFilters();
+      }
+    }
+
+    let routeSuggestionSearchFrame = null;
+    function handleRouteSuggestionFilterInput(event){
+      const target = event.target;
+      if(!target || target.id !== 'routeSuggestionSearch') return;
+      routeSuggestionFilters.search = target.value || '';
+      if(routeSuggestionSearchFrame){
+        cancelAnimationFrame(routeSuggestionSearchFrame);
+      }
+      routeSuggestionSearchFrame = requestAnimationFrame(() => {
+        reapplyRouteSuggestionFilters();
+        routeSuggestionSearchFrame = null;
+      });
+    }
+
+    function reapplyRouteSuggestionFilters(){
+      updateRouteSuggestionFilterUI();
+      const recommendations = Array.isArray(currentRouteRecommendations) ? currentRouteRecommendations : [];
+      const suggestionCount = renderRouteSuggestions(recommendations);
+      renderRouteRecommendationsList(recommendations, { offset: suggestionCount });
     }
 
     function hashString(value){
@@ -10254,15 +10567,24 @@
               <h3>${kidMode ? 'Tonight’s Adventure Paths' : 'Suggested Adventure Paths'}</h3>
               <p class="route-suggestions__intro">${escapeHTML(suggestionsLead)}</p>
             </div>
-            <div class="route-suggestions__list" id="routeSuggestionsList">
-              <p class="route-suggestions__empty">${escapeHTML(kidMode
-                ? 'Adjust the context above to unlock personalised picks.'
-                : 'Fine-tune the context above to surface tailored paths.')}</p>
-            </div>
-            <div class="route-suggestions__detail" id="routeSuggestionDetail">
-              <p class="route-suggestions__placeholder">${escapeHTML(kidMode
-                ? 'Highlight a suggestion to preview the guide here.'
-                : 'Highlight a suggestion to preview the full walkthrough here.')}</p>
+            <div class="route-suggestions__workspace">
+              <aside class="route-suggestions__filters" id="routeSuggestionsFilters">
+                <p class="route-suggestions__filters-empty">${escapeHTML(kidMode
+                  ? 'Loading adventure types…'
+                  : 'Loading adventure filters…')}</p>
+              </aside>
+              <div class="route-suggestions__content">
+                <div class="route-suggestions__list" id="routeSuggestionsList">
+                  <p class="route-suggestions__empty">${escapeHTML(kidMode
+                    ? 'Adjust the context above to unlock personalised picks.'
+                    : 'Fine-tune the context above to surface tailored paths.')}</p>
+                </div>
+                <div class="route-suggestions__selection" id="routeSuggestionDetail">
+                  <p class="route-suggestions__placeholder">${escapeHTML(kidMode
+                    ? 'Tap the cards to pin adventures here.'
+                    : 'Select the cards to pin guides here.')}</p>
+                </div>
+              </div>
             </div>
           </section>
           <section class="card route-recommendations-card" id="routeRecommendationsCard">
@@ -10270,7 +10592,12 @@
               <h3>${kidMode ? 'More adventures to consider' : 'More adaptive picks'}</h3>
               <p class="route-recommendations__intro">${escapeHTML(recommendationLead)}</p>
             </div>
-            <div id="routeRecommendationsList" class="route-recommendations__list"></div>
+            <details class="route-recommendations__collapsible" id="routeRecommendationsDetails">
+              <summary><span id="routeRecommendationsSummaryLabel">${escapeHTML(kidMode
+                ? 'Browse the full adventure library'
+                : 'Browse the full guide library')}</span></summary>
+              <div id="routeRecommendationsList" class="route-recommendations__list"></div>
+            </details>
           </section>
           <section class="card route-controls">
             <p class="route-controls__lead">${escapeHTML(kidMode
@@ -10286,11 +10613,13 @@
         `;
           const wrap = node.querySelector('#routeChapters');
           routes.forEach((route, idx) => {
-            wrap.appendChild(renderChapterCard(route.chapter, idx === 0, route));
+          wrap.appendChild(renderChapterCard(route.chapter, idx === 0, route));
           });
           wrap.addEventListener('change', handleRouteCheckboxChange);
           wrap.addEventListener('click', handleRouteClick);
           bindRouteActionButtons();
+          renderRouteSuggestionFiltersUI();
+          bindRouteSelectionPanel();
           renderRouteFiltersUI(summary.categories);
           applyQueuedRouteFocus();
           refreshRouteIntelligenceUI({ summary, levelEstimate, recommendations });
@@ -10518,10 +10847,34 @@
     let routeRecommendationsAbort = null;
 
     function renderRouteRecommendationsList(recommendations, { offset = 0 } = {}){
-      const list = document.getElementById('routeRecommendationsList');
+      const card = document.getElementById('routeRecommendationsCard');
+      const list = card ? card.querySelector('#routeRecommendationsList') : null;
+      const details = card ? card.querySelector('#routeRecommendationsDetails') : null;
+      const summaryLabel = card ? card.querySelector('#routeRecommendationsSummaryLabel') : null;
       if(!list) return;
-      if(!Array.isArray(recommendations) || recommendations.length <= offset){
-        list.innerHTML = `<p class="route-recommendations__empty">${escapeHTML(kidMode ? 'Set your level or add goals to see suggestions.' : 'Adjust your context to surface tailored recommendations.')}</p>`;
+      const totalRemaining = Array.isArray(recommendations) ? Math.max(0, recommendations.length - offset) : 0;
+      if(summaryLabel){
+        if(totalRemaining > 0){
+          const noun = totalRemaining === 1 ? (kidMode ? 'adventure' : 'guide') : (kidMode ? 'adventures' : 'guides');
+          summaryLabel.textContent = kidMode
+            ? `Browse ${totalRemaining} more ${noun}`
+            : `Browse ${totalRemaining} more ${noun}`;
+        } else {
+          summaryLabel.textContent = kidMode
+            ? 'No other adventures right now'
+            : 'No additional guides right now';
+        }
+      }
+      if(details){
+        if(totalRemaining > 0){
+          details.removeAttribute('data-empty');
+        } else {
+          details.setAttribute('data-empty', 'true');
+          details.open = false;
+        }
+      }
+      if(totalRemaining <= 0){
+        list.innerHTML = `<p class="route-recommendations__empty">${escapeHTML(kidMode ? 'Set your level or add goals to unlock more adventures.' : 'Adjust your context to surface additional guides.')}</p>`;
       } else {
         const cards = recommendations.slice(offset, offset + 5).map(renderRouteRecommendation).join('');
         list.innerHTML = cards;
@@ -10552,6 +10905,7 @@
 
     function renderRouteRecommendation(entry){
       const route = entry.route;
+      const art = routeArtFor(route);
       const range = route?.recommended_level || {};
       const rangeLabel = (range.min != null || range.max != null)
         ? `Lv ${range.min != null ? range.min : '?'}-${range.max != null ? range.max : '?'}`
@@ -10568,13 +10922,17 @@
         ? `<ul class="route-recommendation__reasons">${entry.reasons.map(reason => `<li>${escapeHTML(reason)}</li>`).join('')}</ul>`
         : `<p class="route-recommendation__fallback">${escapeHTML(kidMode ? 'Palmate picked this route for balanced fun and progress.' : 'Palmate selected this route based on your context.')}</p>`;
       const focusStep = entry.nextStepId || route?.chapter?.steps?.[0]?.id || '';
+      const iconAlt = art.iconAlt || art.iconLabel || (kidMode ? 'Adventure icon' : 'Guide icon');
       return `
         <article class="route-recommendation" data-route-id="${escapeHTML(route.id)}">
           <div class="route-recommendation__header">
-            <div>
-              <h4>${escapeHTML(route.title)}</h4>
-              ${metaLine ? `<p class="route-recommendation__meta">${escapeHTML(metaLine)}</p>` : ''}
-              ${tags}
+            <div class="route-recommendation__title">
+              <span class="route-recommendation__icon"><img src="${escapeHTML(art.iconImage)}" alt="${escapeHTML(iconAlt)}"></span>
+              <div class="route-recommendation__text">
+                <h4>${escapeHTML(route.title)}</h4>
+                ${metaLine ? `<p class="route-recommendation__meta">${escapeHTML(metaLine)}</p>` : ''}
+                ${tags}
+              </div>
             </div>
             ${scoreLabel ? `<div class="route-recommendation__score">${escapeHTML(scoreLabel)}</div>` : ''}
           </div>


### PR DESCRIPTION
## Summary
- redesign the route suggestions panel with a two-column workspace and pinboard-style selection area
- add guide classification, icon artwork, and filter controls so users can target pals, bosses, tech, npc, or item routes
- refresh styling of suggestion cards and recommendation list, including collapsible overflow and friendlier kid-mode labels

## Testing
- Manually opened `index.html` in a browser

------
https://chatgpt.com/codex/tasks/task_e_68dc2b299fc883319647de123a2fa641