### PR TITLE
Align guide documents and remove redundant entries

### DIFF
--- a/palworld_complete_guide.md
+++ b/palworld_complete_guide.md
@@ -2,6 +2,8 @@
 
 This comprehensive guide consolidates the catalogue of over 100 Palworld guides, their metadata (categories, trigger phrases and keywords) and detailed step‑by‑step instructions for accomplishing each task.  Citations from reliable sources are included to support key mechanics and features.  Use this document to develop or integrate a complete knowledge base for Palworld.
 
+> **Guide suite context:** This catalogue focuses on granular how‑to entries.  For a narrative, goal‑driven route that strings these tasks together, see **`palworld_purposeful_guides.md`**.  For a checkbox-style family playthrough of the Normal difficulty towers, refer to **`palworld_full_route_normal_coop_optional.md`**.  The three guides share terminology so you can move between them without re-learning concepts.
+
 ## Guide Catalogue and Metadata
 
 ### Getting Started & Core Missions
@@ -12,16 +14,14 @@ This comprehensive guide consolidates the catalogue of over 100 Palworld guides,
 | First Gathering Run | Missions | New players learning how to gather basic materials | early game, gather wood, branches |
 | Build a Workbench | Missions | When players need to craft more complex items | workbench, crafting bench, base setup |
 | Unlock Technology | Missions | Player wants to access the technology tree | tech tree, unlock tech |
-| Find Paldium & Craft Pal Spheres | Resources | When players ask about obtaining Paldium fragments or making capture devices | Paldium, capture device, Pal sphere |
+| Find Paldium & Craft Pal Spheres (Capturing Device) | Resources | When players ask about obtaining Paldium fragments or making capture devices | Paldium, capture device, Pal sphere |
 | Catch Your First Pal | Capturing | Triggered when players ask how to catch a Pal or about Pal spheres | capture Pal, first Pal |
 | Build a Palbox | Base Building | Player asks about storing or healing Pals | Palbox, storage, healing |
 | Establish a Starting Base | Base Building | When players want tips on their first base location | first base, starting base, base location |
-| Assign Pals to Work | Base Management | Player wants to automate tasks or assign Pals | assign Pals, base work, management |
+| Assign Pals to Work | Base Management | Players need to automate tasks and understand base assignments | assign Pals, base work, automation |
 | Gathering Food & Red Berries | Resources | When players ask how to feed themselves or Pals | food, hunger, red berries |
 | Craft Protective Clothing | Crafting | Player encounters extreme weather (cold/heat) | clothing, cold resistant, armor |
 | Increase Character Stats | Mechanics | When players inquire about leveling up or improving stats | level up, enhance stats |
-| Build the Capturing Device | Crafting | Questions about crafting Pal spheres | Pal spheres, crafting device |
-| Put Pals to Work | Base Management | Triggered when players need to understand base automation | base work, assignments |
 | Stay Alive & Survival Options | Survival | Player asks about survival basics | survival tips, health, hunger |
 | First Combat Tips | Combat | When players ask how to fight or defend early on | combat basics, fighting |
 
@@ -291,10 +291,11 @@ Each guide listed above has accompanying step‑by‑step instructions to help u
 2. Spend your accumulated **technology points** to unlock a new item or structure (e.g., Palbox or Pal Sphere blueprint).
 3. **Confirm the unlock**, then gather resources to craft the newly unlocked item.
 
-**Find Paldium & Craft Pal Spheres**
+**Find Paldium & Craft Pal Spheres (Capturing Device)**
 1. **Search near riversides and wetlands** for glowing blue rocks (Paldium nodes)【354485449518951†L225-L231】.
-2. **Mine Paldium fragments** with a pickaxe until you have enough pieces.
-3. **Combine Paldium fragments with wood and stone** at a workbench to craft Pal Spheres【354485449518951†L224-L252】.
+2. **Mine Paldium fragments** with a pickaxe until you have enough pieces for multiple captures.
+3. **Open the technology tree** to unlock the **Capturing Device** blueprint if it is not already unlocked, then gather the required wood and stone.
+4. **Combine the materials at a workbench** to craft Pal Spheres, stocking at least five so you can capture several new Pals without returning to base【354485449518951†L224-L252】.
 
 **Catch Your First Pal**
 1. **Craft several Pal Spheres** using the method above.
