### PR TITLE
Add purposeful progression guides to route UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -270,6 +270,40 @@ gba(119,141,169,0.45)}
 .guide-catalog__keywords{display:flex;flex-wrap:wrap;gap:6px;margin:0}
 .guide-catalog__keyword{padding:4px 10px;border-radius:999px;background:rgba(119,141,169,0.18);border:1px solid rgba(119,141,169,0.32);font-size:.75rem;font-weight:600;color:rgba(224,225,221,0.85)}
 .guide-catalog__steps{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.92rem;color:rgba(224,225,221,0.85)}
+.purposeful-guides{display:grid;gap:20px}
+.purposeful-guides__header{display:flex;flex-direction:column;gap:6px}
+.purposeful-guides__header h3{margin:0;font-size:1.3rem}
+.purposeful-guides__header p{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72))}
+.purposeful-guides__count{font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.82)}
+.purposeful-guides__controls{display:grid;gap:12px}
+@media (min-width:720px){.purposeful-guides__controls{grid-template-columns:260px 1fr;align-items:start}}
+.purposeful-guides__search{display:flex;align-items:center;gap:10px;padding:0 14px;background:rgba(10,22,40,0.82);border:1px solid rgba(119,141,169,0.28);border-radius:16px}
+.purposeful-guides__search input{flex:1;background:transparent;border:none;color:var(--text,#f0f4f8);font-size:1rem;padding:12px 0}
+.purposeful-guides__search input:focus-visible{outline:none}
+.purposeful-guides__filters{display:flex;flex-wrap:wrap;gap:12px}
+.purposeful-guides__filters label{display:flex;flex-direction:column;gap:6px;font-size:.8rem;letter-spacing:.06em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
+.purposeful-guides__filters select{min-width:180px;background:rgba(13,27,42,0.7);border:1px solid rgba(119,141,169,0.35);border-radius:12px;color:var(--text,#f0f4f8);padding:10px 12px;font-size:.95rem}
+.purposeful-guides__filters select:disabled{opacity:.55}
+.purposeful-guides__filters select:focus-visible{outline:none;border-color:var(--accent,#778da9);box-shadow:0 0 0 2px rgba(119,141,169,0.35)}
+.purposeful-guides__list{display:grid;gap:14px}
+.purposeful-guides__empty{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:18px 0}
+.purposeful-guide__item{display:grid;gap:12px;padding:16px;border-radius:18px;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.26);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}
+.purposeful-guide__header{display:flex;flex-wrap:wrap;gap:12px;justify-content:space-between;align-items:flex-start}
+.purposeful-guide__title-block{display:flex;flex-direction:column;gap:4px;min-width:0}
+.purposeful-guide__title{margin:0;font-size:1.15rem}
+.purposeful-guide__subtitle{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.9rem}
+.purposeful-guide__labels{display:flex;flex-wrap:wrap;gap:8px}
+.purposeful-guide__badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:rgba(148,210,189,0.18);border:1px solid rgba(148,210,189,0.45);font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.88)}
+.purposeful-guide__badge--sub{background:rgba(119,141,169,0.2);border-color:rgba(119,141,169,0.45)}
+.purposeful-guide__purpose{margin:0;color:rgba(224,225,221,0.85);line-height:1.5}
+.purposeful-guide__steps{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.95rem;color:rgba(224,225,221,0.88)}
+.purposeful-guide__steps li{line-height:1.45}
+.purposeful-guide__related{display:grid;gap:6px}
+.purposeful-guide__related h5{margin:0;font-size:.78rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
+.purposeful-guide__related-chips{display:flex;flex-wrap:wrap;gap:8px}
+.purposeful-guide__related-chip{padding:4px 10px;border-radius:999px;background:rgba(119,141,169,0.2);border:1px solid rgba(119,141,169,0.4);font-size:.78rem;font-weight:600;color:rgba(224,225,221,0.88)}
+.purposeful-guide__next{margin:0;font-size:.92rem;color:rgba(224,225,221,0.88)}
+.purposeful-guide__reference{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;background:rgba(119,141,169,0.18);border:1px solid rgba(119,141,169,0.32);font-size:.85rem;font-weight:600}
 
 .route-overview__insights{display:grid;gap:16px;margin-top:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 .route-overview__insight{display:grid;gap:8px;padding:14px;border-radius:16px;background:rgba(8,16,32,0.75);border:1px solid rgba(119,141,169,0.26);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}

--- a/index.html
+++ b/index.html
@@ -9337,6 +9337,9 @@
     let guideCatalogSearchTerm = '';
     let guideCatalogGroupFilter = 'all';
     let guideCatalogCategoryFilter = 'all';
+    let purposefulGuidesSearchTerm = '';
+    let purposefulGuidesSectionFilter = 'all';
+    let purposefulGuidesSubsectionFilter = 'all';
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
@@ -9541,6 +9544,7 @@
         .then(guide => {
           routeGuideData = guide;
           ensureGuideCatalogFiltersValid();
+          ensurePurposefulGuideFiltersValid();
           return routeGuideData;
         })
         .catch(err => {
@@ -9706,6 +9710,7 @@
         catalogData = await loadGuideCatalog(catalogMeta);
       }
       const preparedCatalog = prepareGuideCatalog(catalogData, catalogMeta);
+      const purposefulGuides = await loadPurposefulGuides();
       return {
         metadata: parsed?.metadata || null,
         xp: parsed?.xp || null,
@@ -9718,7 +9723,8 @@
         keyResources: sortedResources.slice(0, 24),
         extras: parsed?.extras || [],
         errors: parsed?.errors || [],
-        guideCatalog: preparedCatalog
+        guideCatalog: preparedCatalog,
+        purposefulGuides
       };
     }
 
@@ -9804,6 +9810,317 @@
       return { entries, groups, meta: meta || null, count: entries.length };
     }
 
+    async function loadPurposefulGuides(){
+      try {
+        const res = await fetch('palworld_purposeful_guides.md');
+        if(!res.ok){
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const text = await res.text();
+        const parsed = parsePurposefulGuideMarkdown(text || '');
+        return preparePurposefulGuideData(parsed);
+      } catch(err){
+        console.warn('Failed to load purposeful guides', err);
+      }
+      return null;
+    }
+
+    function parsePurposefulGuideMarkdown(markdown){
+      if(typeof markdown !== 'string' || !markdown.trim()){
+        return { sections: [] };
+      }
+      const lines = markdown.split(/\r?\n/);
+      const sections = [];
+      let currentSection = null;
+      let currentSubsection = null;
+      let currentEntry = null;
+      let seenPrimarySection = false;
+
+      const headingRegex = /^##\s+(.*)$/;
+      const subheadingRegex = /^###\s+(.*)$/;
+      const missionEntryRegex = /^\*\*(.+?)\*\*\s*[\u2013-]\s*(.+)$/;
+      const purposeRegex = /^\*Purpose:\*\s*(.*)$/i;
+      const relatedRegex = /^\*Related quick guides:\*\s*(.*)$/i;
+      const nextRegex = /^\*\*Next step:\*\*\s*(.*)$/i;
+      const stepRegex = /^(\d+)\.\s+(.*)$/;
+
+      function pushCurrentSection(){
+        finalizeEntry();
+        finalizeSubsection();
+        if(currentSection && Array.isArray(currentSection.subsections) && currentSection.subsections.length){
+          sections.push(currentSection);
+        }
+        currentSection = null;
+      }
+
+      function startSection(title){
+        finalizeEntry();
+        finalizeSubsection();
+        if(currentSection){
+          pushCurrentSection();
+        }
+        currentSection = { title: normalizeHeadingText(title), subsections: [] };
+        seenPrimarySection = true;
+      }
+
+      function startSubsection(title){
+        finalizeEntry();
+        if(currentSubsection && currentSection){
+          if(currentSubsection.entries.length){
+            currentSection.subsections.push(currentSubsection);
+          }
+        }
+        currentSubsection = { title: normalizeHeadingText(title), entries: [] };
+        currentEntry = null;
+      }
+
+      function startEntry(title, subtitle){
+        finalizeEntry();
+        if(!currentSection){
+          startSection(title || 'Progression');
+        }
+        if(!currentSubsection){
+          startSubsection(title || currentSection.title || 'Objectives');
+        }
+        currentEntry = {
+          title: normalizeHeadingText(title),
+          subtitle: stripMarkdownFormatting(subtitle),
+          purpose: '',
+          steps: [],
+          related: [],
+          nextStep: ''
+        };
+      }
+
+      function ensureEntry(){
+        if(!currentEntry){
+          const fallback = currentSubsection ? currentSubsection.title : (currentSection ? currentSection.title : 'Guide');
+          startEntry(fallback, '');
+        }
+      }
+
+      function finalizeEntry(){
+        if(currentEntry && currentSubsection){
+          currentEntry.steps = currentEntry.steps.filter(step => step && step.text);
+          currentEntry.related = currentEntry.related.filter(Boolean);
+          if(
+            currentEntry.title ||
+            currentEntry.subtitle ||
+            currentEntry.purpose ||
+            currentEntry.steps.length ||
+            currentEntry.nextStep
+          ){
+            currentSubsection.entries.push(currentEntry);
+          }
+        }
+        currentEntry = null;
+      }
+
+      function finalizeSubsection(){
+        finalizeEntry();
+        if(currentSubsection && currentSection){
+          if(currentSubsection.entries.length){
+            currentSection.subsections.push(currentSubsection);
+          }
+        }
+        currentSubsection = null;
+      }
+
+      for(const rawLine of lines){
+        const line = rawLine.trim();
+        if(!line) continue;
+        const headingMatch = line.match(headingRegex);
+        if(headingMatch){
+          startSection(headingMatch[1]);
+          continue;
+        }
+        const subheadingMatch = line.match(subheadingRegex);
+        if(subheadingMatch){
+          if(!currentSection){
+            startSection(subheadingMatch[1]);
+          }
+          startSubsection(subheadingMatch[1]);
+          continue;
+        }
+        if(!seenPrimarySection){
+          continue;
+        }
+        const missionMatch = line.match(missionEntryRegex);
+        if(missionMatch){
+          if(!currentSection){
+            startSection(missionMatch[1]);
+          }
+          if(!currentSubsection){
+            startSubsection(currentSection.title || missionMatch[1]);
+          }
+          startEntry(missionMatch[1], missionMatch[2]);
+          continue;
+        }
+        const purposeMatch = line.match(purposeRegex);
+        if(purposeMatch){
+          ensureEntry();
+          if(currentEntry){
+            currentEntry.purpose = purposeMatch[1].trim();
+          }
+          continue;
+        }
+        const relatedMatch = line.match(relatedRegex);
+        if(relatedMatch){
+          ensureEntry();
+          if(currentEntry){
+            currentEntry.related = parseRelatedGuideList(relatedMatch[1]);
+          }
+          continue;
+        }
+        const nextMatch = line.match(nextRegex);
+        if(nextMatch){
+          ensureEntry();
+          if(currentEntry){
+            currentEntry.nextStep = nextMatch[1].trim();
+          }
+          continue;
+        }
+        const stepMatch = line.match(stepRegex);
+        if(stepMatch){
+          ensureEntry();
+          if(currentEntry){
+            const order = Number(stepMatch[1]);
+            const text = stepMatch[2].trim();
+            currentEntry.steps.push({ order: Number.isFinite(order) ? order : currentEntry.steps.length + 1, text });
+          }
+          continue;
+        }
+        ensureEntry();
+        if(currentEntry){
+          if(currentEntry.steps.length){
+            const last = currentEntry.steps[currentEntry.steps.length - 1];
+            last.text = `${last.text} ${line}`.trim();
+          } else if(currentEntry.purpose){
+            currentEntry.purpose = `${currentEntry.purpose} ${line}`.trim();
+          } else if(!currentEntry.title){
+            currentEntry.title = normalizeHeadingText(line);
+          } else {
+            currentEntry.steps.push({ order: currentEntry.steps.length + 1, text: line });
+          }
+        }
+      }
+
+      pushCurrentSection();
+      return { sections };
+    }
+
+    function preparePurposefulGuideData(parsed){
+      if(!parsed || !Array.isArray(parsed.sections)){
+        return null;
+      }
+      const sections = [];
+      const entries = [];
+      parsed.sections.forEach((section, sectionIndex) => {
+        if(!section || !Array.isArray(section.subsections) || !section.subsections.length) return;
+        const sectionTitle = section.title || `Section ${sectionIndex + 1}`;
+        const sectionId = slugifyForPalworld(sectionTitle) || `purposeful-section-${sectionIndex + 1}`;
+        const preparedSubsections = [];
+        section.subsections.forEach((subsection, subsectionIndex) => {
+          if(!subsection || !Array.isArray(subsection.entries) || !subsection.entries.length) return;
+          const subsectionTitle = subsection.title || `Objective ${subsectionIndex + 1}`;
+          const subsectionId = slugifyForPalworld(`${sectionId}-${subsectionTitle}`) || `${sectionId}-objective-${subsectionIndex + 1}`;
+          const preparedEntries = [];
+          subsection.entries.forEach((entry, entryIndex) => {
+            if(!entry) return;
+            const entryTitle = entry.title || subsectionTitle;
+            const entryId = slugifyForPalworld(`${subsectionId}-${entryTitle}`) || `${subsectionId}-entry-${entryIndex + 1}`;
+            const steps = Array.isArray(entry.steps)
+              ? entry.steps.map((step, stepIndex) => ({
+                  order: Number.isFinite(Number(step?.order)) ? Number(step.order) : stepIndex + 1,
+                  text: step?.text ? String(step.text).trim() : ''
+                })).filter(step => step.text)
+              : [];
+            steps.sort((a, b) => (a.order || 0) - (b.order || 0));
+            const related = Array.isArray(entry.related)
+              ? entry.related.map(value => stripMarkdownFormatting(String(value))).filter(Boolean)
+              : [];
+            const purpose = entry.purpose ? String(entry.purpose).trim() : '';
+            const nextStep = entry.nextStep ? String(entry.nextStep).trim() : '';
+            const subtitle = entry.subtitle ? String(entry.subtitle).trim() : '';
+            const searchParts = [
+              sectionTitle,
+              subsectionTitle,
+              entryTitle,
+              subtitle,
+              purpose,
+              nextStep,
+              related.join(' '),
+              steps.map(step => step.text).join(' ')
+            ];
+            const searchText = searchParts.join(' ').toLowerCase();
+            const preparedEntry = {
+              id: entryId,
+              title: entryTitle,
+              subtitle,
+              purpose,
+              steps,
+              related,
+              nextStep,
+              sectionId,
+              sectionTitle,
+              subsectionId,
+              subsectionTitle,
+              searchText
+            };
+            preparedEntries.push(preparedEntry);
+            entries.push(preparedEntry);
+          });
+          if(preparedEntries.length){
+            preparedSubsections.push({
+              id: subsectionId,
+              title: subsectionTitle,
+              entries: preparedEntries
+            });
+          }
+        });
+        if(preparedSubsections.length){
+          sections.push({
+            id: sectionId,
+            title: sectionTitle,
+            subsections: preparedSubsections
+          });
+        }
+      });
+      if(!sections.length || !entries.length){
+        return null;
+      }
+      return {
+        sections,
+        entries,
+        count: entries.length,
+        source: 'palworld_purposeful_guides.md'
+      };
+    }
+
+    function normalizeHeadingText(text){
+      const stripped = stripMarkdownFormatting(text);
+      return stripped.replace(/^\d+\.\s*/, '').trim();
+    }
+
+    function stripMarkdownFormatting(text){
+      if(!text) return '';
+      return String(text)
+        .replace(/!\[[^\]]*?\]\([^)]*?\)/g, '')
+        .replace(/\[([^\]]+)]\(([^)]+)\)/g, '$1')
+        .replace(/[`*_~]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function parseRelatedGuideList(text){
+      if(!text) return [];
+      return text
+        .split(/[;,•]/)
+        .map(part => stripMarkdownFormatting(part))
+        .map(part => part.replace(/^[-–—]\s*/, '').trim())
+        .filter(Boolean);
+    }
+
     function ensureGuideCatalogFiltersValid(){
       const catalog = routeGuideData?.guideCatalog;
       if(!catalog || !Array.isArray(catalog.entries)){
@@ -9826,6 +10143,30 @@
       }
       if(guideCatalogCategoryFilter !== 'all' && !categorySet.has(guideCatalogCategoryFilter)){
         guideCatalogCategoryFilter = 'all';
+      }
+    }
+
+    function ensurePurposefulGuideFiltersValid(){
+      const purposeful = routeGuideData?.purposefulGuides;
+      if(!purposeful || !Array.isArray(purposeful.sections) || !purposeful.sections.length){
+        purposefulGuidesSectionFilter = 'all';
+        purposefulGuidesSubsectionFilter = 'all';
+        return;
+      }
+      if(purposefulGuidesSectionFilter !== 'all' && !purposeful.sections.some(section => section.id === purposefulGuidesSectionFilter)){
+        purposefulGuidesSectionFilter = 'all';
+      }
+      if(purposefulGuidesSectionFilter === 'all'){
+        purposefulGuidesSubsectionFilter = 'all';
+        return;
+      }
+      const section = purposeful.sections.find(entry => entry.id === purposefulGuidesSectionFilter);
+      if(!section || !Array.isArray(section.subsections) || !section.subsections.length){
+        purposefulGuidesSubsectionFilter = 'all';
+        return;
+      }
+      if(purposefulGuidesSubsectionFilter !== 'all' && !section.subsections.some(sub => sub.id === purposefulGuidesSubsectionFilter)){
+        purposefulGuidesSubsectionFilter = 'all';
       }
     }
 
@@ -11188,6 +11529,145 @@
       `;
     }
 
+    function renderPurposefulSectionOptions(data){
+      const labelAll = kidMode ? 'All arcs' : 'All stages';
+      const options = [`<option value="all"${purposefulGuidesSectionFilter === 'all' ? ' selected' : ''}>${escapeHTML(labelAll)}</option>`];
+      if(!data || !Array.isArray(data.sections)){
+        return options.join('');
+      }
+      data.sections.forEach(section => {
+        if(!section) return;
+        const value = section.id || slugifyForPalworld(section.title);
+        const selected = value === purposefulGuidesSectionFilter ? ' selected' : '';
+        const label = section.title || 'Stage';
+        options.push(`<option value="${escapeHTML(value)}"${selected}>${escapeHTML(label)}</option>`);
+      });
+      return options.join('');
+    }
+
+    function renderPurposefulSubsectionOptions(data){
+      const labelAll = kidMode ? 'All objectives' : 'All objectives';
+      const options = [`<option value="all"${purposefulGuidesSubsectionFilter === 'all' ? ' selected' : ''}>${escapeHTML(labelAll)}</option>`];
+      if(!data || !Array.isArray(data.sections)){
+        return options.join('');
+      }
+      if(purposefulGuidesSectionFilter === 'all'){
+        return options.join('');
+      }
+      const section = data.sections.find(entry => entry && entry.id === purposefulGuidesSectionFilter);
+      if(!section || !Array.isArray(section.subsections)){
+        return options.join('');
+      }
+      section.subsections.forEach(sub => {
+        if(!sub) return;
+        const value = sub.id || slugifyForPalworld(sub.title);
+        const selected = value === purposefulGuidesSubsectionFilter ? ' selected' : '';
+        const label = sub.title || 'Objective';
+        options.push(`<option value="${escapeHTML(value)}"${selected}>${escapeHTML(label)}</option>`);
+      });
+      return options.join('');
+    }
+
+    function renderPurposefulGuideList(){
+      const card = document.getElementById('purposefulGuidesCard');
+      if(!card) return;
+      const list = card.querySelector('#purposefulGuidesList');
+      if(!list) return;
+      const countEl = card.querySelector('[data-purposeful-count]');
+      const data = routeGuideData?.purposefulGuides;
+      if(!data || !Array.isArray(data.entries) || !data.entries.length){
+        if(countEl) countEl.textContent = '';
+        if(list) list.innerHTML = `<p class="purposeful-guides__empty">${escapeHTML(kidMode ? 'Purposeful guides will appear here once loaded.' : 'Purposeful guides are not available yet.')}</p>`;
+        return;
+      }
+      let entries = data.entries.slice();
+      if(purposefulGuidesSectionFilter !== 'all'){
+        entries = entries.filter(entry => entry.sectionId === purposefulGuidesSectionFilter);
+      }
+      if(purposefulGuidesSubsectionFilter !== 'all'){
+        entries = entries.filter(entry => entry.subsectionId === purposefulGuidesSubsectionFilter);
+      }
+      const query = (purposefulGuidesSearchTerm || '').trim().toLowerCase();
+      if(query){
+        entries = entries.filter(entry => entry.searchText.includes(query));
+      }
+      if(countEl){
+        if(entries.length){
+          const singular = kidMode ? 'playbook' : 'guide';
+          const plural = kidMode ? 'playbooks' : 'guides';
+          const noun = entries.length === 1 ? singular : plural;
+          countEl.textContent = `${entries.length} ${noun}`;
+        } else {
+          countEl.textContent = '';
+        }
+      }
+      if(!entries.length){
+        list.innerHTML = `<p class="purposeful-guides__empty">${escapeHTML(kidMode ? 'No arcs match your filters yet.' : 'No guides match those filters yet.')}</p>`;
+        return;
+      }
+      list.innerHTML = entries.map(entry => renderPurposefulGuideEntry(entry)).join('');
+    }
+
+    function renderPurposefulGuideEntry(entry){
+      if(!entry) return '';
+      const sectionLabel = entry.sectionTitle || '';
+      const subsectionLabel = entry.subsectionTitle || '';
+      const subtitleHtml = entry.subtitle
+        ? `<p class="purposeful-guide__subtitle">${renderSimpleMarkdown(entry.subtitle)}</p>`
+        : '';
+      const purposeHtml = entry.purpose
+        ? `<p class="purposeful-guide__purpose">${renderSimpleMarkdown(entry.purpose)}</p>`
+        : '';
+      const steps = Array.isArray(entry.steps) ? entry.steps.filter(step => step && step.text) : [];
+      const firstOrder = steps.length ? steps[0].order : 1;
+      const startAttr = steps.length && Number.isFinite(firstOrder) && firstOrder !== 1 ? ` start="${firstOrder}"` : '';
+      const stepsHtml = steps.length
+        ? `<ol class="purposeful-guide__steps"${startAttr}>${steps.map(step => `<li>${renderSimpleMarkdown(step.text)}</li>`).join('')}</ol>`
+        : '';
+      const relatedHtml = entry.related && entry.related.length
+        ? `<div class="purposeful-guide__related"><h5>${escapeHTML(kidMode ? 'Quick guide helpers' : 'Related quick guides')}</h5><div class="purposeful-guide__related-chips">${entry.related.map(label => `<span class="purposeful-guide__related-chip">${escapeHTML(label)}</span>`).join('')}</div></div>`
+        : '';
+      const nextHtml = entry.nextStep
+        ? `<p class="purposeful-guide__next"><strong>${escapeHTML(kidMode ? 'Next step:' : 'Next step:')}</strong> ${renderSimpleMarkdown(entry.nextStep)}</p>`
+        : '';
+      return `
+        <article class="purposeful-guide__item">
+          <header class="purposeful-guide__header">
+            <div class="purposeful-guide__title-block">
+              <h4 class="purposeful-guide__title">${escapeHTML(entry.title || subsectionLabel || sectionLabel || 'Guide')}</h4>
+              ${subtitleHtml}
+            </div>
+            <div class="purposeful-guide__labels">
+              ${sectionLabel ? `<span class="purposeful-guide__badge purposeful-guide__badge--section">${escapeHTML(sectionLabel)}</span>` : ''}
+              ${subsectionLabel ? `<span class="purposeful-guide__badge purposeful-guide__badge--sub">${escapeHTML(subsectionLabel)}</span>` : ''}
+            </div>
+          </header>
+          ${purposeHtml}
+          ${stepsHtml}
+          ${relatedHtml}
+          ${nextHtml}
+        </article>
+      `;
+    }
+
+    function renderSimpleMarkdown(text){
+      if(text == null) return '';
+      let html = String(text);
+      html = html
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+      html = html.replace(/\[\[([^\]]+)\]\]/g, '<span class="purposeful-guide__reference">$1</span>');
+      html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+      html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+      html = html.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, (match, prefix, content) => `${prefix}<em>${content}</em>`);
+      html = html.replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+      html = html.replace(/\n/g, '<br />');
+      return html;
+    }
+
     function renderGuideCatalogList(){
       const card = document.getElementById('guideCatalogCard');
       if(!card) return;
@@ -11341,6 +11821,19 @@
               : 'Browse the complete guide catalog as soon as it loads.');
           const groupOptions = renderGuideCatalogGroupOptions(catalog);
           const categoryOptions = renderGuideCatalogCategoryOptions(catalog);
+          const purposeful = routeGuideData?.purposefulGuides;
+          const purposefulCount = purposeful?.count != null
+            ? purposeful.count
+            : (Array.isArray(purposeful?.entries) ? purposeful.entries.length : 0);
+          const purposefulLead = purposefulCount
+            ? (kidMode
+              ? `Follow ${purposefulCount} story arcs from your first base to the toughest raids.`
+              : `Explore ${purposefulCount} purposeful playbooks from fresh spawns to end-game raids.`)
+            : (kidMode
+              ? 'Load the purposeful playbooks once data finishes downloading.'
+              : 'Load the purposeful playbooks after the data finishes downloading.');
+          const purposefulSectionOptions = renderPurposefulSectionOptions(purposeful);
+          const purposefulSubsectionOptions = renderPurposefulSubsectionOptions(purposeful);
           node.innerHTML = `
           <header class="page-header">
             <h2>${escapeHTML(heading)}</h2>
@@ -11418,6 +11911,30 @@
               </div>
             </details>
           </section>
+          <section class="card purposeful-guides" id="purposefulGuidesCard">
+            <div class="purposeful-guides__header">
+              <h3>${escapeHTML(kidMode ? 'Purposeful playbooks' : 'Purposeful progression guides')}</h3>
+              <p>${escapeHTML(purposefulLead)}</p>
+              <span class="purposeful-guides__count" data-purposeful-count></span>
+            </div>
+            <div class="purposeful-guides__controls">
+              <label class="purposeful-guides__search">
+                <span class="sr-only">${escapeHTML(kidMode ? 'Search playbooks' : 'Search purposeful guides')}</span>
+                <input type="search" id="purposefulGuidesSearch" placeholder="${escapeHTML(kidMode ? 'Search story arcs' : 'Search playbooks')}" value="${escapeHTML(purposefulGuidesSearchTerm)}" />
+              </label>
+              <div class="purposeful-guides__filters">
+                <label>
+                  <span>${escapeHTML(kidMode ? 'Game stage' : 'Game stage')}</span>
+                  <select id="purposefulGuidesSection">${purposefulSectionOptions}</select>
+                </label>
+                <label>
+                  <span>${escapeHTML(kidMode ? 'Focus route' : 'Focus route')}</span>
+                  <select id="purposefulGuidesSubsection" ${purposefulGuidesSectionFilter === 'all' ? 'disabled' : ''}>${purposefulSubsectionOptions}</select>
+                </label>
+              </div>
+            </div>
+            <div class="purposeful-guides__list" id="purposefulGuidesList"></div>
+          </section>
           <section class="card guide-catalog" id="guideCatalogCard">
             <div class="guide-catalog__header">
               <h3>${escapeHTML(kidMode ? 'Guide encyclopedia' : 'Complete guide index')}</h3>
@@ -11448,6 +11965,7 @@
           pruneCompletedActiveRoutes();
           renderActiveRoutesList();
           renderRouteLibraryList();
+          renderPurposefulGuideList();
           renderGuideCatalogList();
           const librarySearch = node.querySelector('#routeLibrarySearch');
           if(librarySearch && !librarySearch.dataset.bound){
@@ -11459,6 +11977,7 @@
             });
           }
           bindRouteLibraryControls(node);
+          bindPurposefulGuideControls(node);
           bindGuideCatalogControls(node);
           wrap.addEventListener('change', handleRouteCheckboxChange);
           wrap.addEventListener('click', handleRouteClick);
@@ -11873,6 +12392,7 @@
     let routeContextControlAbort = null;
     let routeLibraryControlsAbort = null;
     let guideCatalogControlsAbort = null;
+    let purposefulGuideControlsAbort = null;
 
     function bindRouteContextControls(root, { guide } = {}){
       if(!root) return;
@@ -12028,6 +12548,54 @@
           renderRouteLibraryList();
         }
       }, { signal });
+    }
+
+    function bindPurposefulGuideControls(root){
+      if(!root) return;
+      const card = root.querySelector('#purposefulGuidesCard');
+      if(!card) return;
+      if(purposefulGuideControlsAbort){
+        purposefulGuideControlsAbort.abort();
+      }
+      purposefulGuideControlsAbort = new AbortController();
+      const { signal } = purposefulGuideControlsAbort;
+      const searchInput = card.querySelector('#purposefulGuidesSearch');
+      const sectionSelect = card.querySelector('#purposefulGuidesSection');
+      const subsectionSelect = card.querySelector('#purposefulGuidesSubsection');
+
+      if(searchInput){
+        searchInput.value = purposefulGuidesSearchTerm;
+        searchInput.addEventListener('input', () => {
+          purposefulGuidesSearchTerm = searchInput.value || '';
+          renderPurposefulGuideList();
+        }, { signal });
+      }
+
+      function refreshSubsectionOptions(){
+        if(!subsectionSelect) return;
+        subsectionSelect.innerHTML = renderPurposefulSubsectionOptions(routeGuideData?.purposefulGuides);
+        subsectionSelect.value = purposefulGuidesSubsectionFilter;
+        subsectionSelect.disabled = purposefulGuidesSectionFilter === 'all';
+      }
+
+      if(sectionSelect){
+        sectionSelect.value = purposefulGuidesSectionFilter;
+        sectionSelect.addEventListener('change', () => {
+          purposefulGuidesSectionFilter = sectionSelect.value || 'all';
+          purposefulGuidesSubsectionFilter = 'all';
+          ensurePurposefulGuideFiltersValid();
+          refreshSubsectionOptions();
+          renderPurposefulGuideList();
+        }, { signal });
+      }
+
+      if(subsectionSelect){
+        refreshSubsectionOptions();
+        subsectionSelect.addEventListener('change', () => {
+          purposefulGuidesSubsectionFilter = subsectionSelect.value || 'all';
+          renderPurposefulGuideList();
+        }, { signal });
+      }
     }
 
     function bindGuideCatalogControls(root){


### PR DESCRIPTION
## Summary
- parse palworld_purposeful_guides.md into structured progression data when loading the planner
- surface a new Purposeful Playbooks card with search and stage/focus filters alongside the existing catalog
- add styling for the purposeful guide list, chips, and reference badges to match the current theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc76ff9b6c833188c78988299fe0ec