### PR TITLE
Refine route planner layout and styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -75,23 +75,37 @@ gba(119,141,169,0.45)}
 .pulse{animation:pulse 1.2s ease-out 1}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(105,228,166,.8)}100%{box-shadow:0 0 0 14px rgba(105,228,166,0)}}
 
-.route-card{display:grid;gap:18px}
-.route-card__header{display:flex;justify-content:space-between;gap:18px;flex-wrap:wrap}
-.route-card__title{display:grid;gap:6px;max-width:640px}
-.route-card__title h3{margin:0}
-.route-card__why{margin:0;color:var(--muted,rgba(224,225,221,0.7));font-size:.95rem}
-.route-card__meta{display:flex;flex-wrap:wrap;gap:8px}
-.route-meta-chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;background:rgba(119,141,169,0.18);border:1px solid rgba(119,141,169,0.35);color:var(--light,#e0e1dd)}
-.route-meta-chip--tag{background:rgba(91,146,255,0.18);border-color:rgba(91,146,255,0.35)}
-.route-meta-chip--high{background:rgba(231,111,81,0.22);border-color:rgba(231,111,81,0.45)}
-.route-meta-chip--medium{background:rgba(255,196,77,0.22);border-color:rgba(255,196,77,0.4)}
-.route-meta-chip--low{background:rgba(105,228,166,0.22);border-color:rgba(105,228,166,0.45)}
-.route-card__progress{min-width:220px}
-.route-card__details{background:rgba(8,16,32,0.65);border:1px solid rgba(119,141,169,0.25);border-radius:16px;padding:14px;box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}
-.route-card__toggle{width:100%;justify-content:center}
-.route-card__actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px}
-.route-card__complete{margin-left:auto;font-weight:600;color:var(--success,#2a9d8f)}
-.route-steps-empty{margin:0;color:var(--muted,rgba(224,225,221,0.7));font-style:italic}
+.route-layout{display:grid;gap:24px}
+@media (min-width:1100px){.route-layout{grid-template-columns:minmax(320px,0.9fr) minmax(0,1.1fr);align-items:flex-start}}
+.route-card{display:grid;gap:22px}
+.route-card__header{display:flex;justify-content:space-between;gap:22px;flex-wrap:wrap;align-items:flex-start}
+.route-card__info{display:flex;align-items:flex-start;gap:18px;flex:1 1 360px;min-width:0}
+.route-card__thumb{position:relative;flex:0 0 104px;width:104px;height:104px;border-radius:22px;overflow:hidden;background:rgba(8,16,32,0.86);box-shadow:0 22px 46px rgba(0,0,0,0.55)}
+.route-card__thumb::before{content:"";position:absolute;inset:0;background-image:linear-gradient(155deg,var(--route-visual-overlay,rgba(12,24,40,0.78)),rgba(10,20,34,0.92)),var(--route-visual-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-visual-position,center);transition:transform .35s ease}
+.route-card__thumb::after{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:inset 0 0 0 1px rgba(255,255,255,0.06)}
+.route-card:hover .route-card__thumb::before{transform:scale(1.04)}
+.route-card__title{display:grid;gap:8px;min-width:0}
+.route-card__title h3{margin:0;font-size:1.35rem}
+.route-card__label{display:inline-flex;align-items:center;gap:6px;width:max-content;padding:4px 12px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.14);font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;color:rgba(255,255,255,0.82)}
+.route-card__why{margin:0;color:var(--muted,rgba(224,225,221,0.74));font-size:.97rem;line-height:1.45}
+.route-card__meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:4px}
+.route-meta-chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;background:rgba(119,141,169,0.2);border:1px solid rgba(119,141,169,0.42);color:var(--light,#e0e1dd);box-shadow:0 6px 12px rgba(0,0,0,0.25)}
+.route-meta-chip--tag{background:rgba(91,146,255,0.22);border-color:rgba(91,146,255,0.42)}
+.route-meta-chip--high{background:rgba(231,111,81,0.28);border-color:rgba(231,111,81,0.5)}
+.route-meta-chip--medium{background:rgba(255,196,77,0.26);border-color:rgba(255,196,77,0.46)}
+.route-meta-chip--low{background:rgba(105,228,166,0.26);border-color:rgba(105,228,166,0.5)}
+.route-card__toolbar{display:flex;flex-wrap:wrap;gap:12px;justify-content:flex-end;align-items:flex-start;min-width:0}
+.route-card__queue{background:rgba(0,0,0,0.38);border-color:rgba(255,255,255,0.18);color:var(--text,#f0f4f8)}
+.route-card__queue:hover{background:rgba(0,0,0,0.48)}
+.route-card__complete{display:inline-flex;align-items:center;gap:8px;font-weight:700;color:var(--success,#2a9d8f);background:rgba(42,157,143,0.18);border-radius:999px;padding:6px 14px}
+.route-card__progress{padding:16px;border-radius:18px;background:rgba(8,16,32,0.72);border:1px solid rgba(119,141,169,0.26);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.05)}
+.route-card__details{background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.3);border-radius:18px;padding:18px;box-shadow:inset 0 0 0 1px rgba(255,255,255,0.05);display:grid;gap:12px}
+.route-card__toggle{width:100%;justify-content:center;margin-bottom:6px}
+.route-card__actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-top:12px}
+.route-card__actions .btn{flex:1 1 200px}
+.route-steps-empty{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-style:italic;text-align:center;padding:12px 0}
+.route-visual__marker{--route-marker-size:22px;position:absolute;top:50%;left:50%;width:var(--route-marker-size);height:var(--route-marker-size);border-radius:50%;background:radial-gradient(circle at center,var(--route-visual-accent,#9bd4ff)0%,var(--route-visual-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);box-shadow:0 0 0 4px rgba(0,0,0,0.4),0 10px 20px rgba(0,0,0,0.45);transform:translate(-50%,-50%);pointer-events:none}
+.route-card__thumb .route-visual__marker{--route-marker-size:20px}
 
 .step-extra{margin-top:8px;display:grid;gap:10px;font-size:.9rem;color:rgba(224,225,221,0.85)}
 .step-extra__text{margin:0}
@@ -134,6 +148,55 @@ gba(119,141,169,0.45)}
 .route-resource-chip__remove{font-weight:700;font-size:1rem}
 .route-resource-chip:hover{background:rgba(119,141,169,0.32)}
 .route-context__empty{margin:0;font-size:.9rem;color:rgba(224,225,221,0.68)}
+.route-library{display:grid}
+.route-library__details{border-radius:22px;overflow:hidden;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.25);box-shadow:0 20px 44px rgba(0,0,0,0.45)}
+.route-library__summary{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:18px 22px;cursor:pointer;list-style:none}
+.route-library__summary::-webkit-details-marker{display:none}
+.route-library__summary-text{display:grid;gap:6px}
+.route-library__summary-text h3{margin:0;font-size:1.25rem}
+.route-library__summary-text p{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-library__count{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:999px;background:rgba(0,0,0,0.4);font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.85)}
+.route-library__details[open] .route-library__summary{border-bottom:1px solid rgba(255,255,255,0.08);background:rgba(12,24,40,0.78)}
+.route-library__body{display:grid;gap:18px;padding:20px 22px 24px;background:rgba(6,14,26,0.9)}
+.route-library__search{display:flex;align-items:center;gap:12px;padding:0 16px;background:rgba(10,22,40,0.82);border:1px solid rgba(119,141,169,0.28);border-radius:16px}
+.route-library__search input{flex:1;background:transparent;border:none;color:var(--text,#f0f4f8);font-size:1rem;padding:12px 0}
+.route-library__search input:focus-visible{outline:none}
+.route-library__search-icon{color:rgba(224,225,221,0.65);font-size:1rem}
+.route-library__list{display:grid;gap:16px;max-height:420px;overflow:auto;padding-right:4px}
+.route-library__list::-webkit-scrollbar{width:8px}
+.route-library__list::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.35);border-radius:999px}
+.route-library__empty{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:18px 0}
+.route-library-card{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:18px;padding:16px;border-radius:18px;background:rgba(12,24,40,0.74);border:1px solid rgba(119,141,169,0.26);box-shadow:0 18px 36px rgba(0,0,0,0.45);transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease}
+.route-library-card:hover{transform:translateY(-3px);border-color:rgba(255,255,255,0.24);box-shadow:0 24px 42px rgba(0,0,0,0.5)}
+.route-library-card__media{position:relative;width:88px;height:88px;border-radius:20px;overflow:hidden;flex:0 0 auto;background:rgba(8,16,32,0.86);box-shadow:0 18px 34px rgba(0,0,0,0.46)}
+.route-library-card__media::before{content:"";position:absolute;inset:0;background-image:linear-gradient(150deg,var(--route-visual-overlay,rgba(12,24,40,0.8)),rgba(10,20,34,0.9)),var(--route-visual-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:center}
+.route-library-card__media .route-visual__marker{--route-marker-size:16px}
+.route-library-card__body{display:grid;gap:6px;min-width:0}
+.route-library-card__body h4{margin:0;font-size:1.05rem}
+.route-library-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.75)}
+.route-library-card__tags{display:flex;flex-wrap:wrap;gap:6px}
+.route-library-card__tag{background:rgba(119,141,169,0.2);border-color:rgba(119,141,169,0.38);font-size:.75rem}
+.route-library-card__actions{display:flex;flex-direction:column;gap:10px;align-items:flex-end}
+.route-library-card__status{font-size:.85rem;font-weight:600;color:var(--success,#2a9d8f);background:rgba(42,157,143,0.18);padding:4px 12px;border-radius:999px}
+.route-library-card__activate{background:rgba(0,0,0,0.38);border-color:rgba(255,255,255,0.18);color:var(--text,#f0f4f8)}
+.route-library-card__activate:hover{background:rgba(0,0,0,0.48)}
+.route-library-card--complete{border-color:rgba(42,157,143,0.42)}
+.route-library-card--complete .route-library-card__media::after{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:inset 0 0 0 2px rgba(42,157,143,0.45)}
+.route-active-card{display:grid;gap:24px}
+.route-active__header{display:flex;flex-direction:column;gap:16px}
+@media (min-width:900px){.route-active__header{flex-direction:row;justify-content:space-between;align-items:flex-start}}
+.route-active__title{display:grid;gap:6px;max-width:760px}
+.route-active__title h3{margin:0;font-size:1.45rem}
+.route-active__intro{margin:0;font-size:.97rem;color:var(--muted,rgba(224,225,221,0.75));line-height:1.5}
+.route-active__actions{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:flex-start}
+@media (min-width:900px){.route-active__actions{justify-content:flex-end}}
+.route-active__filters{display:grid;gap:14px;padding:16px;border-radius:18px;background:rgba(10,22,40,0.78);border:1px solid rgba(119,141,169,0.26);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.05)}
+.route-active__filters .route-filters__chips{max-width:100%;overflow-x:auto;padding-bottom:4px}
+.route-active__filters .route-filters__chips::-webkit-scrollbar{height:6px}
+.route-active__filters .route-filters__chips::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.45);border-radius:999px}
+.route-active__list{display:grid;gap:22px}
+.route-active__list .card{margin:0}
+.route-active__empty{margin:0;font-size:.97rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:24px 12px}
 
 .route-recommendations-card{display:grid;gap:16px}
 .route-recommendations__header{display:grid;gap:6px}
@@ -158,7 +221,8 @@ gba(119,141,169,0.45)}
 .route-suggestions__list{display:grid;gap:12px}
 @media (min-width:720px){.route-suggestions__list{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}}
 .route-suggestions__empty,.route-suggestions__placeholder{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem;text-align:center;padding:12px}
-.route-suggestion-card{position:relative;display:grid;gap:12px;align-items:flex-start;padding:18px;border-radius:20px;background:rgba(12,24,40,0.75);border:1px solid rgba(119,141,169,0.28);color:var(--text,#f0f4f8);box-shadow:0 20px 36px rgba(0,0,0,0.4);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(12,24,40,0.78)),rgba(12,24,40,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center)}
+.route-suggestion-card{position:relative;display:grid;gap:12px;align-items:flex-start;padding:18px;border-radius:20px;background:rgba(12,24,40,0.75);border:1px solid rgba(119,141,169,0.28);color:var(--text,#f0f4f8);box-shadow:0 20px 36px rgba(0,0,0,0.4);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;overflow:hidden;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(12,24,40,0.78)),rgba(12,24,40,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center)}
+.route-suggestion-card::before{content:"";position:absolute;z-index:0;width:var(--route-suggestion-marker-size,26px);height:var(--route-suggestion-marker-size,26px);border-radius:50%;top:var(--route-suggestion-marker-top,50%);left:var(--route-suggestion-marker-left,50%);transform:translate(-50%,-50%);background:radial-gradient(circle at center,var(--route-suggestion-accent,#9bd4ff)0%,var(--route-suggestion-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);opacity:var(--route-suggestion-marker-opacity,0);box-shadow:0 0 0 5px rgba(0,0,0,0.4),0 16px 30px rgba(0,0,0,0.45);pointer-events:none;transition:opacity .2s ease,transform .2s ease}
 .route-suggestion-card::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.4));pointer-events:none}
 .route-suggestion-card__body{position:relative;z-index:1;display:grid;gap:12px}
 .route-suggestion-card__top{display:flex;align-items:flex-start;gap:12px}
@@ -166,17 +230,22 @@ gba(119,141,169,0.45)}
 .route-suggestion-card__text{display:flex;flex-direction:column;gap:4px}
 .route-suggestion-card__title{margin:0;font-size:1.05rem;line-height:1.2}
 .route-suggestion-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.78)}
+.route-suggestion-card__status{display:inline-flex;align-items:center;gap:6px;margin-top:4px;padding:4px 10px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.18);font-size:.78rem;font-weight:600;color:rgba(255,255,255,0.9);letter-spacing:.06em;text-transform:uppercase}
 .route-suggestion-card__score{margin-left:auto;font-weight:700;font-size:1.1rem;color:var(--route-suggestion-accent,#9bd4ff)}
 .route-suggestion-card__progress{display:flex;align-items:center;gap:10px}
 .route-suggestion-card__progress-bar{flex:1;height:6px;border-radius:999px;background:rgba(255,255,255,0.16);overflow:hidden}
-.route-suggestion-card__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-suggestion-accent,#9bd4ff),rgba(255,255,255,0.85))}
+.route-suggestion-card__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-suggestion-accent,#9bd4ff),rgba(255,255,255,0.85));transition:width .35s ease}
 .route-suggestion-card__progress-label{font-size:.85rem;color:rgba(224,225,221,0.86)}
 .route-suggestion-card__reason{margin:0;font-size:.85rem;color:rgba(224,225,221,0.88)}
 .route-suggestion-card:hover{transform:translateY(-4px);box-shadow:0 26px 48px rgba(0,0,0,0.48);border-color:rgba(255,255,255,0.35)}
 .route-suggestion-card--active{border-color:var(--route-suggestion-accent,#9bd4ff);box-shadow:0 28px 52px rgba(0,0,0,0.52);transform:translateY(-4px)}
 .route-suggestions__detail{position:relative;display:grid;gap:0;border-radius:24px;background:rgba(8,16,32,0.8);border:1px solid rgba(119,141,169,0.28);overflow:hidden;box-shadow:0 26px 52px rgba(0,0,0,0.5)}
-.route-suggestion-detail__hero{position:relative;display:grid;gap:12px;padding:24px;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(8,16,32,0.85)),rgba(8,16,32,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center)}
-.route-suggestion-detail__badge{justify-self:flex-start;padding:6px 12px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.24);font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,0.78)}
+.route-suggestion-detail__hero{position:relative;display:grid;gap:14px;padding:26px;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(8,16,32,0.85)),rgba(8,16,32,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center);overflow:hidden}
+.route-suggestion-detail__hero::before{content:"";position:absolute;z-index:0;width:var(--route-suggestion-marker-size,30px);height:var(--route-suggestion-marker-size,30px);border-radius:50%;top:var(--route-suggestion-marker-top,50%);left:var(--route-suggestion-marker-left,50%);transform:translate(-50%,-50%);opacity:var(--route-suggestion-marker-opacity,0);background:radial-gradient(circle at center,var(--route-suggestion-accent,#9bd4ff)0%,var(--route-suggestion-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);box-shadow:0 0 0 6px rgba(0,0,0,0.45),0 18px 34px rgba(0,0,0,0.5);pointer-events:none;transition:opacity .2s ease,transform .2s ease}
+.route-suggestion-detail__hero>*{position:relative;z-index:1}
+.route-suggestion-detail__badges{display:flex;flex-wrap:wrap;gap:10px}
+.route-suggestion-detail__badge{display:inline-flex;align-items:center;justify-content:flex-start;gap:6px;padding:6px 14px;border-radius:999px;background:rgba(0,0,0,0.38);border:1px solid rgba(255,255,255,0.24);font-size:.78rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,0.85)}
+.route-suggestion-detail__badge--accent{background:rgba(0,0,0,0.45);border-color:var(--route-suggestion-accent,#9bd4ff);color:var(--route-suggestion-accent,#9bd4ff)}
 .route-suggestion-detail__title{margin:0;font-size:1.4rem}
 .route-suggestion-detail__meta{margin:0;font-size:.92rem;color:rgba(224,225,221,0.84)}
 .route-suggestion-detail__progress{display:flex;flex-wrap:wrap;align-items:center;gap:10px}
@@ -185,8 +254,8 @@ gba(119,141,169,0.45)}
 .route-suggestion-detail__progress-label{font-size:.9rem;font-weight:600;color:rgba(255,255,255,0.9)}
 .route-suggestion-detail__reasons{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.9rem;color:rgba(255,255,255,0.88)}
 .route-suggestion-detail__reason{margin:0;font-size:.9rem;color:rgba(255,255,255,0.88)}
-.route-suggestion-detail__actions{display:flex;flex-wrap:wrap;gap:10px}
-.route-suggestion-detail__body{padding:20px;background:rgba(10,20,34,0.9)}
+.route-suggestion-detail__actions{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+.route-suggestion-detail__body{padding:22px;background:rgba(10,20,34,0.9);display:grid;gap:18px}
 
 .route-overview{display:flex;flex-direction:column;gap:16px}
 .route-overview__header{display:flex;flex-direction:column;gap:16px}

--- a/index.html
+++ b/index.html
@@ -1933,78 +1933,6 @@
     .item-card .collect-btn.collected {
       background: var(--secondary);
     }
-    /* Route tracking */
-    .route-card {
-      text-align: left;
-      cursor: default;
-      border: 1px solid transparent;
-    }
-    .route-card.completed {
-      border-color: var(--success);
-      box-shadow: 0 4px 14px rgba(46, 204, 113, 0.25);
-      background: rgba(46, 204, 113, 0.08);
-    }
-    .route-card .name {
-      margin-bottom: 6px;
-    }
-    .route-steps {
-      margin-top: 8px;
-    }
-    .route-step-list {
-      list-style-position: inside;
-      padding-left: 0;
-      margin: 4px 0 0;
-      counter-reset: route-step;
-    }
-    .route-step {
-      counter-increment: route-step;
-      margin-bottom: 6px;
-      padding: 6px;
-      border-radius: 6px;
-      background: rgba(255, 255, 255, 0.02);
-      transition: background 0.2s, color 0.2s;
-    }
-    .route-step::marker {
-      font-weight: 700;
-      color: var(--secondary);
-    }
-    .route-step.completed {
-      background: rgba(46, 204, 113, 0.12);
-    }
-    .route-step.completed::marker {
-      color: var(--success);
-    }
-    .route-step-label {
-      display: flex;
-      gap: 8px;
-      align-items: flex-start;
-      font-size: 0.75rem;
-      color: var(--light);
-    }
-    .route-step input[type="checkbox"] {
-      margin-top: 2px;
-      transform: scale(1.05);
-    }
-    .route-step-text {
-      flex: 1;
-      line-height: 1.35;
-    }
-    .route-step.completed .route-step-label {
-      color: var(--text);
-      font-weight: 600;
-    }
-    .route-step.completed .route-step-text {
-      text-decoration: line-through;
-    }
-    .route-progress-summary {
-      font-size: 0.7rem;
-      color: var(--light);
-      margin-top: 6px;
-    }
-    .route-card.completed .route-progress-summary {
-      color: var(--success);
-      font-weight: 600;
-    }
     /* Tech tree */
     #techList {
       display: flex;
@@ -9408,14 +9336,35 @@
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
-    const ROUTE_ART_LIBRARY = {
+    const ROUTE_VISUAL_THEMES = {
+      pal: { overlay: 'rgba(119, 141, 169, 0.58)', accent: '#9bd4ff', icon: 'fa-paw', position: 'center 40%' },
+      tech: { overlay: 'rgba(42, 157, 143, 0.58)', accent: '#72e5c4', icon: 'fa-microchip', position: 'center 48%' },
+      item: { overlay: 'rgba(255, 196, 77, 0.6)', accent: '#ffd166', icon: 'fa-sack', position: 'center 52%' },
       boss: { overlay: 'rgba(126, 87, 255, 0.62)', accent: '#d1b8ff', icon: 'fa-chess-king', position: 'center 18%' },
-      tower: { overlay: 'rgba(126, 87, 255, 0.62)', accent: '#d1b8ff', icon: 'fa-chess-king', position: 'center 18%' },
-      farming: { overlay: 'rgba(42, 157, 143, 0.58)', accent: '#a7f2d2', icon: 'fa-seedling', position: 'center 68%' },
-      gather: { overlay: 'rgba(42, 157, 143, 0.58)', accent: '#a7f2d2', icon: 'fa-seedling', position: 'center 68%' },
+      map: { overlay: 'rgba(118, 206, 255, 0.6)', accent: '#6fe7ff', icon: 'fa-map-location-dot', position: 'center 32%' },
+      npc: { overlay: 'rgba(236, 72, 153, 0.5)', accent: '#f9a8d4', icon: 'fa-user-astronaut', position: 'center 45%' },
+      generic: { overlay: 'rgba(148, 187, 233, 0.55)', accent: '#9bd4ff', icon: 'fa-route', position: 'center 40%' }
+    };
+    const PAL_TYPE_VISUALS = {
+      Fire: { overlay: 'rgba(255, 138, 101, 0.6)', accent: '#ffb199' },
+      Water: { overlay: 'rgba(80, 176, 255, 0.6)', accent: '#75c8ff' },
+      Grass: { overlay: 'rgba(105, 228, 166, 0.6)', accent: '#8ff0b5' },
+      Electric: { overlay: 'rgba(255, 221, 89, 0.55)', accent: '#ffe066' },
+      Ice: { overlay: 'rgba(125, 206, 235, 0.6)', accent: '#b5e8ff' },
+      Ground: { overlay: 'rgba(216, 180, 160, 0.58)', accent: '#f2c8a2' },
+      Dark: { overlay: 'rgba(136, 84, 208, 0.6)', accent: '#d0a3ff' },
+      Dragon: { overlay: 'rgba(142, 178, 255, 0.6)', accent: '#a7c9ff' },
+      Air: { overlay: 'rgba(173, 216, 230, 0.55)', accent: '#c8f1ff' },
+      Neutral: { overlay: ROUTE_VISUAL_THEMES.pal.overlay, accent: ROUTE_VISUAL_THEMES.pal.accent }
+    };
+    const ROUTE_ART_LIBRARY = {
+      boss: { overlay: ROUTE_VISUAL_THEMES.boss.overlay, accent: ROUTE_VISUAL_THEMES.boss.accent, icon: ROUTE_VISUAL_THEMES.boss.icon, position: ROUTE_VISUAL_THEMES.boss.position },
+      tower: { overlay: ROUTE_VISUAL_THEMES.boss.overlay, accent: ROUTE_VISUAL_THEMES.boss.accent, icon: ROUTE_VISUAL_THEMES.boss.icon, position: ROUTE_VISUAL_THEMES.boss.position },
+      farming: { overlay: 'rgba(42, 157, 143, 0.6)', accent: '#8ff0b5', icon: 'fa-seedling', position: 'center 62%' },
+      gather: { overlay: 'rgba(42, 157, 143, 0.6)', accent: '#8ff0b5', icon: 'fa-seedling', position: 'center 62%' },
       capture: { overlay: 'rgba(255, 170, 102, 0.6)', accent: '#ffd6a5', icon: 'fa-paw', position: 'center 58%' },
-      exploration: { overlay: 'rgba(118, 206, 255, 0.6)', accent: '#9bd4ff', icon: 'fa-compass', position: 'center 32%' },
-      travel: { overlay: 'rgba(118, 206, 255, 0.6)', accent: '#9bd4ff', icon: 'fa-compass', position: 'center 32%' },
+      exploration: { overlay: ROUTE_VISUAL_THEMES.map.overlay, accent: ROUTE_VISUAL_THEMES.map.accent, icon: ROUTE_VISUAL_THEMES.map.icon, position: ROUTE_VISUAL_THEMES.map.position },
+      travel: { overlay: ROUTE_VISUAL_THEMES.map.overlay, accent: ROUTE_VISUAL_THEMES.map.accent, icon: ROUTE_VISUAL_THEMES.map.icon, position: ROUTE_VISUAL_THEMES.map.position },
       craft: { overlay: 'rgba(255, 214, 102, 0.58)', accent: '#ffe599', icon: 'fa-hammer', position: 'center 44%' },
       base: { overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' }
     };
@@ -9450,6 +9399,66 @@
     let currentRouteSuggestionEntries = [];
     let activeSuggestedRouteId = null;
     let routeSuggestionsAbort = null;
+    let activeRouteIds = new Set();
+    let routeLibrarySearchTerm = '';
+
+    function loadActiveRouteIdsFromState(state){
+      const meta = state && typeof state.__meta === 'object' ? state.__meta : null;
+      const stored = meta && Array.isArray(meta.activeRoutes) ? meta.activeRoutes : [];
+      return stored
+        .map(id => typeof id === 'string' ? id.trim() : '')
+        .filter(Boolean);
+    }
+
+    function syncActiveRouteIds(){
+      activeRouteIds = new Set(loadActiveRouteIdsFromState(routeState));
+    }
+
+    function persistActiveRouteIds(){
+      if(!routeState.__meta || typeof routeState.__meta !== 'object'){
+        routeState.__meta = {};
+      }
+      routeState.__meta.activeRoutes = Array.from(activeRouteIds);
+      saveRouteState(routeState);
+    }
+
+    function isRouteActive(routeId){
+      if(!routeId) return false;
+      return activeRouteIds.has(routeId);
+    }
+
+    function addActiveRoute(routeId){
+      if(!routeId || isRouteActive(routeId)) return;
+      activeRouteIds.add(routeId);
+      persistActiveRouteIds();
+      renderActiveRoutesList();
+      renderRouteLibraryList();
+      refreshRouteIntelligenceUI();
+    }
+
+    function removeActiveRoute(routeId){
+      if(!routeId || !isRouteActive(routeId)) return;
+      activeRouteIds.delete(routeId);
+      persistActiveRouteIds();
+      renderActiveRoutesList();
+      renderRouteLibraryList();
+      refreshRouteIntelligenceUI();
+    }
+
+    function pruneCompletedActiveRoutes(){
+      if(!routeGuideData || !routeGuideData.routes) return;
+      let changed = false;
+      activeRouteIds.forEach(routeId => {
+        const route = routeGuideData.routeLookup?.[routeId];
+        if(route && isRouteComplete(route)){
+          activeRouteIds.delete(routeId);
+          changed = true;
+        }
+      });
+      if(changed){
+        persistActiveRouteIds();
+      }
+    }
 
     function rebuildTechLookup(){
       TECH_LOOKUP = {};
@@ -9850,31 +9859,223 @@
       return strict ? '' : fallback;
     }
 
-    function routeArtFor(route){
-      const category = (route?.category || '').toLowerCase();
-      const tags = Array.isArray(route?.tags) ? route.tags.map(tag => (tag || '').toLowerCase()) : [];
-      const lookupKeys = [category, ...tags];
-      let art = null;
-      for(const key of lookupKeys){
+    function sanitizeImageUrl(url){
+      return String(url || ROUTE_ART_IMAGE).replace(/'/g, "\\'");
+    }
+
+    function palVisualTheme(pal){
+      const primary = getPrimaryType(pal) || 'Neutral';
+      return PAL_TYPE_VISUALS[primary] || PAL_TYPE_VISUALS.Neutral || { overlay: ROUTE_VISUAL_THEMES.pal.overlay, accent: ROUTE_VISUAL_THEMES.pal.accent };
+    }
+
+    function resolveItemDetail(itemId){
+      if(!itemId || !ITEM_DETAILS) return null;
+      if(ITEM_DETAILS[itemId]) return ITEM_DETAILS[itemId];
+      const slug = slugifyForPalworld(String(itemId));
+      if(slug && ITEM_DETAILS[slug]) return ITEM_DETAILS[slug];
+      return null;
+    }
+
+    function gatherStepTargets(step){
+      const targets = [];
+      const seen = new Set();
+      const links = Array.isArray(step?.links) ? step.links : [];
+      links.forEach(link => {
+        if(!link || !link.type) return;
+        const key = `${link.type}:${link.id || link.slug || link.name || ''}`;
+        seen.add(key);
+        targets.push(link);
+      });
+      const rawTargets = Array.isArray(step?.raw?.targets) ? step.raw.targets : [];
+      rawTargets.forEach(target => {
+        if(!target || !target.kind) return;
+        const typeMap = { pal: 'pal', item: 'item', tech: 'tech', station: 'tech', boss: 'tower', npc: 'npc' };
+        const mapped = typeMap[target.kind];
+        if(!mapped) return;
+        const ident = target.id || target.slug || target.name || '';
+        const key = `${mapped}:${ident}`;
+        if(seen.has(key)) return;
+        seen.add(key);
+        targets.push({ type: mapped, id: target.id || target.slug, slug: target.slug, name: target.name, map: target.map });
+      });
+      return targets;
+    }
+
+    function routeStepLocation(step){
+      const raw = step?.raw;
+      if(raw && Array.isArray(raw.locations) && raw.locations.length){
+        const loc = raw.locations.find(entry => Array.isArray(entry.coords) && entry.coords.length >= 2) || raw.locations[0];
+        if(loc){
+          const coords = Array.isArray(loc.coords) && loc.coords.length >= 2 ? [Number(loc.coords[0]), Number(loc.coords[1])] : null;
+          const region = loc.region || loc.region_id || '';
+          const label = loc.label || loc.landmark || (region ? niceName(region) : '');
+          return { coords, region, label };
+        }
+      }
+      const link = (step?.links || []).find(entry => entry && entry.type === 'tower' && entry.map);
+      if(link && link.map){
+        const map = link.map;
+        const coords = Array.isArray(map.coords) ? [Number(map.coords[0]), Number(map.coords[1])] : (
+          map.entrance && Array.isArray(map.entrance.coords) ? [Number(map.entrance.coords[0]), Number(map.entrance.coords[1])] : null
+        );
+        const region = map.region || '';
+        const label = map.label || map.title || (map.entrance && map.entrance.label) || '';
+        return { coords, region, label };
+      }
+      return null;
+    }
+
+    function routeVisualFromStep(step, route){
+      const targets = gatherStepTargets(step);
+      for(const target of targets){
+        if(target.type === 'pal'){
+          const palId = resolvePalIdFromLink(target);
+          const pal = palId != null ? PALS?.[palId] : null;
+          if(pal){
+            const theme = palVisualTheme(pal);
+            const image = getPalArtSource(pal) || getPalOnlineArtSource(pal) || getPalIconSource(pal);
+            if(image){
+              return {
+                type: 'pal',
+                image,
+                overlay: theme.overlay,
+                accent: theme.accent,
+                icon: ROUTE_VISUAL_THEMES.pal.icon,
+                position: ROUTE_VISUAL_THEMES.pal.position,
+                label: pal.name,
+                alt: `${pal.name} pal artwork`
+              };
+            }
+          }
+        } else if(target.type === 'tech'){
+          const tech = resolveTechFromLink(target);
+          const item = tech?.item;
+          const image = item?.image || item?.icon;
+          if(item && image){
+            return {
+              type: 'tech',
+              image,
+              overlay: ROUTE_VISUAL_THEMES.tech.overlay,
+              accent: ROUTE_VISUAL_THEMES.tech.accent,
+              icon: ROUTE_VISUAL_THEMES.tech.icon,
+              position: ROUTE_VISUAL_THEMES.tech.position,
+              label: item.name || niceName(target.id || target.slug || ''),
+              alt: `${item.name || niceName(target.id || target.slug || '')} technology`
+            };
+          }
+        } else if(target.type === 'item'){
+          const detail = resolveItemDetail(target.id);
+          const image = detail?.image || detail?.icon;
+          if(image){
+            const name = detail?.name || niceName(target.id || '');
+            return {
+              type: 'item',
+              image,
+              overlay: ROUTE_VISUAL_THEMES.item.overlay,
+              accent: ROUTE_VISUAL_THEMES.item.accent,
+              icon: ROUTE_VISUAL_THEMES.item.icon,
+              position: ROUTE_VISUAL_THEMES.item.position,
+              label: name,
+              alt: `${name} item`
+            };
+          }
+        } else if(target.type === 'tower'){
+          const location = routeStepLocation(step);
+          const marker = location?.coords ? worldCoordsToPercent(location.coords) : null;
+          return {
+            type: 'boss',
+            image: ROUTE_ART_IMAGE,
+            overlay: ROUTE_VISUAL_THEMES.boss.overlay,
+            accent: ROUTE_VISUAL_THEMES.boss.accent,
+            icon: ROUTE_VISUAL_THEMES.boss.icon,
+            position: ROUTE_VISUAL_THEMES.boss.position,
+            marker,
+            label: location?.label || niceName(target.id || target.slug || target.name || ''),
+            alt: `${route?.title || 'Boss'} location`
+          };
+        } else if(target.type === 'npc' && target.image){
+          return {
+            type: 'npc',
+            image: target.image,
+            overlay: ROUTE_VISUAL_THEMES.npc.overlay,
+            accent: ROUTE_VISUAL_THEMES.npc.accent,
+            icon: ROUTE_VISUAL_THEMES.npc.icon,
+            position: ROUTE_VISUAL_THEMES.npc.position,
+            label: target.name || niceName(target.id || ''),
+            alt: `${target.name || 'NPC'} portrait`
+          };
+        }
+      }
+      const location = routeStepLocation(step);
+      if(location){
+        const marker = location.coords ? worldCoordsToPercent(location.coords) : null;
+        return {
+          type: 'map',
+          image: ROUTE_ART_IMAGE,
+          overlay: ROUTE_VISUAL_THEMES.map.overlay,
+          accent: ROUTE_VISUAL_THEMES.map.accent,
+          icon: ROUTE_VISUAL_THEMES.map.icon,
+          position: ROUTE_VISUAL_THEMES.map.position,
+          marker,
+          label: location.label || niceName(location.region || ''),
+          alt: `${route?.title || 'Route'} map location`
+        };
+      }
+      return null;
+    }
+
+    function routeVisualFromTags(route){
+      if(!route) return {};
+      const keys = [];
+      if(route.category) keys.push(String(route.category).toLowerCase());
+      if(Array.isArray(route.tags)){
+        route.tags.forEach(tag => keys.push(String(tag).toLowerCase()));
+      }
+      for(const key of keys){
         if(!key) continue;
         if(ROUTE_ART_LIBRARY[key]){
-          art = ROUTE_ART_LIBRARY[key];
-          break;
+          return { ...ROUTE_ART_LIBRARY[key], type: key };
         }
         if(key.includes('tower') || key.includes('boss')){
-          art = ROUTE_ART_LIBRARY.tower || ROUTE_ART_LIBRARY.boss;
-          break;
+          return { ...ROUTE_VISUAL_THEMES.boss, type: 'boss' };
         }
-        if(key.includes('farm')){
-          art = ROUTE_ART_LIBRARY.farming;
+        if(key.includes('farm') || key.includes('gather')){
+          return { ...ROUTE_VISUAL_THEMES.item, icon: 'fa-seedling', type: 'item' };
         }
       }
-      if(!art){
-        const variants = ROUTE_ART_VARIANTS.length ? ROUTE_ART_VARIANTS : [{ overlay: 'rgba(148, 187, 233, 0.55)', accent: '#9bd4ff', icon: 'fa-route', position: 'center 40%' }];
-        const variant = variants[Math.abs(hashString(route?.id || 'route')) % variants.length] || variants[0];
-        art = variant;
+      return {};
+    }
+
+    function computeRouteVisual(route){
+      const fallback = { ...ROUTE_VISUAL_THEMES.generic, image: ROUTE_ART_IMAGE, type: 'generic', label: route?.title || 'Route', alt: route?.title ? `${route.title} guide artwork` : 'Route guide artwork', marker: null };
+      if(!route) return fallback;
+      const steps = Array.isArray(route?.chapter?.steps) ? route.chapter.steps : [];
+      for(const step of steps){
+        const visual = routeVisualFromStep(step, route);
+        if(visual && visual.image){
+          return { ...fallback, ...visual };
+        }
       }
-      return { image: ROUTE_ART_IMAGE, ...art };
+      const tagVisual = routeVisualFromTags(route);
+      if(tagVisual && Object.keys(tagVisual).length){
+        return { ...fallback, ...tagVisual };
+      }
+      const variants = ROUTE_ART_VARIANTS.length ? ROUTE_ART_VARIANTS : [ROUTE_VISUAL_THEMES.generic];
+      const variant = variants[Math.abs(hashString(route?.id || route?.title || 'route')) % variants.length] || variants[0];
+      return { ...fallback, ...variant };
+    }
+
+    function routeArtFor(route){
+      const visual = computeRouteVisual(route);
+      return {
+        ...visual,
+        image: sanitizeImageUrl(visual.image),
+        overlay: visual.overlay || ROUTE_VISUAL_THEMES.generic.overlay,
+        accent: visual.accent || ROUTE_VISUAL_THEMES.generic.accent,
+        icon: visual.icon || ROUTE_VISUAL_THEMES.generic.icon,
+        position: visual.position || ROUTE_VISUAL_THEMES.generic.position,
+        marker: visual.marker || null
+      };
     }
 
     function routeProgressBreakdown(route){
@@ -9909,6 +10110,7 @@
 
     function refreshRouteIntelligenceUI({ summary, levelEstimate, recommendations } = {}){
       if(!routeGuideData) return;
+      pruneCompletedActiveRoutes();
       const effectiveSummary = summary || calculateGuideProgressSummary();
       const effectiveLevel = levelEstimate || estimatePlayerLevel(routeContext);
       const effectiveRecommendations = recommendations || computeRouteRecommendations(routeGuideData, routeContext, effectiveLevel);
@@ -9916,6 +10118,8 @@
       renderRouteRecommendationsList(effectiveRecommendations, { offset: suggestionCount });
       updateRouteOverviewUI(effectiveSummary);
       renderBossRouteTimeline();
+      renderActiveRoutesList();
+      renderRouteLibraryList();
     }
 
     function renderRouteSuggestions(recommendations){
@@ -10043,6 +10247,15 @@
       detail.style.setProperty('--route-suggestion-overlay', art.overlay);
       detail.style.setProperty('--route-suggestion-accent', art.accent);
       detail.style.setProperty('--route-suggestion-position', art.position);
+      if(art.marker){
+        detail.style.setProperty('--route-suggestion-marker-left', `${art.marker.left}%`);
+        detail.style.setProperty('--route-suggestion-marker-top', `${art.marker.top}%`);
+        detail.style.setProperty('--route-suggestion-marker-opacity', '1');
+      } else {
+        detail.style.removeProperty('--route-suggestion-marker-left');
+        detail.style.removeProperty('--route-suggestion-marker-top');
+        detail.style.setProperty('--route-suggestion-marker-opacity', '0');
+      }
       const breakdown = routeProgressBreakdown(route);
       const requiredLabel = breakdown.requiredTotal
         ? `${breakdown.requiredDone}/${breakdown.requiredTotal} ${kidMode ? 'big steps' : 'required'}`
@@ -10071,12 +10284,19 @@
         : `<p class="route-suggestion-detail__reason">${escapeHTML(kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.')}</p>`;
       const focusStep = entry.nextStepId || (findFirstIncompleteStepForRoute(route, { includeOptional: true })?.id || '');
       const roleLabel = route.progression_role ? capitalize(route.progression_role) : capitalize(route.category || 'route');
+      const typeLabel = art.label || '';
       const stepButton = focusStep
         ? `<button type="button" class="btn" data-step-focus="${escapeHTML(focusStep)}">${escapeHTML(kidMode ? 'Jump to this step' : 'Jump to this step')}</button>`
         : '';
+      const queueButton = isRouteActive(route.id)
+        ? `<button type="button" class="btn" data-action="deactivateRoute" data-route-id="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Remove from queue' : 'Remove from active')}</button>`
+        : `<button type="button" class="btn" data-action="activateRoute" data-route-id="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Add to queue' : 'Add to active')}</button>`;
       detail.innerHTML = `
         <div class="route-suggestion-detail__hero">
-          <div class="route-suggestion-detail__badge">${escapeHTML(roleLabel)}</div>
+          <div class="route-suggestion-detail__badges">
+            <span class="route-suggestion-detail__badge">${escapeHTML(roleLabel)}</span>
+            ${typeLabel ? `<span class="route-suggestion-detail__badge route-suggestion-detail__badge--accent">${escapeHTML(typeLabel)}</span>` : ''}
+          </div>
           <h4 class="route-suggestion-detail__title">${escapeHTML(route.title)}</h4>
           ${metaLine ? `<p class="route-suggestion-detail__meta">${escapeHTML(metaLine)}</p>` : ''}
           <div class="route-suggestion-detail__progress">
@@ -10085,6 +10305,7 @@
           </div>
           ${reasonsHtml}
           <div class="route-suggestion-detail__actions">
+            ${queueButton}
             <button type="button" class="btn" data-route-focus="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Open full guide' : 'Open full guide')}</button>
             ${stepButton}
           </div>
@@ -10113,8 +10334,12 @@
       const reasonHighlight = Array.isArray(entry.reasons) && entry.reasons.length
         ? entry.reasons[0]
         : (kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.');
-      const style = `--route-suggestion-image: url('${art.image}'); --route-suggestion-overlay: ${art.overlay}; --route-suggestion-accent: ${art.accent}; --route-suggestion-position: ${art.position};`;
+      const markerCss = art.marker
+        ? ` --route-suggestion-marker-left: ${art.marker.left}%; --route-suggestion-marker-top: ${art.marker.top}%; --route-suggestion-marker-opacity: 1;`
+        : ' --route-suggestion-marker-opacity: 0;';
+      const style = `--route-suggestion-image: url('${art.image}'); --route-suggestion-overlay: ${art.overlay}; --route-suggestion-accent: ${art.accent}; --route-suggestion-position: ${art.position};${markerCss}`;
       const scoreLabel = typeof entry.score === 'number' ? entry.score.toFixed(1) : '';
+      const queued = isRouteActive(route.id);
       return `
         <button type="button" class="route-suggestion-card${active ? ' route-suggestion-card--active' : ''}" data-suggestion-route="${escapeHTML(route.id)}" aria-pressed="${active ? 'true' : 'false'}" style="${escapeHTML(style)}">
           <div class="route-suggestion-card__body">
@@ -10123,6 +10348,7 @@
               <div class="route-suggestion-card__text">
                 <h4 class="route-suggestion-card__title">${escapeHTML(route.title)}</h4>
                 ${metaLine ? `<p class="route-suggestion-card__meta">${escapeHTML(metaLine)}</p>` : ''}
+                ${queued ? `<span class="route-suggestion-card__status">${escapeHTML(kidMode ? 'In your queue' : 'In queue')}</span>` : ''}
               </div>
               ${scoreLabel ? `<span class="route-suggestion-card__score">${escapeHTML(scoreLabel)}</span>` : ''}
             </div>
@@ -10133,6 +10359,106 @@
             <p class="route-suggestion-card__reason">${escapeHTML(reasonHighlight)}</p>
           </div>
         </button>
+      `;
+    }
+
+    function renderActiveRoutesList(){
+      const wrap = document.getElementById('routeChapters');
+      if(!wrap) return;
+      if(!routeGuideData || !Array.isArray(routeGuideData.routes)){
+        wrap.innerHTML = `<p class="route-active__empty">${escapeHTML(kidMode ? 'Guides are still loading…' : 'Guide data is still loading.')}</p>`;
+        return;
+      }
+      const activeIds = Array.from(activeRouteIds);
+      wrap.innerHTML = '';
+      if(!activeIds.length){
+        wrap.innerHTML = `<p class="route-active__empty">${escapeHTML(kidMode
+          ? 'Tap an adventure above to add it to your queue.'
+          : 'Choose a guide from the suggestions above to add it to your queue.')}</p>`;
+        return;
+      }
+      activeIds.forEach((routeId, index) => {
+        const route = routeGuideData.routeLookup?.[routeId];
+        if(!route) return;
+        wrap.appendChild(renderChapterCard(route.chapter, index === 0, route));
+      });
+    }
+
+    function renderRouteLibraryList(){
+      const list = document.getElementById('routeLibraryList');
+      const countNode = document.querySelector('[data-route-role="library-count"]');
+      if(!list){
+        return;
+      }
+      if(!routeGuideData || !Array.isArray(routeGuideData.routes) || !routeGuideData.routes.length){
+        list.innerHTML = `<p class="route-library__empty">${escapeHTML(kidMode ? 'Guides are still loading…' : 'Guide library is still loading.')}</p>`;
+        if(countNode) countNode.textContent = '';
+        return;
+      }
+      const active = new Set(activeRouteIds);
+      const query = (routeLibrarySearchTerm || '').trim().toLowerCase();
+      const availableRoutes = routeGuideData.routes.filter(route => {
+        if(!route || !route.id || active.has(route.id)) return false;
+        if(!query) return true;
+        const haystack = [
+          route.title,
+          route.category,
+          ...(Array.isArray(route.tags) ? route.tags : []),
+          ...(Array.isArray(route.objectives) ? route.objectives : [])
+        ].filter(Boolean).join(' ').toLowerCase();
+        return haystack.includes(query);
+      });
+      if(countNode){
+        const remaining = routeGuideData.routes.filter(route => route && route.id && !active.has(route.id)).length;
+        const label = remaining > 0
+          ? `${remaining} ${remaining === 1 ? (kidMode ? 'guide available' : 'guide available') : (kidMode ? 'guides available' : 'guides available')}`
+          : (kidMode ? 'All guides active' : 'All guides active');
+        countNode.textContent = label;
+      }
+      if(!availableRoutes.length){
+        list.innerHTML = `<p class="route-library__empty">${escapeHTML(query
+          ? (kidMode ? 'No guides match that search.' : 'No guides match your search.')
+          : (kidMode ? 'Everything up here is in your queue.' : 'Every remaining guide is already active.'))}</p>`;
+        return;
+      }
+      list.innerHTML = availableRoutes.map(route => renderRouteLibraryCard(route)).join('');
+    }
+
+    function renderRouteLibraryCard(route){
+      const art = routeArtFor(route);
+      const metaBits = [];
+      const level = route?.recommended_level || {};
+      if(level.min != null || level.max != null){
+        metaBits.push(`Lv ${level.min != null ? level.min : '?'}-${level.max != null ? level.max : '?'}`);
+      }
+      if(route?.risk_profile){
+        metaBits.push(`${capitalize(route.risk_profile)} risk`);
+      }
+      const timeLabel = formatTimeLabel(route?.estimated_time_minutes);
+      if(timeLabel){
+        metaBits.push(timeLabel);
+      }
+      const metaLine = metaBits.length ? metaBits.join(' • ') : '';
+      const tags = Array.isArray(route?.tags) && route.tags.length
+        ? `<div class="route-library-card__tags">${route.tags.slice(0, 4).map(tag => `<span class="chip route-library-card__tag">${escapeHTML(tag)}</span>`).join('')}</div>`
+        : '';
+      const complete = isRouteComplete(route);
+      const markerStyle = art.marker ? `style="left:${art.marker.left}%;top:${art.marker.top}%"` : '';
+      return `
+        <article class="route-library-card${complete ? ' route-library-card--complete' : ''}" data-route-id="${escapeHTML(route.id)}">
+          <div class="route-library-card__media" style="--route-visual-image: url('${art.image}'); --route-visual-overlay: ${art.overlay}; --route-visual-accent: ${art.accent};">
+            ${art.marker ? `<span class="route-visual__marker" ${markerStyle}></span>` : ''}
+          </div>
+          <div class="route-library-card__body">
+            <h4>${escapeHTML(route.title)}</h4>
+            ${metaLine ? `<p class="route-library-card__meta">${escapeHTML(metaLine)}</p>` : ''}
+            ${tags}
+          </div>
+          <div class="route-library-card__actions">
+            ${complete ? `<span class="route-library-card__status">${escapeHTML(kidMode ? 'Complete' : 'Complete')}</span>` : ''}
+            <button type="button" class="chip route-library-card__activate" data-action="activateRoute" data-route-id="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Add to queue' : 'Add to active')}</button>
+          </div>
+        </article>
       `;
     }
 
@@ -10245,25 +10571,63 @@
           <header class="page-header">
             <h2>${escapeHTML(heading)}</h2>
           </header>
-          <section class="card route-context" id="routeContextCard">
-            ${renderRouteContextOverview(routeContext, levelEstimate, summary)}
-            ${renderRouteContextControls(routeGuideData, routeContext)}
+          <div class="route-layout">
+            <section class="card route-context" id="routeContextCard">
+              ${renderRouteContextOverview(routeContext, levelEstimate, summary)}
+              ${renderRouteContextControls(routeGuideData, routeContext)}
+            </section>
+            <section class="card route-suggestions-card" id="routeSuggestionsCard">
+              <div class="route-suggestions__header">
+                <h3>${kidMode ? 'Tonight’s Adventure Paths' : 'Suggested Adventure Paths'}</h3>
+                <p class="route-suggestions__intro">${escapeHTML(suggestionsLead)}</p>
+              </div>
+              <div class="route-suggestions__list" id="routeSuggestionsList">
+                <p class="route-suggestions__empty">${escapeHTML(kidMode
+                  ? 'Adjust the context above to unlock personalised picks.'
+                  : 'Fine-tune the context above to surface tailored paths.')}</p>
+              </div>
+              <div class="route-suggestions__detail" id="routeSuggestionDetail">
+                <p class="route-suggestions__placeholder">${escapeHTML(kidMode
+                  ? 'Highlight a suggestion to preview the guide here.'
+                  : 'Highlight a suggestion to preview the full walkthrough here.')}</p>
+              </div>
+            </section>
+          </div>
+          <section class="card route-active-card" id="routeActiveCard">
+            <div class="route-active__header">
+              <div class="route-active__title">
+                <h3>${escapeHTML(kidMode ? 'Your adventure queue' : 'Active guides')}</h3>
+                <p class="route-active__intro">${escapeHTML(kidMode
+                  ? 'Pick guides from the suggestions above. Only your chosen adventures stay visible here until you finish them.'
+                  : 'Pick guides from the suggestions above. Only the adventures you select stay visible here until they are complete.')}</p>
+              </div>
+              <div class="route-active__actions">
+                <button type="button" class="btn" data-route-action="toggle-optional">${routeOptionalToggleLabel(routeHideOptional)}</button>
+                <button type="button" class="btn" data-route-action="jump-next" data-step-id="">${kidMode ? 'Jump to next step' : 'Jump to next required'}</button>
+              </div>
+            </div>
+            <div class="route-active__filters" data-route-role="filters" aria-label="Filter steps by category"></div>
+            <div class="route-active__list" id="routeChapters"></div>
           </section>
-          <section class="card route-suggestions-card" id="routeSuggestionsCard">
-            <div class="route-suggestions__header">
-              <h3>${kidMode ? 'Tonight’s Adventure Paths' : 'Suggested Adventure Paths'}</h3>
-              <p class="route-suggestions__intro">${escapeHTML(suggestionsLead)}</p>
-            </div>
-            <div class="route-suggestions__list" id="routeSuggestionsList">
-              <p class="route-suggestions__empty">${escapeHTML(kidMode
-                ? 'Adjust the context above to unlock personalised picks.'
-                : 'Fine-tune the context above to surface tailored paths.')}</p>
-            </div>
-            <div class="route-suggestions__detail" id="routeSuggestionDetail">
-              <p class="route-suggestions__placeholder">${escapeHTML(kidMode
-                ? 'Highlight a suggestion to preview the guide here.'
-                : 'Highlight a suggestion to preview the full walkthrough here.')}</p>
-            </div>
+          <section class="card route-library" id="routeLibraryCard">
+            <details class="route-library__details">
+              <summary class="route-library__summary">
+                <div class="route-library__summary-text">
+                  <h3>${escapeHTML(kidMode ? 'Browse every guide' : 'Browse the full library')}</h3>
+                  <p>${escapeHTML(kidMode
+                    ? 'Open this drawer when you want to look up older or completed guides.'
+                    : 'Open the drawer to search the full guide library, including completed runs.')}</p>
+                </div>
+                <span class="route-library__count" data-route-role="library-count"></span>
+              </summary>
+              <div class="route-library__body">
+                <label class="route-library__search">
+                  <span class="route-library__search-icon"><i class="fa-solid fa-magnifying-glass"></i></span>
+                  <input type="search" id="routeLibrarySearch" placeholder="${escapeHTML(kidMode ? 'Search guides' : 'Search guides')}" aria-label="${escapeHTML(kidMode ? 'Search guides' : 'Search guides')}" />
+                </label>
+                <div class="route-library__list" id="routeLibraryList"></div>
+              </div>
+            </details>
           </section>
           <section class="card route-recommendations-card" id="routeRecommendationsCard">
             <div class="route-recommendations__header">
@@ -10272,22 +10636,21 @@
             </div>
             <div id="routeRecommendationsList" class="route-recommendations__list"></div>
           </section>
-          <section class="card route-controls">
-            <p class="route-controls__lead">${escapeHTML(kidMode
-              ? 'Check off each friendly step together. Hide bonus chores, focus categories, or jump straight to the next task.'
-              : 'Track every objective across Palworld. Hide optional steps, filter by category, or jump straight to your next move.')}</p>
-            <div class="route-controls__actions">
-              <button type="button" class="btn" data-route-action="toggle-optional">${routeOptionalToggleLabel(routeHideOptional)}</button>
-              <button type="button" class="btn" data-route-action="jump-next" data-step-id="">${kidMode ? 'Jump to next step' : 'Jump to next required'}</button>
-            </div>
-            <div class="route-controls__filters" data-route-role="filters" aria-label="Filter steps by category"></div>
-          </section>
-          <div id="routeChapters"></div>
         `;
           const wrap = node.querySelector('#routeChapters');
-          routes.forEach((route, idx) => {
-            wrap.appendChild(renderChapterCard(route.chapter, idx === 0, route));
-          });
+          syncActiveRouteIds();
+          pruneCompletedActiveRoutes();
+          renderActiveRoutesList();
+          renderRouteLibraryList();
+          const librarySearch = node.querySelector('#routeLibrarySearch');
+          if(librarySearch && !librarySearch.dataset.bound){
+            librarySearch.value = routeLibrarySearchTerm;
+            librarySearch.dataset.bound = 'true';
+            librarySearch.addEventListener('input', () => {
+              routeLibrarySearchTerm = librarySearch.value || '';
+              renderRouteLibraryList();
+            });
+          }
           wrap.addEventListener('change', handleRouteCheckboxChange);
           wrap.addEventListener('click', handleRouteClick);
           bindRouteActionButtons();
@@ -11157,22 +11520,38 @@
       const completeLabel = progress.requiredDone
         ? `<span class="route-card__complete">✅ ${escapeHTML(kidMode ? 'Route complete' : 'Chapter complete')}</span>`
         : '';
+      const art = routeArtFor(route);
+      const routeId = route?.id || chapter.id;
+      const markerAttr = art.marker ? ` style="left:${art.marker.left}%;top:${art.marker.top}%"` : '';
+      const label = art.label && art.label !== routeChapterTitle(chapter) ? art.label : '';
+      const queueButton = isRouteActive(routeId)
+        ? `<button type="button" class="chip route-card__queue" data-action="deactivateRoute" data-route-id="${escapeHTML(routeId)}">${escapeHTML(kidMode ? 'Remove from queue' : 'Remove from queue')}</button>`
+        : '';
       return `
         <div class="route-card__header">
-          <div class="route-card__title">
-            <h3>${escapeHTML(routeChapterTitle(chapter))}</h3>
-            ${why ? `<p class="route-card__why">${escapeHTML(why)}</p>` : ''}
-            ${meta}
+          <div class="route-card__info">
+            <div class="route-card__thumb" style="--route-visual-image: url('${art.image}'); --route-visual-overlay: ${art.overlay}; --route-visual-accent: ${art.accent}; --route-visual-position: ${art.position};">
+              ${art.marker ? `<span class="route-visual__marker"${markerAttr}></span>` : ''}
+            </div>
+            <div class="route-card__title">
+              <h3>${escapeHTML(routeChapterTitle(chapter))}</h3>
+              ${label ? `<span class="route-card__label">${escapeHTML(label)}</span>` : ''}
+              ${why ? `<p class="route-card__why">${escapeHTML(why)}</p>` : ''}
+              ${meta}
+            </div>
           </div>
-          <div class="route-card__progress">${renderProgress(progress)}</div>
+          <div class="route-card__toolbar">
+            ${completeLabel}
+            ${queueButton}
+          </div>
         </div>
+        <div class="route-card__progress">${renderProgress(progress)}</div>
         <details class="route-card__details"${openByDefault ? ' open' : ''}>
           <summary class="btn route-card__toggle">${escapeHTML(kidMode ? 'Show steps' : 'Open steps')}</summary>
           ${renderSteps(chapter, route)}
           <div class="route-card__actions">
             <button class="btn" data-action="markRequired" data-ch="${chapter.id}">${escapeHTML(kidMode ? 'Mark big steps complete' : 'Mark Required Complete')}</button>
             <button class="btn" data-action="resetChapter" data-ch="${chapter.id}">${escapeHTML(kidMode ? 'Reset route' : 'Reset Chapter')}</button>
-            ${completeLabel}
           </div>
         </details>
       `;
@@ -11389,10 +11768,29 @@
       }
       const btn = event.target.closest('button[data-action]');
       if(!btn) return;
+      const action = btn.dataset.action;
+      if(action === 'activateRoute'){
+        const routeId = btn.dataset.routeId || btn.dataset.route;
+        if(routeId){
+          addActiveRoute(routeId);
+          playSound(clickSound);
+        }
+        event.preventDefault();
+        return;
+      }
+      if(action === 'deactivateRoute'){
+        const routeId = btn.dataset.routeId || btn.dataset.route;
+        if(routeId){
+          removeActiveRoute(routeId);
+          playSound(clickSound);
+        }
+        event.preventDefault();
+        return;
+      }
       const chapterId = btn.dataset.ch;
       const chapter = (routeGuideData?.chapters || []).find(ch => ch.id === chapterId);
       if(!chapter) return;
-      if(btn.dataset.action === 'markRequired'){
+      if(action === 'markRequired'){
         chapter.steps.filter(step => !step.optional).forEach(step => {
           routeState[step.id] = true;
           const options = buildStepProgressOptions(step);
@@ -11405,7 +11803,7 @@
         rerenderChapter(chapter);
         refreshRouteIntelligenceUI();
         updateProgressUI();
-      } else if(btn.dataset.action === 'resetChapter'){
+      } else if(action === 'resetChapter'){
         chapter.steps.forEach(step => {
           delete routeState[step.id];
         });


### PR DESCRIPTION
## Summary
- Refresh the adaptive route cards with hero art, labels, queue controls, and progress framing that keeps the focus on the selected adventure.
- Introduce polished styles for the active queue, filter drawer, and collapsible route library so only chosen guides dominate the layout.
- Enhance route suggestion cards and details with real imagery, markers, and kid-friendly status badges for a more visual browsing experience.

## Testing
- Manual QA via local browser to review the updated route tab


------
https://chatgpt.com/codex/tasks/task_e_68dc3375140c833190f2b8790f37af7a