@@ -313,8 +314,9 @@ Each guide listed above has accompanying step‑by‑step instructions to help u
 
 **Assign Pals to Work**
 1. **Open the base management menu** via the Palbox【354485449518951†L329-L332】.
-2. Select a Pal with relevant work suitability (e.g., transport, kindling) and **assign it to a task**.
-3. Ensure Pals have access to required stations (e.g., furnace, farm) and monitor their SAN to avoid overwork.
+2. Select a Pal with relevant work suitability (e.g., Transporting, Kindling) and **assign it to the base roster** so it automatically picks up nearby jobs.
+3. **Guide the Pal toward the intended structure**—such as a furnace, farm plot or logging site—so it links with the workstation and begins performing the task.
+4. **Monitor SAN and workload** by checking the management screen; rotate duties or provide food and rest if morale drops to keep automation efficient.
 
 **Gathering Food & Red Berries**
 1. **Search for bushes** bearing red berries in the starting area.
@@ -330,16 +332,6 @@ Each guide listed above has accompanying step‑by‑step instructions to help u
 1. **Gain experience** by completing missions, defeating enemies and gathering resources.
 2. When you level up, open your **inventory/stats screen**【354485449518951†L382-L386】.
 3. Allocate the available stat points to Health, Stamina, Weight or other desired attributes.
-
-**Build the Capturing Device**
-1. Unlock the **Capturing Device** (Pal Sphere) blueprint from the tech tree.
-2. **Collect Paldium fragments, wood and stones**.
-3. Use the workbench to **craft Pal Spheres** for capturing Pals.
-
-**Put Pals to Work**
-1. **Assign a Pal** to the base using the management menu.
-2. Place the Pal near the desired production structure (e.g., farm, furnace).
-3. **Monitor the Pal’s SAN and efficiency**; provide food and rest as needed.
 
 **Stay Alive & Survival Options**
 1. **Keep your hunger bar filled** by eating berries, cooked meat or dishes.

--- a/palworld_full_route_normal_coop_optional.md
+++ b/palworld_full_route_normal_coop_optional.md
@@ -7,6 +7,7 @@
 > - Each bullet with `- [ ]` is a **checkbox step**. Your app can persist completion state so you and your son can pick up where you left off.  
 > - Steps marked **(Optional)** are non-blocking. Steps marked **(Co‑op Optional)** are designed for two players and should appear as separate, non-required checkboxes.  
 > - Keep the **“Chapter Checklist”** visible and collapse the **“Why / Tips”** section by default for a simpler kid UI.
+> - Need extra context?  Pair this route with the granular catalogue in **`palworld_complete_guide.md`** or the progression overview in **`palworld_purposeful_guides.md`**.
 
 ---
 

--- a/palworld_purposeful_guides.md
+++ b/palworld_purposeful_guides.md
@@ -1,7 +1,7 @@
 
 # Palworld Purposeful Progression Guides (2025)
 
-These guides are designed to replace the generic tips from earlier versions with **purpose‑driven, progression‑oriented routes**.  Each section lays out *what* you need to do, *why* it matters, and *where* to go (with coordinates) so you can chart a clear path from your first base to the end‑game.  After each objective you'll find a suggested **Next step** to help you chain tasks together naturally.
+These guides are designed to replace the generic tips from earlier versions with **purpose‑driven, progression‑oriented routes**.  Each section lays out *what* you need to do, *why* it matters, and *where* to go (with coordinates) so you can chart a clear path from your first base to the end‑game.  After each objective you'll find a suggested **Next step** to help you chain tasks together naturally.  Pair this document with the granular reference material in **`palworld_complete_guide.md`** and the family-friendly checklist route in **`palworld_full_route_normal_coop_optional.md`** to cover every playstyle.
 
 ## Early Game (Levels 1–10)
 
