### PR TITLE
Fix route guide highlight aggregation crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -9703,7 +9703,7 @@
       const steps = Array.isArray(route?.steps) ? route.steps.slice() : [];
       const chapter = convertRouteToChapter(route, { index, role: normalizedRole });
       const resourceOutputs = collectRouteResourceOutputs(route);
-      const highlights = collectRouteHighlights(route);
+      const highlights = collectRouteHighlights(route, resourceOutputs);
       const playstyleKey = deriveRoutePlaystyleKey(route);
       return {
         id,
@@ -9865,7 +9865,7 @@
       return Array.from(items);
     }
 
-    function collectRouteHighlights(route){
+    function collectRouteHighlights(route, resourceOutputs = []){
       const pals = new Set();
       const items = new Set();
       const tech = new Set();
@@ -9927,7 +9927,9 @@
         if(entry.type.startsWith('have-item')) addItem(entry.item_id || entry.id);
         if(entry.type.startsWith('unlock-tech')) addTech(entry.tech_id || entry.id);
       });
-      route.resourceOutputs.forEach(addItem);
+      if(Array.isArray(resourceOutputs)){
+        resourceOutputs.forEach(addItem);
+      }
       return {
         pals: Array.from(pals),
         items: Array.from(items),


### PR DESCRIPTION
## Summary
- ensure route highlight aggregation receives the computed resource outputs so the adaptive planner can build its chapter list
- guard highlight aggregation against undefined inputs to avoid runtime failures

## Testing
- node <<'NODE' … (parses guides.md and runs collectRouteHighlights with resource outputs)

------
https://chatgpt.com/codex/tasks/task_e_68dc473553648331b31c9d6501480895