### PR TITLE
Enhance guide catalog visibility and route visuals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -128,13 +128,37 @@ gba(119,141,169,0.45)}
 .route-context__toggles{display:flex;flex-wrap:wrap;gap:8px}
 .route-context__toggle{border:1px solid rgba(119,141,169,0.35);background:rgba(119,141,169,0.18);color:var(--text,#f0f4f8);padding:8px 14px;border-radius:999px;font-weight:600;cursor:pointer;transition:background .2s ease,border-color .2s ease}
 .route-context__toggle--active{background:rgba(42,157,143,0.25);border-color:rgba(42,157,143,0.6)}
-.route-context__goals{display:block}
-.route-goal-board{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr))}
-.route-goal-tile{display:grid;gap:6px;place-items:center;padding:16px;border-radius:18px;border:1px solid rgba(119,141,169,0.28);background:rgba(12,24,40,0.7);color:var(--text,#f0f4f8);font-weight:600;cursor:pointer;transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease}
-.route-goal-tile__icon{display:grid;place-items:center;width:44px;height:44px;border-radius:14px;background:rgba(119,141,169,0.22);color:var(--accent,#778da9);font-size:1.15rem}
-.route-goal-tile__label{text-align:center;font-size:.9rem}
-.route-goal-tile:hover{transform:translateY(-2px);border-color:rgba(255,255,255,0.24);box-shadow:0 16px 28px rgba(0,0,0,0.38)}
-.route-goal-tile--active{border-color:rgba(42,157,143,0.6);box-shadow:0 18px 32px rgba(42,157,143,0.3);background:rgba(42,157,143,0.18)}
+.route-context__goals{position:relative}
+.route-goal-drawer{position:relative;display:grid;gap:10px}
+.route-goal-drawer__toggle{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:10px;width:100%;padding:16px 18px;border-radius:18px;background:linear-gradient(135deg,rgba(42,157,143,0.22),rgba(17,36,60,0.92));border:1px solid rgba(119,141,169,0.45);color:var(--text,#f0f4f8);cursor:pointer;box-shadow:0 0 24px rgba(42,157,143,0.35);transition:box-shadow .25s ease,transform .25s ease,border-color .25s ease}
+.route-goal-drawer__toggle::before{content:"";position:absolute;inset:-1px;border-radius:inherit;background:radial-gradient(circle at top left,rgba(148,210,189,0.45),rgba(148,210,189,0)60%);opacity:.7;pointer-events:none;transition:opacity .3s ease}
+.route-goal-drawer__toggle:hover,.route-goal-drawer__toggle:focus-visible{transform:translateY(-1px);box-shadow:0 0 28px rgba(119,141,169,0.5);border-color:rgba(148,210,189,0.7);outline:none}
+.route-goal-drawer__toggle:hover::before,.route-goal-drawer__toggle:focus-visible::before{opacity:1}
+.route-goal-drawer__title{font-size:.82rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.72)}
+.route-goal-drawer__summary{position:relative;display:flex;flex-wrap:wrap;align-items:center;gap:8px;width:100%;min-height:42px;padding:10px 12px;border-radius:14px;background:linear-gradient(135deg,rgba(11,26,44,0.92),rgba(12,32,54,0.88));box-shadow:0 0 18px rgba(42,157,143,0.35);border:1px solid rgba(119,141,169,0.35)}
+.route-goal-summary__placeholder{font-size:1rem;font-weight:600;color:rgba(224,225,221,0.78)}
+.route-goal-summary__chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(42,157,143,0.18);border:1px solid rgba(148,210,189,0.65);box-shadow:0 6px 16px rgba(0,0,0,0.35);font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.92);letter-spacing:.03em;text-transform:capitalize}
+.route-goal-summary__chip--more{background:rgba(148,210,189,0.22);border-color:rgba(148,210,189,0.85);color:rgba(255,255,255,0.92)}
+.route-goal-drawer__panel{position:relative;border-radius:20px;padding:18px;background:linear-gradient(150deg,rgba(13,27,42,0.95),rgba(8,18,34,0.88));border:1px solid rgba(119,141,169,0.4);box-shadow:0 28px 52px rgba(0,0,0,0.55),0 0 36px rgba(42,157,143,0.4);display:grid;gap:14px;max-height:320px;overflow:auto}
+.route-goal-drawer__panel::before{content:"";position:absolute;inset:0;border-radius:inherit;background:radial-gradient(circle at top right,rgba(148,210,189,0.28),rgba(148,210,189,0)65%);pointer-events:none}
+.route-goal-drawer__panel[hidden]{display:none}
+.route-goal-drawer__panel::-webkit-scrollbar{width:8px}
+.route-goal-drawer__panel::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.4);border-radius:999px}
+.route-goal-drawer__list{display:grid;gap:10px}
+@media (min-width:640px){.route-goal-drawer__list{grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}}
+.route-goal-option{display:grid;grid-template-columns:auto auto 1fr;align-items:center;gap:12px;padding:12px 16px;border-radius:14px;border:1px solid rgba(119,141,169,0.32);background:rgba(8,16,32,0.8);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04);transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease}
+.route-goal-option input[type=checkbox]{appearance:none;width:24px;height:24px;border-radius:8px;border:2px solid rgba(119,141,169,0.45);background:rgba(6,14,26,0.9);display:grid;place-items:center;transition:border-color .2s ease,background .2s ease,box-shadow .2s ease;cursor:pointer}
+.route-goal-option input[type=checkbox]::after{content:"";width:12px;height:12px;border-radius:4px;background:transparent;transform:scale(0);transition:transform .2s ease,background .2s ease}
+.route-goal-option input[type=checkbox]:checked{border-color:rgba(148,210,189,0.85);background:rgba(148,210,189,0.18);box-shadow:0 0 0 3px rgba(148,210,189,0.22)}
+.route-goal-option input[type=checkbox]:checked::after{background:rgba(148,210,189,0.95);transform:scale(1)}
+.route-goal-option input[type=checkbox]:focus-visible{outline:2px solid var(--accent,#778da9);outline-offset:2px}
+.route-goal-option__icon{display:grid;place-items:center;width:42px;height:42px;border-radius:14px;background:rgba(119,141,169,0.2);color:var(--accent,#778da9);font-size:1.1rem}
+.route-goal-option__label{font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.92)}
+.route-goal-option--active{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 32px rgba(148,210,189,0.2);transform:translateY(-1px)}
+.route-goal-drawer__footer{display:flex;justify-content:flex-end}
+.route-goal-drawer__close{background:rgba(0,0,0,0.35);border-color:rgba(119,141,169,0.4);color:var(--text,#f0f4f8)}
+.route-goal-drawer__close:hover{background:rgba(0,0,0,0.45)}
+.route-goal-drawer--open .route-goal-drawer__toggle{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}
 .route-context__resources{display:grid;gap:10px}
 .route-context__resource-add{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
 .route-context__resource-add select,.route-context__resource-add input{background:rgba(13,27,42,0.6);border:1px solid rgba(119,141,169,0.35);border-radius:10px;color:var(--text,#f0f4f8);padding:8px 12px;font-size:.95rem;min-width:160px;transition:border-color .2s ease,box-shadow .2s ease}
@@ -196,6 +220,34 @@ gba(119,141,169,0.45)}
 .route-library-card--complete{border-color:rgba(42,157,143,0.42)}
 .route-library-card--complete .route-library-card__media::after{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:inset 0 0 0 2px rgba(42,157,143,0.45)}
 .route-library-card--context{border-color:rgba(119,141,169,0.5);box-shadow:0 20px 40px rgba(119,141,169,0.25)}
+
+.guide-catalog{display:grid;gap:20px}
+.guide-catalog__header{display:flex;flex-direction:column;gap:6px}
+.guide-catalog__header h3{margin:0;font-size:1.3rem}
+.guide-catalog__header p{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72))}
+.guide-catalog__count{font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.82)}
+.guide-catalog__controls{display:grid;gap:12px}
+@media (min-width:720px){.guide-catalog__controls{grid-template-columns:260px 1fr;align-items:start}}
+.guide-catalog__search{display:flex;align-items:center;gap:10px;padding:0 14px;background:rgba(10,22,40,0.82);border:1px solid rgba(119,141,169,0.28);border-radius:16px}
+.guide-catalog__search input{flex:1;background:transparent;border:none;color:var(--text,#f0f4f8);font-size:1rem;padding:12px 0}
+.guide-catalog__search input:focus-visible{outline:none}
+.guide-catalog__filters{display:flex;flex-wrap:wrap;gap:12px}
+.guide-catalog__filters label{display:flex;flex-direction:column;gap:6px;font-size:.8rem;letter-spacing:.06em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
+.guide-catalog__filters select{min-width:180px;background:rgba(13,27,42,0.7);border:1px solid rgba(119,141,169,0.35);border-radius:12px;color:var(--text,#f0f4f8);padding:10px 12px;font-size:.95rem}
+.guide-catalog__filters select:focus-visible{outline:none;border-color:var(--accent,#778da9);box-shadow:0 0 0 2px rgba(119,141,169,0.35)}
+.guide-catalog__list{display:grid;gap:14px;padding-right:0}
+@media (min-width:900px){.guide-catalog__list{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}}
+.guide-catalog__empty{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:18px 0}
+.guide-catalog__item{display:grid;gap:10px;padding:16px;border-radius:18px;background:rgba(12,24,40,0.74);border:1px solid rgba(119,141,169,0.28);box-shadow:0 20px 42px rgba(0,0,0,0.45);transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease}
+.guide-catalog__item:hover{transform:translateY(-2px);border-color:rgba(148,210,189,0.55);box-shadow:0 26px 48px rgba(0,0,0,0.5)}
+.guide-catalog__item-header{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
+.guide-catalog__title{margin:0;font-size:1.1rem}
+.guide-catalog__badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:rgba(148,210,189,0.22);border:1px solid rgba(148,210,189,0.55);font-size:.75rem;font-weight:600;color:rgba(224,225,221,0.9);text-transform:uppercase;letter-spacing:.08em}
+.guide-catalog__group{margin:0;font-size:.85rem;color:rgba(224,225,221,0.7)}
+.guide-catalog__trigger{margin:0;font-size:.9rem;color:rgba(224,225,221,0.82)}
+.guide-catalog__keywords{display:flex;flex-wrap:wrap;gap:6px;margin:0}
+.guide-catalog__keyword{padding:4px 10px;border-radius:999px;background:rgba(119,141,169,0.18);border:1px solid rgba(119,141,169,0.32);font-size:.75rem;font-weight:600;color:rgba(224,225,221,0.85)}
+.guide-catalog__steps{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.92rem;color:rgba(224,225,221,0.85)}
 
 .route-overview__insights{display:grid;gap:16px;margin-top:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 .route-overview__insight{display:grid;gap:8px;padding:14px;border-radius:16px;background:rgba(8,16,32,0.75);border:1px solid rgba(119,141,169,0.26);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}

--- a/index.html
+++ b/index.html
@@ -9333,6 +9333,10 @@
           .filter(Boolean)
       : []);
     let routeContext = loadRouteContext();
+    let routeGoalDrawerOpen = false;
+    let guideCatalogSearchTerm = '';
+    let guideCatalogGroupFilter = 'all';
+    let guideCatalogCategoryFilter = 'all';
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
@@ -9520,12 +9524,16 @@
         })
         .then(text => {
           const parsed = parseGuideMarkdown(text || '');
-          routeGuideData = augmentGuideData(parsed);
+          return augmentGuideData(parsed);
+        })
+        .then(guide => {
+          routeGuideData = guide;
+          ensureGuideCatalogFiltersValid();
           return routeGuideData;
         })
         .catch(err => {
           console.error('Failed to load adaptive guide', err);
-          routeGuideData = { routes: [], chapters: [], tags: [], routeLookup: {}, metadata: null, recommender: null };
+          routeGuideData = { routes: [], chapters: [], tags: [], routeLookup: {}, metadata: null, recommender: null, guideCatalog: null };
           return routeGuideData;
         });
     }
@@ -9539,6 +9547,7 @@
         levelEstimator: null,
         recommender: null,
         sourceRegistry: null,
+        guideCatalog: null,
         extras: [],
         errors: []
       };
@@ -9579,6 +9588,10 @@
             }
             if(json.source_registry){
               result.sourceRegistry = json.source_registry;
+              continue;
+            }
+            if(json.guide_catalog){
+              result.guideCatalog = json.guide_catalog;
               continue;
             }
           }
@@ -9658,7 +9671,7 @@
       return { importance, optional: !!optional, routeRole };
     }
 
-    function augmentGuideData(parsed){
+    async function augmentGuideData(parsed){
       const routes = Array.isArray(parsed?.routes) ? parsed.routes : [];
       const augmentedRoutes = routes.map((route, index) => augmentRoute(route, index));
       const chapters = augmentedRoutes.map(entry => entry.chapter);
@@ -9675,6 +9688,12 @@
       const sortedResources = Array.from(resourceFrequency.entries())
         .sort((a, b) => b[1] - a[1])
         .map(entry => entry[0]);
+      const catalogMeta = parsed?.guideCatalog || null;
+      let catalogData = null;
+      if(catalogMeta){
+        catalogData = await loadGuideCatalog(catalogMeta);
+      }
+      const preparedCatalog = prepareGuideCatalog(catalogData, catalogMeta);
       return {
         metadata: parsed?.metadata || null,
         xp: parsed?.xp || null,
@@ -9686,8 +9705,116 @@
         tags: Array.from(tagSet).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
         keyResources: sortedResources.slice(0, 24),
         extras: parsed?.extras || [],
-        errors: parsed?.errors || []
+        errors: parsed?.errors || [],
+        guideCatalog: preparedCatalog
       };
+    }
+
+    async function loadGuideCatalog(meta){
+      if(!meta || !meta.path){
+        return null;
+      }
+      const source = meta.path;
+      try {
+        const res = await fetch(source);
+        if(!res.ok){
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const payload = await res.json();
+        if(payload && typeof payload === 'object'){
+          return payload;
+        }
+      } catch(err){
+        console.warn('Failed to load guide catalog', err);
+      }
+      return null;
+    }
+
+    function prepareGuideCatalog(raw, meta){
+      if(!raw || typeof raw !== 'object' || !Array.isArray(raw.guides)){
+        return null;
+      }
+      const entries = [];
+      raw.guides.forEach((guide, index) => {
+        if(!guide || typeof guide !== 'object') return;
+        const groupLabelRaw = String(guide.category_group || 'General').trim() || 'General';
+        const groupLabel = groupLabelRaw;
+        const groupId = slugifyForPalworld(groupLabelRaw) || `group-${index}`;
+        const categoryLabelRaw = String(guide.category || 'General').trim() || 'General';
+        const categoryLabel = categoryLabelRaw;
+        const categoryId = slugifyForPalworld(categoryLabelRaw) || `${groupId}-category`;
+        const title = guide.title || guide.source_heading || 'Guide';
+        const trigger = guide.trigger || '';
+        const keywords = Array.isArray(guide.keywords) ? guide.keywords.filter(Boolean).map(value => String(value)) : [];
+        const steps = Array.isArray(guide.steps)
+          ? guide.steps.map((step, stepIndex) => ({
+            order: Number(step?.order ?? (stepIndex + 1)),
+            instruction: step?.instruction || '',
+            citations: Array.isArray(step?.citations) ? step.citations.slice() : []
+          })).filter(step => step.instruction)
+          : [];
+        steps.sort((a, b) => (a.order || 0) - (b.order || 0));
+        const searchParts = [title, groupLabel, categoryLabel, trigger, keywords.join(' '), steps.map(step => step.instruction).join(' ')];
+        const searchText = searchParts.join(' ').toLowerCase();
+        entries.push({
+          id: guide.id || `${groupId}-${categoryId}-${index}`,
+          title,
+          groupId,
+          groupLabel,
+          categoryId,
+          categoryLabel,
+          trigger,
+          keywords,
+          steps,
+          searchText
+        });
+      });
+      entries.sort((a, b) => {
+        const groupCompare = a.groupLabel.localeCompare(b.groupLabel, undefined, { sensitivity: 'base' });
+        if(groupCompare !== 0) return groupCompare;
+        return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
+      });
+      const groupMap = new Map();
+      entries.forEach(entry => {
+        if(!groupMap.has(entry.groupId)){
+          groupMap.set(entry.groupId, { id: entry.groupId, label: entry.groupLabel, categories: new Map() });
+        }
+        const group = groupMap.get(entry.groupId);
+        if(!group.categories.has(entry.categoryId)){
+          group.categories.set(entry.categoryId, { id: entry.categoryId, label: entry.categoryLabel });
+        }
+      });
+      const groups = Array.from(groupMap.values()).map(group => ({
+        id: group.id,
+        label: group.label,
+        categories: Array.from(group.categories.values()).sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }))
+      })).sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+      return { entries, groups, meta: meta || null, count: entries.length };
+    }
+
+    function ensureGuideCatalogFiltersValid(){
+      const catalog = routeGuideData?.guideCatalog;
+      if(!catalog || !Array.isArray(catalog.entries)){
+        return;
+      }
+      const groups = Array.isArray(catalog.groups) ? catalog.groups : [];
+      if(guideCatalogGroupFilter !== 'all' && !groups.some(group => group.id === guideCatalogGroupFilter)){
+        guideCatalogGroupFilter = 'all';
+      }
+      const categorySet = new Set();
+      if(guideCatalogGroupFilter === 'all'){
+        groups.forEach(group => {
+          (group.categories || []).forEach(cat => categorySet.add(cat.id));
+        });
+      } else {
+        const group = groups.find(entry => entry.id === guideCatalogGroupFilter);
+        if(group){
+          (group.categories || []).forEach(cat => categorySet.add(cat.id));
+        }
+      }
+      if(guideCatalogCategoryFilter !== 'all' && !categorySet.has(guideCatalogCategoryFilter)){
+        guideCatalogCategoryFilter = 'all';
+      }
     }
 
     function augmentRoute(route, index){
@@ -10205,6 +10332,20 @@
 
     function routeArtFor(route){
       const visual = computeRouteVisual(route);
+      const highlight = (routeHighlightMedia(route, { limit: 1 }) || [])[0];
+      if(highlight && highlight.image){
+        const themeMap = { pal: ROUTE_VISUAL_THEMES.pal, tech: ROUTE_VISUAL_THEMES.tech, item: ROUTE_VISUAL_THEMES.item };
+        const theme = themeMap[highlight.type] || {};
+        return {
+          ...visual,
+          image: sanitizeImageUrl(highlight.image || visual.image),
+          overlay: theme.overlay || visual.overlay || ROUTE_VISUAL_THEMES.generic.overlay,
+          accent: theme.accent || visual.accent || ROUTE_VISUAL_THEMES.generic.accent,
+          icon: theme.icon || visual.icon || ROUTE_VISUAL_THEMES.generic.icon,
+          position: visual.position || ROUTE_VISUAL_THEMES.generic.position,
+          marker: visual.marker || null
+        };
+      }
       return {
         ...visual,
         image: sanitizeImageUrl(visual.image),
@@ -10446,6 +10587,7 @@
       }
       if(list){
         list.innerHTML = entries.map(entry => renderRouteSuggestionCard(entry, entry.route.id === activeSuggestedRouteId)).join('');
+        applyRouteSuggestionArtStyles(list);
       }
       routeSuggestionsAbort = new AbortController();
       const { signal } = routeSuggestionsAbort;
@@ -10631,18 +10773,34 @@
       const reasonHighlight = Array.isArray(entry.reasons) && entry.reasons.length
         ? entry.reasons[0]
         : (kidMode ? 'Balanced for your crew.' : 'Balanced recommendation tailored to your context.');
-      const markerCss = art.marker
-        ? ` --route-suggestion-marker-left: ${art.marker.left}%; --route-suggestion-marker-top: ${art.marker.top}%; --route-suggestion-marker-opacity: 1;`
-        : ' --route-suggestion-marker-opacity: 0;';
-      const style = `--route-suggestion-image: url('${art.image}'); --route-suggestion-overlay: ${art.overlay}; --route-suggestion-accent: ${art.accent}; --route-suggestion-position: ${art.position};${markerCss}`;
       const scoreLabel = typeof entry.score === 'number' ? entry.score.toFixed(1) : '';
       const queued = isRouteActive(route.id);
       const highlights = routeHighlightMedia(route, { limit: 3 });
       const highlightsHtml = highlights.length
         ? `<div class="route-suggestion-card__highlights">${highlights.map(item => renderRouteHighlight(item, { size: 'small' })).join('')}</div>`
         : '';
+      const dataAttributes = [
+        `data-suggestion-route="${escapeHTML(route.id)}"`,
+        `aria-pressed="${active ? 'true' : 'false'}"`
+      ];
+      if(art.image){
+        dataAttributes.push(`data-art-image="${escapeHTML(art.image)}"`);
+      }
+      if(art.overlay){
+        dataAttributes.push(`data-art-overlay="${escapeHTML(art.overlay)}"`);
+      }
+      if(art.accent){
+        dataAttributes.push(`data-art-accent="${escapeHTML(art.accent)}"`);
+      }
+      if(art.position){
+        dataAttributes.push(`data-art-position="${escapeHTML(art.position)}"`);
+      }
+      if(art.marker && typeof art.marker.left === 'number' && typeof art.marker.top === 'number'){
+        dataAttributes.push(`data-art-marker-left="${escapeHTML(String(art.marker.left))}"`);
+        dataAttributes.push(`data-art-marker-top="${escapeHTML(String(art.marker.top))}"`);
+      }
       return `
-        <button type="button" class="route-suggestion-card${active ? ' route-suggestion-card--active' : ''}" data-suggestion-route="${escapeHTML(route.id)}" aria-pressed="${active ? 'true' : 'false'}" style="${escapeHTML(style)}">
+        <button type="button" class="route-suggestion-card${active ? ' route-suggestion-card--active' : ''}" ${dataAttributes.join(' ')}>
           <div class="route-suggestion-card__body">
             <div class="route-suggestion-card__top">
               <span class="route-suggestion-card__icon"><i class="fa-solid ${escapeHTML(art.icon)}"></i></span>
@@ -10662,6 +10820,48 @@
           </div>
         </button>
       `;
+    }
+
+    function applyRouteSuggestionArtStyles(container){
+      if(!container) return;
+      const cards = container.querySelectorAll('.route-suggestion-card');
+      cards.forEach(card => {
+        const image = card.dataset.artImage;
+        if(image){
+          card.style.setProperty('--route-suggestion-image', `url('${image}')`);
+        } else {
+          card.style.removeProperty('--route-suggestion-image');
+        }
+        const overlay = card.dataset.artOverlay;
+        if(overlay){
+          card.style.setProperty('--route-suggestion-overlay', overlay);
+        } else {
+          card.style.removeProperty('--route-suggestion-overlay');
+        }
+        const accent = card.dataset.artAccent;
+        if(accent){
+          card.style.setProperty('--route-suggestion-accent', accent);
+        } else {
+          card.style.removeProperty('--route-suggestion-accent');
+        }
+        const position = card.dataset.artPosition;
+        if(position){
+          card.style.setProperty('--route-suggestion-position', position);
+        } else {
+          card.style.removeProperty('--route-suggestion-position');
+        }
+        const markerLeft = Number(card.dataset.artMarkerLeft);
+        const markerTop = Number(card.dataset.artMarkerTop);
+        if(Number.isFinite(markerLeft) && Number.isFinite(markerTop)){
+          card.style.setProperty('--route-suggestion-marker-left', `${markerLeft}%`);
+          card.style.setProperty('--route-suggestion-marker-top', `${markerTop}%`);
+          card.style.setProperty('--route-suggestion-marker-opacity', '1');
+        } else {
+          card.style.removeProperty('--route-suggestion-marker-left');
+          card.style.removeProperty('--route-suggestion-marker-top');
+          card.style.setProperty('--route-suggestion-marker-opacity', '0');
+        }
+      });
     }
 
     function renderActiveRoutesList(){
@@ -10816,6 +11016,111 @@
       `;
     }
 
+    function renderGuideCatalogGroupOptions(catalog){
+      const groups = Array.isArray(catalog?.groups) ? catalog.groups : [];
+      const options = [`<option value="all"${guideCatalogGroupFilter === 'all' ? ' selected' : ''}>${escapeHTML(kidMode ? 'All categories' : 'All categories')}</option>`];
+      groups.forEach(group => {
+        if(!group || !group.id) return;
+        const value = String(group.id);
+        const label = group.label || niceName(value);
+        options.push(`<option value="${escapeHTML(value)}"${guideCatalogGroupFilter === value ? ' selected' : ''}>${escapeHTML(label)}</option>`);
+      });
+      return options.join('');
+    }
+
+    function renderGuideCatalogCategoryOptions(catalog){
+      const groups = Array.isArray(catalog?.groups) ? catalog.groups : [];
+      const categories = new Map();
+      if(guideCatalogGroupFilter === 'all'){
+        groups.forEach(group => {
+          (group?.categories || []).forEach(cat => {
+            if(cat && cat.id && !categories.has(cat.id)){
+              categories.set(cat.id, cat.label || niceName(cat.id));
+            }
+          });
+        });
+      } else {
+        const group = groups.find(entry => entry && entry.id === guideCatalogGroupFilter);
+        if(group){
+          (group.categories || []).forEach(cat => {
+            if(cat && cat.id && !categories.has(cat.id)){
+              categories.set(cat.id, cat.label || niceName(cat.id));
+            }
+          });
+        }
+      }
+      const sorted = Array.from(categories.entries()).sort((a, b) => a[1].localeCompare(b[1], undefined, { sensitivity: 'base' }));
+      const labelAll = kidMode ? 'All focuses' : 'All focuses';
+      const options = [`<option value="all"${guideCatalogCategoryFilter === 'all' ? ' selected' : ''}>${escapeHTML(labelAll)}</option>`];
+      sorted.forEach(([id, label]) => {
+        options.push(`<option value="${escapeHTML(id)}"${guideCatalogCategoryFilter === id ? ' selected' : ''}>${escapeHTML(label)}</option>`);
+      });
+      return options.join('');
+    }
+
+    function renderGuideCatalogCard(entry){
+      if(!entry) return '';
+      const badge = `<span class="guide-catalog__badge">${escapeHTML(entry.categoryLabel || 'Guide')}</span>`;
+      const groupLine = entry.groupLabel ? `<p class="guide-catalog__group">${escapeHTML(entry.groupLabel)}</p>` : '';
+      const triggerLabel = kidMode ? 'Why use it:' : 'Trigger:';
+      const trigger = entry.trigger ? `<p class="guide-catalog__trigger"><strong>${escapeHTML(triggerLabel)}</strong> ${escapeHTML(entry.trigger)}</p>` : '';
+      const keywords = entry.keywords && entry.keywords.length
+        ? `<div class="guide-catalog__keywords">${entry.keywords.map(keyword => `<span class="guide-catalog__keyword">${escapeHTML(keyword)}</span>`).join('')}</div>`
+        : '';
+      const steps = entry.steps && entry.steps.length
+        ? `<ol class="guide-catalog__steps">${entry.steps.map(step => `<li>${escapeHTML(step.instruction)}</li>`).join('')}</ol>`
+        : '';
+      return `
+        <article class="guide-catalog__item">
+          <div class="guide-catalog__item-header">
+            <h4 class="guide-catalog__title">${escapeHTML(entry.title)}</h4>
+            ${badge}
+          </div>
+          ${groupLine}
+          ${trigger}
+          ${keywords}
+          ${steps}
+        </article>
+      `;
+    }
+
+    function renderGuideCatalogList(){
+      const card = document.getElementById('guideCatalogCard');
+      if(!card) return;
+      const list = card.querySelector('#guideCatalogList');
+      const countNode = card.querySelector('[data-guide-catalog-count]');
+      if(!list) return;
+      const catalog = routeGuideData?.guideCatalog;
+      if(!catalog || !Array.isArray(catalog.entries) || !catalog.entries.length){
+        list.innerHTML = `<p class="guide-catalog__empty">${escapeHTML(kidMode ? 'Guide index loading…' : 'Guide catalog loading…')}</p>`;
+        if(countNode) countNode.textContent = '';
+        return;
+      }
+      let entries = catalog.entries.slice();
+      if(guideCatalogGroupFilter !== 'all'){
+        entries = entries.filter(entry => entry.groupId === guideCatalogGroupFilter);
+      }
+      if(guideCatalogCategoryFilter !== 'all'){
+        entries = entries.filter(entry => entry.categoryId === guideCatalogCategoryFilter);
+      }
+      const query = (guideCatalogSearchTerm || '').trim().toLowerCase();
+      if(query){
+        entries = entries.filter(entry => entry.searchText.includes(query));
+      }
+      const total = catalog.entries.length;
+      const countLabel = entries.length === total
+        ? `${total} ${total === 1 ? 'guide' : 'guides'}`
+        : `${entries.length} of ${total} guides`;
+      if(countNode){
+        countNode.textContent = countLabel;
+      }
+      if(!entries.length){
+        list.innerHTML = `<p class="guide-catalog__empty">${escapeHTML(kidMode ? 'No guides match those filters yet.' : 'No guides match your filters yet.')}</p>`;
+        return;
+      }
+      list.innerHTML = entries.map(renderGuideCatalogCard).join('');
+    }
+
     function hashString(value){
       const str = String(value);
       let hash = 0;
@@ -10921,6 +11226,17 @@
           const recommendationLead = kidMode
             ? 'Need other ideas? These extra adventures re-rank when your context changes.'
             : 'Want alternatives? The rest of the ranked library updates whenever your context shifts.';
+          const catalog = routeGuideData?.guideCatalog;
+          const catalogCount = catalog?.count != null ? catalog.count : (Array.isArray(catalog?.entries) ? catalog.entries.length : 0);
+          const catalogLead = catalogCount
+            ? (kidMode
+              ? `Browse ${catalogCount} quick guides covering Palworld adventures.`
+              : `Browse ${catalogCount} structured guides across Palworld systems.`)
+            : (kidMode
+              ? 'Browse the full guide index once data loads.'
+              : 'Browse the complete guide catalog as soon as it loads.');
+          const groupOptions = renderGuideCatalogGroupOptions(catalog);
+          const categoryOptions = renderGuideCatalogCategoryOptions(catalog);
           node.innerHTML = `
           <header class="page-header">
             <h2>${escapeHTML(heading)}</h2>
@@ -10991,6 +11307,30 @@
               </div>
             </details>
           </section>
+          <section class="card guide-catalog" id="guideCatalogCard">
+            <div class="guide-catalog__header">
+              <h3>${escapeHTML(kidMode ? 'Guide encyclopedia' : 'Complete guide index')}</h3>
+              <p>${escapeHTML(catalogLead)}</p>
+              <span class="guide-catalog__count" data-guide-catalog-count></span>
+            </div>
+            <div class="guide-catalog__controls">
+              <label class="guide-catalog__search">
+                <span class="sr-only">${escapeHTML(kidMode ? 'Search guides' : 'Search guide catalog')}</span>
+                <input type="search" id="guideCatalogSearch" placeholder="${escapeHTML(kidMode ? 'Search all guides' : 'Search the catalog')}" value="${escapeHTML(guideCatalogSearchTerm)}" />
+              </label>
+              <div class="guide-catalog__filters">
+                <label>
+                  <span>${escapeHTML(kidMode ? 'Category group' : 'Category group')}</span>
+                  <select id="guideCatalogGroup">${groupOptions}</select>
+                </label>
+                <label>
+                  <span>${escapeHTML(kidMode ? 'Focus' : 'Focus')}</span>
+                  <select id="guideCatalogCategory">${categoryOptions}</select>
+                </label>
+              </div>
+            </div>
+            <div class="guide-catalog__list" id="guideCatalogList"></div>
+          </section>
           <section class="card route-recommendations-card" id="routeRecommendationsCard">
             <div class="route-recommendations__header">
               <h3>${kidMode ? 'More adventures to consider' : 'More adaptive picks'}</h3>
@@ -11004,6 +11344,7 @@
           pruneCompletedActiveRoutes();
           renderActiveRoutesList();
           renderRouteLibraryList();
+          renderGuideCatalogList();
           const librarySearch = node.querySelector('#routeLibrarySearch');
           if(librarySearch && !librarySearch.dataset.bound){
             librarySearch.value = routeLibrarySearchTerm;
@@ -11014,6 +11355,7 @@
             });
           }
           bindRouteLibraryControls(node);
+          bindGuideCatalogControls(node);
           wrap.addEventListener('change', handleRouteCheckboxChange);
           wrap.addEventListener('click', handleRouteClick);
           bindRouteActionButtons();
@@ -11207,15 +11549,12 @@
       const levelValue = context?.declaredLevel != null ? Number(context.declaredLevel) : '';
       const timeValue = context?.availableTimeMinutes != null ? Number(context.availableTimeMinutes) : '';
       const tags = Array.isArray(guide?.tags) ? guide.tags : [];
+      if(!tags.length){
+        routeGoalDrawerOpen = false;
+      }
       const resourceOptions = Array.isArray(guide?.keyResources) ? guide.keyResources : [];
       const goalTiles = tags.length
-        ? `<div class="route-goal-board">${tags.map(tag => {
-            const active = context.goals.includes(tag);
-            const classes = ['route-goal-tile'];
-            if(active) classes.push('route-goal-tile--active');
-            const icon = routeGoalIcon(tag);
-            return `<button type="button" class="${classes.join(' ')}" data-context-goal="${escapeHTML(tag)}"><span class="route-goal-tile__icon"><i class="fa-solid ${escapeHTML(icon)}"></i></span><span class="route-goal-tile__label">${escapeHTML(capitalize(tag))}</span></button>`;
-          }).join('')}</div>`
+        ? renderGoalDrawer(tags, context.goals)
         : `<p class="route-context__empty">${escapeHTML(kidMode ? 'Goals load soon.' : 'No goals available yet.')}</p>`;
       const resourceChips = context.resourceGaps.length
         ? context.resourceGaps.map(entry => renderResourceGapChip(entry)).join('')
@@ -11263,6 +11602,63 @@
                 </div>
                 <div class="route-context__resource-list" id="routeResourceList">${resourceChips}</div>
               </div>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    function formatGoalSummary(goals){
+      if(!Array.isArray(goals) || !goals.length){
+        return kidMode ? 'Tap to pick tonight’s goals' : 'Tap to pick tonight’s goals';
+      }
+      const labels = goals.slice(0, 3).map(goal => capitalize(goal));
+      const remainder = goals.length - labels.length;
+      const suffix = remainder > 0 ? ` +${remainder}` : '';
+      return `${labels.join(', ')}${suffix}`;
+    }
+
+    function renderGoalSummaryMarkup(goals){
+      if(!Array.isArray(goals) || !goals.length){
+        const label = kidMode ? 'Tap to pick tonight’s goals' : 'Tap to pick tonight’s goals';
+        return `<span class="route-goal-summary__placeholder">${escapeHTML(label)}</span>`;
+      }
+      const chips = goals.slice(0, 3).map(goal => `<span class="route-goal-summary__chip">${escapeHTML(capitalize(goal))}</span>`);
+      const remainder = goals.length - chips.length;
+      if(remainder > 0){
+        chips.push(`<span class="route-goal-summary__chip route-goal-summary__chip--more">+${remainder}</span>`);
+      }
+      return chips.join('');
+    }
+
+    function renderGoalDrawer(tags, selectedGoals){
+      const selectedSet = new Set((selectedGoals || []).map(goal => String(goal)));
+      const summary = formatGoalSummary(selectedGoals);
+      const summaryMarkup = renderGoalSummaryMarkup(selectedGoals);
+      const toggleLabel = kidMode ? 'Tonight’s goals' : 'Tonight’s goals';
+      const classes = ['route-goal-drawer'];
+      if(routeGoalDrawerOpen) classes.push('route-goal-drawer--open');
+      const panelHiddenAttr = routeGoalDrawerOpen ? '' : ' hidden';
+      const options = tags.map(tag => {
+        const normalized = String(tag);
+        const active = selectedSet.has(normalized);
+        const optionClasses = ['route-goal-option'];
+        if(active) optionClasses.push('route-goal-option--active');
+        const icon = routeGoalIcon(normalized);
+        return `<label class="${optionClasses.join(' ')}"><input type="checkbox" data-context-goal value="${escapeHTML(normalized)}" ${active ? 'checked' : ''} /><span class="route-goal-option__icon"><i class="fa-solid ${escapeHTML(icon)}"></i></span><span class="route-goal-option__label">${escapeHTML(capitalize(normalized))}</span></label>`;
+      }).join('');
+      return `
+        <div class="${classes.join(' ')}" data-goal-picker>
+          <button type="button" class="route-goal-drawer__toggle" data-goal-toggle aria-expanded="${routeGoalDrawerOpen ? 'true' : 'false'}" aria-label="${escapeHTML(`${toggleLabel}: ${summary}`)}" title="${escapeHTML(summary)}">
+            <span class="route-goal-drawer__title">${escapeHTML(toggleLabel)}</span>
+            <div class="route-goal-drawer__summary" data-goal-summary data-goal-summary-text="${escapeHTML(summary)}">${summaryMarkup}</div>
+          </button>
+          <div class="route-goal-drawer__panel"${panelHiddenAttr}>
+            <div class="route-goal-drawer__list">
+              ${options}
+            </div>
+            <div class="route-goal-drawer__footer">
+              <button type="button" class="chip route-goal-drawer__close" data-goal-close>${escapeHTML(kidMode ? 'Done picking' : 'Lock selections')}</button>
             </div>
           </div>
         </div>
@@ -11359,6 +11755,7 @@
 
     let routeContextControlAbort = null;
     let routeLibraryControlsAbort = null;
+    let guideCatalogControlsAbort = null;
 
     function bindRouteContextControls(root, { guide } = {}){
       if(!root) return;
@@ -11410,13 +11807,58 @@
         }, { signal });
       }
       if(goalWrap){
-        goalWrap.addEventListener('click', event => {
-          const btn = event.target.closest('[data-context-goal]');
-          if(!btn) return;
-          const goal = btn.dataset.contextGoal;
+        const goalDrawer = goalWrap.querySelector('[data-goal-picker]');
+        const panel = goalDrawer ? goalDrawer.querySelector('.route-goal-drawer__panel') : null;
+        const toggle = goalDrawer ? goalDrawer.querySelector('[data-goal-toggle]') : null;
+        const closeBtn = goalDrawer ? goalDrawer.querySelector('[data-goal-close]') : null;
+        const setDrawerOpen = open => {
+          routeGoalDrawerOpen = !!open;
+          if(goalDrawer){
+            goalDrawer.classList.toggle('route-goal-drawer--open', routeGoalDrawerOpen);
+          }
+          if(panel){
+            panel.hidden = !routeGoalDrawerOpen;
+          }
+          if(toggle){
+            toggle.setAttribute('aria-expanded', routeGoalDrawerOpen ? 'true' : 'false');
+          }
+        };
+        setDrawerOpen(routeGoalDrawerOpen);
+        if(toggle){
+          toggle.addEventListener('click', () => {
+            setDrawerOpen(!routeGoalDrawerOpen);
+          }, { signal });
+        }
+        if(closeBtn){
+          closeBtn.addEventListener('click', () => {
+            setDrawerOpen(false);
+            if(toggle) toggle.focus();
+          }, { signal });
+        }
+        const handleOutsideClick = event => {
+          if(!routeGoalDrawerOpen) return;
+          if(goalDrawer && goalDrawer.contains(event.target)) return;
+          setDrawerOpen(false);
+        };
+        document.addEventListener('click', handleOutsideClick, { signal });
+        goalWrap.addEventListener('change', event => {
+          const input = event.target.closest('input[type=checkbox][data-context-goal]');
+          if(!input) return;
+          const goal = input.value;
           const next = new Set(routeContext.goals);
-          if(next.has(goal)) next.delete(goal); else next.add(goal);
+          if(input.checked){
+            next.add(goal);
+          } else {
+            next.delete(goal);
+          }
           updateRouteContextState({ goals: Array.from(next) });
+        }, { signal });
+        goalWrap.addEventListener('keydown', event => {
+          if(event.key === 'Escape' && routeGoalDrawerOpen){
+            event.preventDefault();
+            setDrawerOpen(false);
+            if(toggle) toggle.focus();
+          }
         }, { signal });
       }
       if(resourceAdd){
@@ -11469,6 +11911,47 @@
           renderRouteLibraryList();
         }
       }, { signal });
+    }
+
+    function bindGuideCatalogControls(root){
+      if(!root) return;
+      if(guideCatalogControlsAbort){
+        guideCatalogControlsAbort.abort();
+      }
+      guideCatalogControlsAbort = new AbortController();
+      const { signal } = guideCatalogControlsAbort;
+      const card = root.querySelector('#guideCatalogCard');
+      if(!card) return;
+      const searchInput = card.querySelector('#guideCatalogSearch');
+      const groupSelect = card.querySelector('#guideCatalogGroup');
+      const categorySelect = card.querySelector('#guideCatalogCategory');
+      if(searchInput){
+        searchInput.value = guideCatalogSearchTerm;
+        searchInput.addEventListener('input', () => {
+          guideCatalogSearchTerm = searchInput.value || '';
+          renderGuideCatalogList();
+        }, { signal });
+      }
+      if(groupSelect){
+        groupSelect.value = guideCatalogGroupFilter;
+        groupSelect.addEventListener('change', () => {
+          guideCatalogGroupFilter = groupSelect.value || 'all';
+          guideCatalogCategoryFilter = 'all';
+          const catalog = routeGuideData?.guideCatalog;
+          if(categorySelect){
+            categorySelect.innerHTML = renderGuideCatalogCategoryOptions(catalog);
+            categorySelect.value = guideCatalogCategoryFilter;
+          }
+          renderGuideCatalogList();
+        }, { signal });
+      }
+      if(categorySelect){
+        categorySelect.value = guideCatalogCategoryFilter;
+        categorySelect.addEventListener('change', () => {
+          guideCatalogCategoryFilter = categorySelect.value || 'all';
+          renderGuideCatalogList();
+        }, { signal });
+      }
     }
 
     function updateRouteContextState(updates){


### PR DESCRIPTION
## Summary
- remove the internal scroll cap from the guide catalog and lay cards out in a responsive grid so the full guide library is accessible at once
- feed route suggestion cards with highlight artwork and apply it via CSS variables so each recommendation shows context-aware imagery
- restyle the goals drawer into a glowing, collapsible panel with chip summaries and a multi-column scrolling list for easier multi-selects

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4f12e4c08331b09554d6a44e83e2