@@ -14,6 +14,8 @@ These guides are designed to replace the generic tips from earlier versions with
 4. **Craft basic tools:** Create a stone axe and pickaxe at the workbench and use them to harvest wood and stone more efficiently.  Save extra wood for Pal Spheres and campfires.
 5. **Unlock key tech:** Spend early technology points on the Palbox, Primitive Furnace, and Pal Sphere upgrades.  Ancient tech items (like the Grappling Gun) require ancient points from bosses【440006372449663†L112-L117】.
 
+*Related quick guides:* Establish a Starting Base; Build a Palbox; Assign Pals to Work.
+
 **Next step:** With your base established, craft 5–10 Pal Spheres and head out to capture your first Pals.
 
 ### 2. Capture Your First Working Pals
@@ -23,6 +25,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Capture Foxparks for Kindling:** Travel east to **(171, −473)**, near a river and waterfall, to find Fire‑type **Foxparks**【225842761179926†L61-L78】.  Bring a water‑type Pal like Pengullet.  Weaken Foxparks with water attacks and capture it with Pal Spheres【225842761179926†L82-L88】.  Assign it to kindling tasks at your campfire or furnace; it also drops Flame Organs and Leather【225842761179926†L98-L106】.
 3. **Assign Pals to work:** Use the Palbox to designate Lamball for Wool production, Tanzee for Lumbering, and Foxparks for Kindling.  This early automation speeds up resource collection.
 
+*Related quick guides:* Find Paldium & Craft Pal Spheres (Capturing Device); Catch Your First Pal; Assigning Work Pals (Transport, Kindling).
+
 **Next step:** Begin gathering rare materials like Leather and Paldium to unlock mounts and advanced crafting.
 
 ### 3. Harvest Leather and Paldium
@@ -30,6 +34,8 @@ These guides are designed to replace the generic tips from earlier versions with
 
 1. **Leather hunting:** Venture to areas north of the Plateau and hunt **Rushoars** and **Fuacks** for Leather.  Each Leather costs 150 Gold if purchased from merchants, but farming it yourself saves money.
 2. **Mine Paldium:** Search riverbeds and glowing blue rocks near your base to mine **Paldium fragments**【354485449518951†L225-L231】.  Gather at least 15 fragments to craft multiple Pal Spheres and prepare for mount harnesses.
+
+*Related quick guides:* Hunting for Leather & Wool; Gathering Paldium Fragments.
 
 **Next step:** With Leather and Paldium in hand, unlock your first mount.
 
@@ -39,6 +45,8 @@ These guides are designed to replace the generic tips from earlier versions with
 1. **Capture Eikthyrdeer Terra:** Travel to the **No. 1 Wildlife Sanctuary** at **(95, −729)**【376067536546693†L142-L145】.  Avoid PIDF guards or fight them if necessary【376067536546693†L146-L146】.  Bring high‑tier Pal Spheres and weaken the ground‑type Pal before capturing.
 2. **Unlock the saddle:** Reach **Level 12**, then spend two technology points to unlock the **Eikthyrdeer Saddle**【960495633276618†L192-L203】.  Gather **5 Leather, 20 Fiber, 10 Ingots, 3 Horns, and 15 Paldium fragments** to craft the saddle【960495633276618†L179-L191】.
 3. **Craft and equip:** Use the Pal Gear Workbench to craft the saddle.  Equip it in the Pal Gear menu and mount Eikthyrdeer to enjoy faster travel and increased logging efficiency【960495633276618†L206-L213】.
+
+*Related quick guides:* Capturing Specific Legendary Pals; Crafting Pal Gear & Saddles.
 
 **Next step:** Use your mount to explore mid‑game regions like **Cinnamoth Forest** (−77, −310) for sulfur and ore【715083186508802†L142-L148】.
 
@@ -51,6 +59,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Sealed Realm of the Guardian:** For coal farming, set up a satellite base near **(180, −39)**; this area has plentiful coal and is ideal for powering furnaces【715083186508802†L150-L155】.
 3. **Upgrade base level:** Build additional structures (e.g., Primitive Furnace, Ranch, Crusher) and assign Pals to them.  Completing more structures raises your base level, allowing you to employ more Pals simultaneously.
 
+*Related quick guides:* Base Location: Cinnamoth Forest; Base Location: Sealed Realm of the Guardian; Managing Base Sanity & Pal Morale.
+
 **Next step:** With resource production automated, prepare to challenge your first tower boss.
 
 ### 6. Confront the First Tower Boss (Zoe & Grizzbolt)
@@ -59,6 +69,8 @@ These guides are designed to replace the generic tips from earlier versions with
 1. **Gather a balanced team:** Assemble Pals with **Ground‑type** moves (e.g., Rushoar or Grizzbolt) to counter the boss’s **Electric** element【243842513808367†L60-L67】.  Reach at least Level 20 and craft firearms or crossbows.
 2. **Reach Rayne Syndicate Tower:** Travel west of your starting area to **(110, −431)**【243842513808367†L60-L67】.  Activate the fast travel point outside for quick access.
 3. **Prep and fight:** Equip healing items and ranged weapons.  During the fight, focus on dodging Grizzbolt’s electric attacks and exploit its weakness with Ground moves.  You must deal ~30k damage within 10 minutes.  Upon victory you receive several Ancient Technology Points.
+
+*Related quick guides:* Tower Boss: Zoe & Grizzbolt; First Combat Tips; Crafting Weapons: Crossbows, Bows & Guns.
 
 **Next step:** Spend your Ancient Technology Points on the **Grappling Gun** or **Egg Incubator**, then plan your next tower assault.
 
@@ -69,6 +81,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Duneshelter:** Travel to the Dessicated Desert at **(356, 346)**.  Bring heat protection for daytime and cold protection for night【751885980579990†L281-L286】.  Trade with merchants for weapons and ammo; be aware of NPCs glitching underground (reload the game to fix). 
 3. **Fisherman’s Point:** Visit **(−479, −745)** near Mount Obsidian【751885980579990†L298-L303】.  Buy seafood, fish Pals and other supplies.  Watch out for volcanic hazards if you venture inland.
 4. **Wandering merchant camps:** Look for merchants at **Marsh Island (432, −272)**, **Sea Breeze Archipelago (−189, −601)** and **Forgotten Island (−397, 17)**【751885980579990†L315-L337】.  Note the items each merchant specializes in (red vs. green)【751885980579990†L358-L379】.
+
+*Related quick guides:* Refreshing Vendor Stock; Selling & Trading Items; Vendor & Merchant Mechanics.
 
 **Next step:** Save up gold by selling extra Pals or resources to merchants; you’ll need funds for legendary spheres later.
 
@@ -81,6 +95,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Firearms:** Unlock **Musket** and **Handgun** technologies.  Craft **Gunpowder** by combining **Sulfur** and **Charcoal** in the Furnace, then craft bullets at the Weapon Workbench.
 3. **Lockpicking Tools v1–v3:** Craft lockpicks at the Workbench using **Ingot, Paldium** and **Fiber**.  Use them to open locked chests found in dungeons and supply drops.  Higher tiers open more complex locks.
 
+*Related quick guides:* Unlocking the Technology Tree; Crafting Weapons: Crossbows, Bows & Guns; Crafting Lockpicking Tools (v1‑v3).
+
 **Next step:** Continue leveling and collecting sulfur, coal and oil to prepare for later raids and bosses.
 
 ### 9. Challenge Subsequent Towers
@@ -90,6 +106,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Eternal Pyre Tower (Axel & Orserk):** Head to **(−584, −514)** in the southwestern volcanic region【243842513808367†L60-L67】.  Use **Ice** and **Ground** attacks against their Dragon/Electric elements.  Equip heat‑resistant armour.
 3. **Tower of the PIDF (Marcus & Faleris):** Located at **(558, 338)**【243842513808367†L60-L67】, this fight requires **Water‑type** Pals to exploit Faleris’ Fire weakness.  Craft extra cooling gear for the desert climate.
 4. **Pal Genetic Research Unit (Victor & Shadowbeak):** The final tower at **(−150, 440)** pits you against Dark/Dragon types【243842513808367†L60-L67】.  Bring **Dragon‑ and Ice‑type** Pals and the best weapons you have.
+
+*Related quick guides:* Tower Boss: Lily & Lyleen; Tower Boss: Axel & Orserk; Tower Boss: Victor & Shadowbeak.
 
 **Next step:** After clearing all towers, you’ll have ample Ancient Tech Points.  Invest in Electric Incubators, advanced saddles and end‑game weapons.
 
@@ -102,6 +120,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Frostallion (Ice Mount):** Seek out Frostallion in the snowy regions (coordinate details vary).  Use **Fire‑type** attacks and heavy armour.  The mount provides a fast ground‑and‑air hybrid ride and high damage.  
 3. **Other legendaries:** Hunt **Necromus, Paladius** and **Jormuntide Ignis** in high‑level regions; each requires specialised Pals and legendary spheres.  Consult updated patch notes for spawn coordinates and strategies.
 
+*Related quick guides:* Capturing Specific Legendary Pals; Pal Sphere Tiers & Catch Rates; Best Pals for Combat.
+
 **Next step:** With multiple legendary mounts, you can tackle world events, raids and co‑op challenges with ease.
 
 ### 11. Complete Raids and Seasonal Events
@@ -111,6 +131,8 @@ These guides are designed to replace the generic tips from earlier versions with
 2. **Stock supplies:** Craft hundreds of bullets, rockets, potions and food.  Bring backup weapons and armour sets tailored to the raid’s element.
 3. **Learn mechanics:** Pay attention to raid cues (e.g., telegraphed AoE attacks) and prioritise adds (minions) when they spawn.  Use terrain to your advantage.
 4. **Claim rewards:** Defeating a raid boss yields powerful gear, rare Pals and cosmetic items.  Repeat raids for better rolls.
+
+*Related quick guides:* Raids: Xenolord & Blazamut Ryu; Raid: Bellanoir & Bellanoir Libero; Boss: Moon Lord Raid.
 
 **Next step:** Participate in limited‑time events (e.g., **Terraria** crossover) to obtain unique Pals and skins.
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,15 @@ Routes are adaptive in three ways:
 2. **Resource dependencies** – When a route requires materials (e.g. a saddle needing Leather), it either contains steps to gather those materials or branches to a **resource subroute**.  The amount of material required is calculated from the current recipe (plus a buffer for Hardcore).  This ensures players never get stuck because they are missing ingredients.
 3. **Dynamic rules** – Each route now ships with machine-readable triggers (level gaps, time budgets, resource shortages, party composition, player goals) that tell the recommender how to pivot the route.  When the player’s context matches a rule, Palmate explains the adjustment (e.g. “Skip the capture step and craft now”) and boosts that route’s score.
 
+## Guide Suite
+
+| File | Audience | Purpose |
+| --- | --- | --- |
+| `guides.md` | Palmate runtime & integrators | Master data file with schema, ontologies, XP tables and machine-readable routes. |
+| `palworld_complete_guide.md` | Researchers, tool builders | Encyclopedic catalogue of every quick guide plus detailed step-by-step instructions, now aligned with the other documents. |
+| `palworld_purposeful_guides.md` | Players seeking a directed campaign | Goal-driven progression playbooks that link out to the relevant quick guides and missions. |
+| `palworld_full_route_normal_coop_optional.md` | Families and co-op duos on Normal | Checkbox-focused story route covering all towers with optional co-op chores and kid-friendly wording. |
+
 ## Data Layout
 
 All game data lives in **guides.md**.  The file is organised into human‑readable sections followed by machine‑readable JSON blocks.  The main sections are:


### PR DESCRIPTION
## Summary
- link the catalogue, progression playbooks, and family route so each guide explains how it fits into the suite
- merge duplicate "capturing device" and "put pals to work" entries in the catalogue while expanding the shared steps
- add cross references from the purposeful progression guide back to the relevant quick guides and document the guide suite in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc7518a8c48331ab40d3a13d19efdc