### PR TITLE
Improve route planner persistence and responsive styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -18,6 +18,8 @@
 .btn{background:var(--secondary,#415a77);border:none;border-radius:999px;color:var(--text,#f0f4f8);cursor:pointer;font-size:0.95rem;font-weight:600;padding:10px 18px;transition:transform 0.2s ease,background 0.2s ease;min-height:44px}
 .btn:hover{background:var(--accent,#778da9);transform:translateY(-1px)}
 .btn:active{transform:scale(0.98)}
+.btn--ghost{background:rgba(13,27,42,0.5);border:1px solid rgba(119,141,169,0.35);color:var(--text,#f0f4f8);transition:border-color 0.25s ease,background 0.25s ease,color 0.25s ease}
+.btn--ghost:hover,.btn--ghost:focus-visible{background:rgba(13,27,42,0.7);border-color:rgba(148,210,189,0.55);color:var(--accent,#778da9);outline:none}
 .chip{display:inline-flex;align-items:center;justify-content:center;padding:8px 14px;border-radius:999px;background:rgba(119,141,169,0.18);color:var(--text,#f0f4f8);font-size:0.9rem;font-weight:600;text-decoration:none;border:1px solid rgba(119,141,169,0.4);min-height:40px}
 .chip.link{cursor:pointer;background:rgba(119,141,169,0.24)}
 .chip.link:hover{background:rgba(119,141,169,0.4)}
@@ -71,23 +73,92 @@ gba(119,141,169,0.45)}
 0.25);border:1px solid rgba(255,255,255,0.08)}
 .tech-materials span:last-child{font-variant-numeric:tabular-nums;font-weight:600;color:rgba(224,225,221,0.95)}
 .step-group{margin:12px 0}
-.step-list{display:grid;gap:10px;margin:12px 0}
-.step{display:flex;align-items:flex-start;gap:12px;padding:10px;border:1px solid #22314A;border-radius:12px;background:#101828}
-.step input[type=checkbox]{width:24px;height:24px}
-.step.optional{opacity:.95}
-.step-meta{display:flex;flex-direction:column;gap:6px;flex:1}
-.step .step-text{line-height:1.4}
-.step .badges{margin-left:auto}
-.step-category{display:inline-flex;align-items:center;font-size:.7rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:2px 10px;border-radius:999px;background:rgba(119,141,169,0.2);color:#e0e9f5}
-.step-category--base{background:rgba(94,163,255,0.22);color:#e6f2ff}
-.step-category--gear{background:rgba(255,196,77,0.22);color:#fff4d6}
-.step-category--tech{background:rgba(206,135,255,0.22);color:#f5e9ff}
-.step-category--catch{background:rgba(125,214,134,0.22);color:#eaffed}
-.step-category--prep{background:rgba(255,160,122,0.22);color:#ffe8e0}
-.step-category--explore{background:rgba(132,206,235,0.22);color:#e7f6ff}
-.step-category--boss{background:rgba(255,116,140,0.24);color:#ffe7ec}
+.step-list{display:grid;gap:16px;margin:12px 0}
+.step{display:grid;grid-template-columns:auto 1fr;gap:16px;padding:18px 20px;border:1px solid rgba(119,141,169,0.28);border-radius:18px;background:rgba(8,16,32,0.78);box-shadow:0 18px 36px rgba(0,0,0,0.35);transition:transform .2s ease,border-color .25s ease,box-shadow .25s ease}
+.step:hover{transform:translateY(-2px);border-color:rgba(148,210,189,0.6);box-shadow:0 26px 48px rgba(0,0,0,0.45)}
+.step input[type=checkbox]{width:24px;height:24px;margin-top:4px;accent-color:var(--accent,#778da9)}
+.step.optional{background:rgba(12,24,40,0.72);border-color:rgba(119,141,169,0.2)}
+.step-content{display:grid;gap:10px}
+.step-header{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.step-text{margin:0;font-size:.98rem;line-height:1.6;color:var(--light,#e0e1dd)}
+.step-links{display:flex;flex-wrap:wrap;gap:8px}
+.step .badges{margin:0}
+.step-flag{display:inline-flex;align-items:center;padding:4px 10px;border-radius:999px;font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;background:rgba(148,210,189,0.2);border:1px solid rgba(148,210,189,0.45);color:rgba(224,255,244,0.9);font-weight:700}
+.step.optional .step-flag{background:rgba(255,196,77,0.22);border-color:rgba(255,196,77,0.45);color:rgba(255,244,214,0.9)}
+.step-category{display:inline-flex;align-items:center;font-size:.75rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:4px 12px;border-radius:999px;background:rgba(119,141,169,0.24);border:1px solid rgba(119,141,169,0.4);color:#e0e9f5}
+.step-category--base{background:rgba(94,163,255,0.22);border-color:rgba(94,163,255,0.38);color:#e6f2ff}
+.step-category--gear{background:rgba(255,196,77,0.22);border-color:rgba(255,196,77,0.4);color:#fff4d6}
+.step-category--tech{background:rgba(206,135,255,0.22);border-color:rgba(206,135,255,0.4);color:#f5e9ff}
+.step-category--catch{background:rgba(125,214,134,0.22);border-color:rgba(125,214,134,0.38);color:#eaffed}
+.step-category--prep{background:rgba(255,160,122,0.22);border-color:rgba(255,160,122,0.4);color:#ffe8e0}
+.step-category--explore{background:rgba(132,206,235,0.22);border-color:rgba(132,206,235,0.38);color:#e7f6ff}
+.step-category--boss{background:rgba(255,116,140,0.24);border-color:rgba(255,116,140,0.42);color:#ffe7ec}
 .pulse{animation:pulse 1.2s ease-out 1}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(105,228,166,.8)}100%{box-shadow:0 0 0 14px rgba(105,228,166,0)}}
+
+.route-page--modern{display:grid;gap:28px;margin:16px 0}
+.route-dashboard{padding:clamp(24px,3vw,32px);display:grid;gap:clamp(20px,2vw,28px);background:linear-gradient(140deg,rgba(18,40,62,0.92),rgba(8,18,32,0.92));border-radius:28px;border:1px solid rgba(119,141,169,0.32);box-shadow:0 32px 60px rgba(0,0,0,0.52)}
+.route-dashboard__header{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:20px}
+.route-dashboard__titles{display:grid;gap:10px;max-width:min(680px,100%)}
+.route-dashboard__eyebrow{font-size:.75rem;letter-spacing:.16em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
+.route-dashboard__lead{margin:0;font-size:1rem;color:var(--muted,rgba(224,225,221,0.74));line-height:1.55}
+.route-dashboard__actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.route-dashboard__stats{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.route-dashboard__stat{background:rgba(8,16,32,0.72);border:1px solid rgba(119,141,169,0.26);border-radius:20px;padding:18px;display:grid;gap:10px;box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}
+.route-dashboard__stat-label{font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;color:rgba(224,225,221,0.64)}
+.route-dashboard__stat-value{font-size:clamp(1.6rem,1.1vw+1.35rem,2.1rem);font-weight:700;color:var(--text,#f0f4f8)}
+.route-dashboard__stat-meta{margin:0;font-size:.9rem;color:var(--muted,rgba(224,225,221,0.74))}
+.route-dashboard__progress-bar{position:relative;width:100%;height:8px;border-radius:999px;background:rgba(255,255,255,0.14);overflow:hidden}
+.route-dashboard__progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--accent,#778da9),rgba(148,210,189,0.9));transition:width .3s ease}
+.route-dashboard__progress-fill--optional{background:linear-gradient(90deg,rgba(255,196,77,0.85),rgba(231,111,81,0.9))}
+.route-dashboard__next{border-top:1px solid rgba(119,141,169,0.28);padding-top:14px;font-size:1rem;font-weight:600;color:var(--light,#e0e1dd)}
+.route-workspace{display:grid;gap:24px}
+.route-workspace__sidebar,.route-workspace__content{display:grid;gap:24px}
+@media (min-width:1024px){.route-workspace{grid-template-columns:minmax(0,0.36fr) minmax(0,0.64fr);align-items:start}}
+@media (min-width:1100px){.route-workspace__sidebar{position:sticky;top:clamp(16px,4vw,36px)}}
+.route-timeline{display:grid;gap:16px;padding:clamp(20px,2.5vw,26px);border-radius:24px;background:linear-gradient(150deg,rgba(13,27,42,0.92),rgba(8,18,34,0.92));border:1px solid rgba(119,141,169,0.32);box-shadow:0 30px 58px rgba(0,0,0,0.52)}
+.route-timeline__header h3{margin:0}
+.route-timeline__header p{margin:0;font-size:.9rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-timeline__list{list-style:none;margin:0;padding:0;display:grid;gap:10px}
+.route-timeline__item{border:1px solid rgba(119,141,169,0.24);border-radius:16px;background:rgba(8,16,32,0.65);transition:border-color .25s ease,box-shadow .25s ease,transform .2s ease}
+.route-timeline__item--active{border-color:rgba(148,210,189,0.65);box-shadow:0 20px 36px rgba(148,210,189,0.18)}
+.route-timeline__item--complete{border-color:rgba(119,141,169,0.32);background:rgba(8,16,32,0.72)}
+.route-timeline__anchor{width:100%;display:grid;gap:4px;padding:14px 16px;background:none;border:none;color:inherit;text-align:left;cursor:pointer;border-radius:inherit;position:relative;isolation:isolate}
+.route-timeline__anchor:hover,.route-timeline__anchor:focus-visible{outline:none}
+.route-timeline__anchor:focus-visible{box-shadow:0 0 0 3px rgba(148,210,189,0.45)}
+.route-timeline__anchor:hover .route-timeline__title,.route-timeline__anchor:focus-visible .route-timeline__title{color:var(--accent,#778da9)}
+.route-timeline__step{font-size:.74rem;letter-spacing:.12em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
+.route-timeline__title{font-size:1rem;font-weight:600;color:var(--text,#f0f4f8)}
+.route-timeline__meta{font-size:.82rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-timeline__progress{display:block;width:100%;height:6px;border-radius:999px;background:rgba(255,255,255,0.16);overflow:hidden;margin-top:6px}
+.route-timeline__progress-fill{display:block;height:100%;background:linear-gradient(90deg,var(--accent,#778da9),rgba(148,210,189,0.92));transition:width .3s ease}
+.route-timeline__empty{text-align:center;padding:18px 0;font-size:.92rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-chapter{padding:clamp(22px,2.5vw,30px);display:grid;gap:18px;border-radius:26px;border:1px solid rgba(119,141,169,0.28);background:linear-gradient(150deg,rgba(13,27,42,0.94),rgba(8,18,34,0.9));box-shadow:0 34px 68px rgba(0,0,0,0.55);scroll-margin-top:120px}
+.route-chapter__header{display:flex;align-items:flex-start;justify-content:space-between;gap:18px;flex-wrap:wrap}
+.route-chapter__titles{display:flex;align-items:flex-start;gap:14px}
+.route-chapter__number{width:48px;height:48px;border-radius:16px;background:rgba(148,210,189,0.22);border:1px solid rgba(148,210,189,0.5);display:grid;place-items:center;font-weight:700;font-size:1rem;color:rgba(148,210,189,0.95)}
+.route-chapter__title{margin:0;font-size:1.35rem;color:var(--text,#f0f4f8)}
+.route-chapter__subtitle{margin:4px 0 0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.74));max-width:60ch}
+.route-chapter__progress{min-width:220px}
+.route-progress{display:grid;gap:8px}
+.route-progress__bar{width:100%;height:8px;border-radius:999px;background:rgba(255,255,255,0.16);overflow:hidden}
+.route-progress__fill{display:block;height:100%;background:linear-gradient(90deg,var(--accent,#778da9),rgba(148,210,189,0.92));transition:width .3s ease}
+.route-progress__label{font-size:.85rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-chapter__details{border-radius:22px;border:1px solid rgba(119,141,169,0.22);background:rgba(8,16,32,0.8);overflow:hidden}
+.route-chapter__summary{display:flex;align-items:center;justify-content:space-between;gap:14px;padding:16px 20px;cursor:pointer;list-style:none}
+.route-chapter__summary::-webkit-details-marker{display:none}
+.route-chapter__summary-text{display:grid;gap:4px}
+.route-chapter__summary-text span:first-child{font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;color:rgba(224,225,221,0.64)}
+.route-chapter__summary-meta{font-size:.95rem;color:var(--light,#e0e1dd)}
+.route-chapter__summary-toggle{color:var(--muted,rgba(224,225,221,0.62));transition:transform .25s ease}
+.route-chapter__details[open] .route-chapter__summary{background:rgba(8,16,32,0.85);border-bottom:1px solid rgba(119,141,169,0.24)}
+.route-chapter__details[open] .route-chapter__summary-toggle{transform:rotate(180deg)}
+.route-chapter__body{padding:20px;display:grid;gap:14px}
+.route-chapter__footer{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;padding:18px 20px;border-top:1px solid rgba(119,141,169,0.24);background:rgba(8,16,32,0.82)}
+.route-chapter__footer-meta{display:flex;flex-direction:column;gap:4px;font-size:.85rem;color:var(--muted,rgba(224,225,221,0.72))}
+.route-chapter__footer-actions{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:flex-end}
+.route-chapter__badge{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:999px;background:rgba(148,210,189,0.22);border:1px solid rgba(148,210,189,0.5);font-size:.85rem;font-weight:600;color:rgba(224,255,244,0.92)}
+.route-steps-empty{margin:0;font-size:.92rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:20px 0}
 
 .route-page-header{display:flex;flex-direction:column;gap:12px;margin:16px 0 12px}
 .route-page-header h2{margin:0}
@@ -130,6 +201,38 @@ gba(119,141,169,0.45)}
 .route-card__meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:4px}
 .route-meta-chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;background:rgba(119,141,169,0.2);border:1px solid rgba(119,141,169,0.42);color:var(--light,#e0e1dd);box-shadow:0 6px 12px rgba(0,0,0,0.25)}
 .route-meta-chip--tag{background:rgba(91,146,255,0.22);border-color:rgba(91,146,255,0.42)}
+
+@media (max-width: 900px){
+  .route-workspace{grid-template-columns:1fr}
+  .route-workspace__sidebar{position:static}
+  .route-timeline__list{grid-auto-flow:column;grid-auto-columns:minmax(210px,1fr);overflow-x:auto;padding-bottom:8px;margin-bottom:-8px}
+  .route-timeline__list::-webkit-scrollbar{height:6px}
+  .route-timeline__list::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.4);border-radius:999px}
+  .route-timeline__item{min-width:210px}
+  .route-chapter{padding:24px 18px}
+  .route-chapter__header{flex-direction:column;align-items:stretch}
+  .route-chapter__progress{min-width:0}
+  .route-chapter__footer{flex-direction:column;align-items:stretch}
+  .route-chapter__footer-actions{justify-content:flex-start}
+}
+
+@media (max-width: 640px){
+  .route-dashboard__header{flex-direction:column;align-items:flex-start}
+  .route-dashboard__stats{grid-template-columns:1fr}
+  .route-dashboard__actions{width:100%}
+  .route-dashboard__actions .btn{flex:1 1 auto;width:100%}
+  .step{grid-template-columns:1fr;gap:14px}
+  .step input[type=checkbox]{margin:0}
+  .step-content{gap:8px}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .route-timeline__item,
+  .route-timeline__progress-fill,
+  .route-progress__fill,
+  .route-dashboard__progress-fill{transition:none}
+  .step{transition:none}
+}
 .route-meta-chip--high{background:rgba(231,111,81,0.28);border-color:rgba(231,111,81,0.5)}
 .route-meta-chip--medium{background:rgba(255,196,77,0.26);border-color:rgba(255,196,77,0.46)}
 .route-meta-chip--low{background:rgba(105,228,166,0.26);border-color:rgba(105,228,166,0.5)}
@@ -142,7 +245,6 @@ gba(119,141,169,0.45)}
 .route-card__toggle{width:100%;justify-content:center;margin-bottom:6px}
 .route-card__actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-top:12px}
 .route-card__actions .btn{flex:1 1 200px}
-.route-steps-empty{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-style:italic;text-align:center;padding:12px 0}
 .route-visual__marker{--route-marker-size:22px;position:absolute;top:50%;left:50%;width:var(--route-marker-size);height:var(--route-marker-size);border-radius:50%;background:radial-gradient(circle at center,var(--route-visual-accent,#9bd4ff)0%,var(--route-visual-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);box-shadow:0 0 0 4px rgba(0,0,0,0.4),0 10px 20px rgba(0,0,0,0.45);transform:translate(-50%,-50%);pointer-events:none}
 .route-card__thumb .route-visual__marker{--route-marker-size:20px}
 

--- a/js/pages/route.js
+++ b/js/pages/route.js
@@ -1,64 +1,124 @@
 import guide from '../../data/route.chapters.json' assert { type: 'json' };
 
 const STORAGE_KEY = 'palmarathon:route:v1';
+const PREFERENCES_KEY = 'palmarathon:route:prefs:v1';
 
 export function renderRoute(node){
   const kidMode = isKidMode();
-  node.innerHTML = `
-    <section class="card">
-      <h2>Boss Route & Progress</h2>
-      <p>Work through each chapter. Check off steps as you do them. <em>Optional</em> steps don’t block completion.</p>
-      <div class="badges" style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
-        <button class="btn" id="toggleOptional">${optionalToggleLabel(false, kidMode)}</button>
-      </div>
-    </section>
-    <div id="chapters"></div>
-  `;
-  const wrap = node.querySelector('#chapters');
   const state = loadState();
-  let hideOptional = false;
+  const preferences = loadPreferences();
+  let hideOptional = !!preferences.hideOptional;
+  const overview = calculateGuideOverview(guide.chapters, state);
+  const openChapterIndex = (() => {
+    if(overview.nextChapterId){
+      const idx = guide.chapters.findIndex(ch => ch.id === overview.nextChapterId);
+      if(idx >= 0) return idx;
+    }
+    if(overview.clearedChapters && overview.clearedChapters >= guide.chapters.length){
+      return guide.chapters.length ? guide.chapters.length - 1 : 0;
+    }
+    return 0;
+  })();
+  const heroTitle = kidMode ? 'Family Boss Route' : 'Boss Route Command Center';
+  const heroLead = kidMode
+    ? 'Track every big step together, highlight bonus adventures, and jump straight to the next win.'
+    : 'Monitor chapter momentum, surface optional clean-up, and hop directly to the next required task.';
 
-  // Build chapter accordions
-  guide.chapters.forEach((ch, idx) => {
-    const chapterEl = document.createElement('section');
-    chapterEl.className = 'card';
-    chapterEl.id = `chapter-${ch.id}`;
-    const progress = chapterProgress(ch, state);
-    chapterEl.innerHTML = `
-      <div style="display:flex;align-items:center;gap:12px;justify-content:space-between;flex-wrap:wrap">
-        <div>
-          <h3 style="margin:0">${escapeHTML(chapterTitle(ch))}</h3>
-          <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(chapterWhy(ch))}</p>
+  node.innerHTML = `
+    <div class="route-page route-page--modern">
+      <section class="card route-dashboard" id="routeDashboard">
+        <div class="route-dashboard__header">
+          <div class="route-dashboard__titles">
+            <span class="route-dashboard__eyebrow">${escapeHTML(kidMode ? 'Tower campaign' : 'Boss route')}</span>
+            <h2>${escapeHTML(heroTitle)}</h2>
+            <p class="route-dashboard__lead">${escapeHTML(heroLead)}</p>
+          </div>
+          <div class="route-dashboard__actions">
+            <button class="btn route-dashboard__action" id="toggleOptional">${optionalToggleLabel(false, kidMode)}</button>
+          </div>
         </div>
-        <div style="min-width:220px">
-          ${renderProgress(progress)}
+        <div class="route-dashboard__stats">
+          <div class="route-dashboard__stat">
+            <span class="route-dashboard__stat-label">${escapeHTML(kidMode ? 'Chapters cleared' : 'Chapters complete')}</span>
+            <strong class="route-dashboard__stat-value" data-route-overview="chapters">${overview.clearedChapters}/${overview.totalChapters}</strong>
+            <p class="route-dashboard__stat-meta">${escapeHTML(kidMode ? 'Finish the required steps in a chapter to mark it as cleared.' : 'Complete every required step to finish a chapter.')}</p>
+          </div>
+          <div class="route-dashboard__stat">
+            <span class="route-dashboard__stat-label">${escapeHTML(kidMode ? 'Required progress' : 'Required steps')}</span>
+            <strong class="route-dashboard__stat-value" data-route-overview="required-count">${overview.requiredChecked}/${overview.requiredTotal}</strong>
+            <div class="route-dashboard__progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${overview.requiredPct}">
+              <span class="route-dashboard__progress-fill" data-route-overview="required-fill" style="width:${overview.requiredPct}%"></span>
+            </div>
+            <p class="route-dashboard__stat-meta" data-route-overview="required-summary">${escapeHTML(overview.requiredSummary)}</p>
+          </div>
+          <div class="route-dashboard__stat">
+            <span class="route-dashboard__stat-label">${escapeHTML(kidMode ? 'Bonus progress' : 'Optional steps')}</span>
+            <strong class="route-dashboard__stat-value" data-route-overview="optional-count">${overview.optionalChecked}/${overview.optionalTotal}</strong>
+            <div class="route-dashboard__progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${overview.optionalPct}">
+              <span class="route-dashboard__progress-fill route-dashboard__progress-fill--optional" data-route-overview="optional-fill" style="width:${overview.optionalPct}%"></span>
+            </div>
+            <p class="route-dashboard__stat-meta" data-route-overview="optional-summary">${escapeHTML(overview.optionalSummary)}</p>
+          </div>
         </div>
+        <div class="route-dashboard__next" data-route-overview="next">${escapeHTML(overview.nextLabel)}</div>
+      </section>
+      <div class="route-workspace">
+        <aside class="route-workspace__sidebar">
+          <section class="card route-timeline" id="routeTimeline">
+            <div class="route-timeline__header">
+              <h3>${escapeHTML(kidMode ? 'Tonight’s roadmap' : 'Route timeline')}</h3>
+              <p>${escapeHTML(kidMode ? 'Tap any chapter to jump to its checklist.' : 'Jump to a chapter or skim completion at a glance.')}</p>
+            </div>
+            <ol class="route-timeline__list" id="routeTimelineList"></ol>
+          </section>
+        </aside>
+        <div class="route-workspace__content" id="chapters"></div>
       </div>
-      <details ${idx===0 ? 'open' : ''}>
-        <summary class="btn" style="margin-top:8px">Open steps</summary>
-        ${renderSteps(ch, state, hideOptional)}
-        <div style="display:flex;gap:8px;margin-top:12px">
-          <button class="btn" data-action="markRequired" data-ch="${ch.id}">Mark Required Complete</button>
-          <button class="btn" data-action="resetChapter" data-ch="${ch.id}">Reset Chapter</button>
-          ${progress.requiredDone ? `<span style="margin-left:auto">✅ Chapter Complete</span>` : ''}
-        </div>
-      </details>
-    `;
+    </div>
+  `;
+
+  const wrap = node.querySelector('#chapters');
+  guide.chapters.forEach((ch, idx) => {
+    const chapterEl = document.createElement('article');
+    chapterEl.className = 'card route-chapter';
+    chapterEl.id = `chapter-${ch.id}`;
+    chapterEl.dataset.chapter = ch.id;
+    chapterEl.dataset.index = String(idx);
+    chapterEl.innerHTML = renderChapterInner(ch, idx, state, hideOptional, idx === openChapterIndex);
     wrap.appendChild(chapterEl);
   });
 
-  // Delegated events
+  const timeline = node.querySelector('#routeTimeline');
+  if(timeline){
+    timeline.addEventListener('click', (event) => {
+      const anchor = event.target.closest('[data-scroll-target]');
+      if(!anchor) return;
+      event.preventDefault();
+      const targetId = anchor.dataset.scrollTarget;
+      if(!targetId) return;
+      const chapter = node.querySelector(`#${targetId}`);
+      if(chapter){
+        const details = chapter.querySelector('.route-chapter__details');
+        if(details) details.open = true;
+        chapter.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        pulse(chapter);
+      }
+    });
+  }
+
   wrap.addEventListener('change', (e) => {
     if(e.target.matches('input[type=checkbox][data-step]')){
       const stepId = e.target.dataset.step;
       const checked = e.target.checked;
       state[stepId] = checked;
       saveState(state);
-      // Update chapter progress bar
-      const chId = e.target.closest('section.card').id.replace('chapter-','');
-      const ch = guide.chapters.find(c=>c.id===chId);
-      const prog = chapterProgress(ch, state);
-      e.target.closest('section.card').querySelector('.progress').outerHTML = renderProgress(prog);
+      const chapterNode = e.target.closest('.route-chapter');
+      const chId = chapterNode ? chapterNode.dataset.chapter : null;
+      const ch = guide.chapters.find(c => c.id === chId);
+      if(ch){
+        rerenderChapter(ch, state, node, hideOptional);
+      }
+      refreshGuideAnalytics(node, guide.chapters, state);
     }
   });
 
@@ -73,65 +133,135 @@ export function renderRoute(node){
     if(!btn) return;
     const chId = btn.dataset.ch;
     const ch = guide.chapters.find(c=>c.id===chId);
+    if(!ch) return;
     if(btn.dataset.action==='markRequired'){
       ch.steps.filter(s=>!s.optional).forEach(s=> state[s.id] = true);
       saveState(state);
       rerenderChapter(ch, state, node, hideOptional);
+      refreshGuideAnalytics(node, guide.chapters, state);
     } else if(btn.dataset.action==='resetChapter'){
       ch.steps.forEach(s=> delete state[s.id]);
       saveState(state);
       rerenderChapter(ch, state, node, hideOptional);
+      refreshGuideAnalytics(node, guide.chapters, state);
     }
   });
 
-  node.querySelector('#toggleOptional').onclick = ()=>{
-    const kid = isKidMode();
-    hideOptional = !hideOptional;
-    node.querySelector('#toggleOptional').textContent = optionalToggleLabel(hideOptional, kid);
-    // Rerender all chapters with the new optional filter
-    guide.chapters.forEach(ch => rerenderChapter(ch, state, node, hideOptional));
-  };
+  const optionalButton = node.querySelector('#toggleOptional');
+  if(optionalButton){
+    optionalButton.addEventListener('click', () => {
+      hideOptional = !hideOptional;
+      preferences.hideOptional = hideOptional;
+      savePreferences(preferences);
+      optionalButton.textContent = optionalToggleLabel(hideOptional, isKidMode());
+      optionalButton.setAttribute('aria-pressed', hideOptional ? 'true' : 'false');
+      guide.chapters.forEach(ch => rerenderChapter(ch, state, node, hideOptional));
+      refreshGuideAnalytics(node, guide.chapters, state);
+    });
+  }
+  if(optionalButton){
+    optionalButton.setAttribute('aria-pressed', hideOptional ? 'true' : 'false');
+  }
+  refreshGuideAnalytics(node, guide.chapters, state);
 }
 
-function rerenderChapter(ch, state, node, hideOptional){
-  const sec = node.querySelector(`#chapter-${ch.id}`);
-  const detailsWasOpen = sec.querySelector('details').open;
+function renderChapterInner(ch, index, state, hideOptional, open){
+  const kid = isKidMode();
   const progress = chapterProgress(ch, state);
-  sec.innerHTML = `
-    <div style="display:flex;align-items:center;gap:12px;justify-content:space-between;flex-wrap:wrap">
-      <div>
-        <h3 style="margin:0">${escapeHTML(chapterTitle(ch))}</h3>
-        <p style="margin:.25rem 0;color:var(--muted)">${escapeHTML(chapterWhy(ch))}</p>
+  const optionalStats = chapterOptionalProgress(ch, state);
+  const nextRequired = ch.steps.find(step => !step.optional && !state[step.id]);
+  const nextOptional = ch.steps.find(step => step.optional && !state[step.id]);
+  let summaryMeta;
+  if(nextRequired){
+    summaryMeta = kid
+      ? `Next big step: ${stepText(nextRequired)}`
+      : `Next required: ${stepText(nextRequired)}`;
+  } else if(nextOptional && !hideOptional){
+    summaryMeta = kid
+      ? `Bonus idea: ${stepText(nextOptional)}`
+      : `Next optional: ${stepText(nextOptional)}`;
+  } else if(nextOptional && hideOptional){
+    summaryMeta = kid ? 'Bonus steps hidden' : 'Optional steps hidden';
+  } else {
+    summaryMeta = kid ? 'Chapter complete' : 'Chapter complete';
+  }
+  const requiredLabel = kid
+    ? `${progress.requiredChecked}/${progress.requiredCount} big step${progress.requiredCount === 1 ? '' : 's'} done`
+    : `${progress.requiredChecked}/${progress.requiredCount} required complete`;
+  const optionalLabel = optionalStats.optionalCount
+    ? (kid
+      ? `${optionalStats.optionalChecked}/${optionalStats.optionalCount} bonus cleared`
+      : `${optionalStats.optionalChecked}/${optionalStats.optionalCount} optional complete`)
+    : (kid ? 'No bonus steps' : 'No optional steps');
+  const stepsHtml = renderSteps(ch, state, hideOptional);
+  const stepsContent = stepsHtml || `<p class="route-steps-empty">${escapeHTML(kid ? 'All bonus steps are hidden.' : 'Optional steps are hidden. Show them to revisit bonus content.')}</p>`;
+  return `
+    <header class="route-chapter__header">
+      <div class="route-chapter__titles">
+        <span class="route-chapter__number">${String(index + 1).padStart(2, '0')}</span>
+        <div class="route-chapter__text">
+          <h3 class="route-chapter__title">${escapeHTML(chapterTitle(ch))}</h3>
+          <p class="route-chapter__subtitle">${escapeHTML(chapterWhy(ch))}</p>
+        </div>
       </div>
-      <div style="min-width:220px">${renderProgress(progress)}</div>
-    </div>
-    <details ${detailsWasOpen ? 'open' : ''}>
-      <summary class="btn" style="margin-top:8px">Open steps</summary>
-      ${renderSteps(ch, state, hideOptional)}
-      <div style="display:flex;gap:8px;margin-top:12px">
-        <button class="btn" data-action="markRequired" data-ch="${ch.id}">Mark Required Complete</button>
-        <button class="btn" data-action="resetChapter" data-ch="${ch.id}">Reset Chapter</button>
-        ${progress.requiredDone ? `<span style="margin-left:auto">✅ Chapter Complete</span>` : ''}
-      </div>
+      <div class="route-chapter__progress">${renderProgress(progress)}</div>
+    </header>
+    <details class="route-chapter__details" ${open ? 'open' : ''}>
+      <summary class="route-chapter__summary">
+        <div class="route-chapter__summary-text">
+          <span>${escapeHTML(kid ? 'Chapter checklist' : 'Chapter checklist')}</span>
+          <span class="route-chapter__summary-meta">${escapeHTML(summaryMeta)}</span>
+        </div>
+        <span class="route-chapter__summary-toggle"><i class="fa-solid fa-chevron-down"></i></span>
+      </summary>
+      <div class="route-chapter__body">${stepsContent}</div>
+      <footer class="route-chapter__footer">
+        <div class="route-chapter__footer-meta">
+          <span>${escapeHTML(requiredLabel)}</span>
+          <span>${escapeHTML(optionalLabel)}</span>
+        </div>
+        <div class="route-chapter__footer-actions">
+          <button class="btn" data-action="markRequired" data-ch="${ch.id}">${escapeHTML(kid ? 'Mark big steps done' : 'Mark required complete')}</button>
+          <button class="btn btn--ghost" data-action="resetChapter" data-ch="${ch.id}">${escapeHTML(kid ? 'Restart chapter' : 'Reset chapter')}</button>
+          ${progress.requiredDone ? `<span class="route-chapter__badge">${escapeHTML(kid ? 'Chapter complete!' : 'Chapter complete')}</span>` : ''}
+        </div>
+      </footer>
     </details>
   `;
 }
 
+function rerenderChapter(ch, state, node, hideOptional){
+  const sec = node.querySelector(`#chapter-${ch.id}`);
+  if(!sec) return;
+  const details = sec.querySelector('.route-chapter__details');
+  const wasOpen = details ? details.open : false;
+  const index = Number(sec.dataset.index) || 0;
+  sec.innerHTML = renderChapterInner(ch, index, state, hideOptional, wasOpen);
+}
+
 function renderSteps(ch, state, hideOptional){
   const fragments = [];
+  const kid = isKidMode();
   ch.steps.forEach(step=>{
     if(hideOptional && step.optional) return;
     const checked = !!state[step.id];
     const category = step.category || 'Task';
     const categorySlug = category.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'') || 'task';
+    const optionalFlag = step.optional
+      ? `<span class="step-flag">${escapeHTML(kid ? 'Bonus' : 'Optional')}</span>`
+      : '';
+    const links = renderLinks(step.links || []);
     fragments.push(`
-      <label class="step ${step.optional?'optional':''}">
-        <input type="checkbox" data-step="${step.id}" ${checked?'checked':''} />
-        <span class="step-meta">
-          <span class="step-category step-category--${categorySlug}">${escapeHTML(category)}</span>
-          <span class="step-text">${escapeHTML(stepText(step))} ${step.optional?'<em>(Optional)</em>':''}</span>
-        </span>
-        ${renderLinks(step.links||[])}
+      <label class="step ${step.optional ? 'optional' : ''}">
+        <input type="checkbox" data-step="${step.id}" ${checked ? 'checked' : ''} />
+        <div class="step-content">
+          <div class="step-header">
+            <span class="step-category step-category--${categorySlug}">${escapeHTML(category)}</span>
+            ${optionalFlag}
+          </div>
+          <p class="step-text">${escapeHTML(stepText(step))}</p>
+          ${links}
+        </div>
       </label>
     `);
   });
@@ -140,16 +270,25 @@ function renderSteps(ch, state, hideOptional){
 }
 
 function renderProgress({requiredDone, requiredCount, requiredChecked}){
-  const pct = requiredCount ? Math.round((requiredChecked/requiredCount)*100) : 0;
-  const label = isKidMode()
-    ? `${requiredChecked}/${requiredCount} steps done (${pct}%)`
-    : `${requiredChecked}/${requiredCount} required done (${pct}%)`;
+  const kid = isKidMode();
+  const pct = requiredCount ? Math.round((requiredChecked / requiredCount) * 100) : 0;
+  let label;
+  if(requiredCount === 0){
+    label = kid ? 'No big steps required' : 'No required steps';
+  } else if(requiredDone){
+    label = kid ? 'Big steps finished' : 'All required steps complete';
+  } else {
+    const noun = requiredCount === 1 ? (kid ? 'big step' : 'required step') : (kid ? 'big steps' : 'required steps');
+    label = kid
+      ? `${requiredChecked}/${requiredCount} ${noun} done`
+      : `${requiredChecked}/${requiredCount} ${noun} complete`;
+  }
   return `
-    <div class="progress" aria-label="Chapter progress" style="display:grid;gap:6px">
-      <div style="height:10px;border-radius:999px;background:#22314A;overflow:hidden">
-        <div style="height:10px;width:${pct}%;background:var(--accent)"></div>
+    <div class="route-progress" data-role="chapter-progress">
+      <div class="route-progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pct}">
+        <span class="route-progress__fill" style="width:${pct}%"></span>
       </div>
-      <div style="font-size:.9rem;color:var(--muted)">${label}</div>
+      <span class="route-progress__label">${escapeHTML(label)}</span>
     </div>
   `;
 }
@@ -160,13 +299,208 @@ function chapterProgress(ch, state){
   return { requiredCount: required.length, requiredChecked, requiredDone: requiredChecked === required.length };
 }
 
+function chapterOptionalProgress(ch, state){
+  const optional = ch.steps.filter(step => step.optional);
+  const optionalChecked = optional.filter(step => state[step.id]).length;
+  return { optionalCount: optional.length, optionalChecked };
+}
+
+function calculateGuideOverview(chapters, state){
+  const kid = isKidMode();
+  const totalChapters = Array.isArray(chapters) ? chapters.length : 0;
+  let clearedChapters = 0;
+  let requiredTotal = 0;
+  let requiredChecked = 0;
+  let optionalTotal = 0;
+  let optionalChecked = 0;
+  let nextChapter = null;
+  let nextStep = null;
+
+  if(Array.isArray(chapters)){
+    chapters.forEach(ch => {
+      if(!ch || !Array.isArray(ch.steps)) return;
+      const progress = chapterProgress(ch, state);
+      const optional = chapterOptionalProgress(ch, state);
+      requiredTotal += progress.requiredCount;
+      requiredChecked += progress.requiredChecked;
+      optionalTotal += optional.optionalCount;
+      optionalChecked += optional.optionalChecked;
+      const hasOptionalRemaining = optional.optionalCount > optional.optionalChecked;
+      if(progress.requiredDone){
+        clearedChapters += 1;
+        if(!nextChapter && hasOptionalRemaining){
+          nextChapter = ch;
+        }
+      } else if(!nextChapter){
+        nextChapter = ch;
+      }
+      if(!nextStep){
+        const nextRequired = ch.steps.find(step => !step.optional && !state[step.id]);
+        if(nextRequired){
+          nextStep = nextRequired;
+        } else {
+          const nextOptional = ch.steps.find(step => step.optional && !state[step.id]);
+          if(nextOptional){
+            nextStep = nextOptional;
+          }
+        }
+      }
+    });
+  }
+
+  const requiredPct = requiredTotal ? Math.round((requiredChecked / requiredTotal) * 100) : 0;
+  const optionalPct = optionalTotal ? Math.round((optionalChecked / optionalTotal) * 100) : 0;
+
+  const remainingRequired = Math.max(requiredTotal - requiredChecked, 0);
+  const remainingOptional = Math.max(optionalTotal - optionalChecked, 0);
+
+  let requiredSummary;
+  if(requiredTotal === 0){
+    requiredSummary = kid ? 'No big steps to track yet.' : 'No required steps to track yet.';
+  } else if(remainingRequired === 0){
+    requiredSummary = kid ? 'All big steps are complete.' : 'Every required step is complete.';
+  } else {
+    const noun = remainingRequired === 1 ? (kid ? 'big step' : 'required step') : (kid ? 'big steps' : 'required steps');
+    requiredSummary = kid
+      ? `${remainingRequired} ${noun} left`
+      : `${remainingRequired} ${noun} remaining`;
+  }
+
+  let optionalSummary;
+  if(optionalTotal === 0){
+    optionalSummary = kid ? 'Bonus chores appear as you unlock them.' : 'Optional tasks appear when available.';
+  } else if(remainingOptional === 0){
+    optionalSummary = kid ? 'All bonus fun complete.' : 'Optional clean-up complete.';
+  } else {
+    const noun = remainingOptional === 1 ? (kid ? 'bonus step' : 'optional step') : (kid ? 'bonus steps' : 'optional steps');
+    optionalSummary = kid
+      ? `${remainingOptional} ${noun} to explore`
+      : `${remainingOptional} ${noun} remaining`;
+  }
+
+  let nextLabel;
+  let nextChapterId = null;
+  if(totalChapters === 0){
+    nextLabel = kid ? 'No chapters available yet.' : 'No chapters available yet.';
+  } else if(nextStep){
+    const prefix = nextStep.optional
+      ? (kid ? 'Bonus idea' : 'Next optional step')
+      : (kid ? 'Next big step' : 'Next required step');
+    nextLabel = `${prefix}: ${stepText(nextStep)}`;
+    if(nextChapter && nextChapter.id){
+      nextChapterId = nextChapter.id;
+    }
+  } else if(clearedChapters === totalChapters){
+    nextLabel = kid ? 'All chapters complete! Celebrate with your crew.' : 'All chapters complete—legendary work.';
+  } else if(nextChapter && nextChapter.id){
+    nextChapterId = nextChapter.id;
+    nextLabel = kid
+      ? `Begin ${chapterTitle(nextChapter)}`
+      : `Begin ${chapterTitle(nextChapter)}`;
+  } else {
+    nextLabel = kid ? 'Pick a chapter to begin.' : 'Choose a chapter to begin.';
+  }
+
+  return {
+    totalChapters,
+    clearedChapters,
+    requiredTotal,
+    requiredChecked,
+    optionalTotal,
+    optionalChecked,
+    requiredPct,
+    optionalPct,
+    requiredSummary,
+    optionalSummary,
+    nextLabel,
+    nextChapterId
+  };
+}
+
+function refreshGuideAnalytics(node, chapters, state){
+  const overview = calculateGuideOverview(chapters, state);
+  updateOverview(node, overview);
+  renderTimeline(node, chapters, state, overview.nextChapterId);
+  return overview;
+}
+
+function updateOverview(node, overview){
+  const setText = (key, value) => {
+    const el = node.querySelector(`[data-route-overview="${key}"]`);
+    if(el) el.textContent = value;
+  };
+  setText('chapters', `${overview.clearedChapters}/${overview.totalChapters}`);
+  setText('required-count', `${overview.requiredChecked}/${overview.requiredTotal}`);
+  setText('optional-count', `${overview.optionalChecked}/${overview.optionalTotal}`);
+  setText('required-summary', overview.requiredSummary);
+  setText('optional-summary', overview.optionalSummary);
+  setText('next', overview.nextLabel);
+  const requiredFill = node.querySelector('[data-route-overview="required-fill"]');
+  if(requiredFill){
+    requiredFill.style.width = `${overview.requiredPct}%`;
+    const bar = requiredFill.parentElement;
+    if(bar && bar.setAttribute){
+      bar.setAttribute('aria-valuenow', String(overview.requiredPct));
+    }
+  }
+  const optionalFill = node.querySelector('[data-route-overview="optional-fill"]');
+  if(optionalFill){
+    optionalFill.style.width = `${overview.optionalPct}%`;
+    const bar = optionalFill.parentElement;
+    if(bar && bar.setAttribute){
+      bar.setAttribute('aria-valuenow', String(overview.optionalPct));
+    }
+  }
+}
+
+function renderTimeline(node, chapters, state, activeChapterId){
+  const list = node.querySelector('#routeTimelineList');
+  if(!list) return;
+  if(!Array.isArray(chapters) || !chapters.length){
+    list.innerHTML = `<li class="route-timeline__empty">${escapeHTML(isKidMode() ? 'Routes will appear here soon.' : 'Routes will appear here soon.')}</li>`;
+    return;
+  }
+  list.innerHTML = chapters.map((ch, idx) => renderTimelineEntry(ch, idx, state, activeChapterId)).join('');
+}
+
+function renderTimelineEntry(ch, index, state, activeChapterId){
+  const classes = ['route-timeline__item'];
+  const progress = chapterProgress(ch, state);
+  const optional = chapterOptionalProgress(ch, state);
+  if(progress.requiredDone) classes.push('route-timeline__item--complete');
+  if(activeChapterId && activeChapterId === ch.id) classes.push('route-timeline__item--active');
+  const kid = isKidMode();
+  const requiredStatus = progress.requiredDone
+    ? (kid ? 'Complete' : 'Complete')
+    : `${progress.requiredChecked}/${progress.requiredCount || 0} ${kid ? 'big' : 'required'}`;
+  const optionalStatus = optional.optionalCount
+    ? `${optional.optionalChecked}/${optional.optionalCount} ${kid ? 'bonus' : 'optional'}`
+    : '';
+  const meta = optionalStatus ? `${requiredStatus} • ${optionalStatus}` : requiredStatus;
+  const pct = progress.requiredCount
+    ? Math.round((progress.requiredChecked / progress.requiredCount) * 100)
+    : 0;
+  return `
+    <li class="${classes.join(' ')}">
+      <button type="button" class="route-timeline__anchor" data-scroll-target="chapter-${ch.id}">
+        <span class="route-timeline__step">${String(index + 1).padStart(2, '0')}</span>
+        <span class="route-timeline__title">${escapeHTML(chapterTitle(ch))}</span>
+        <span class="route-timeline__meta">${escapeHTML(meta)}</span>
+        <span class="route-timeline__progress" aria-hidden="true">
+          <span class="route-timeline__progress-fill" style="width:${pct}%"></span>
+        </span>
+      </button>
+    </li>
+  `;
+}
+
 function renderLinks(links){
   if(!links || !links.length) return '';
-  return `<span class="badges">${links.map(l=>{
+  return `<div class="step-links badges">${links.map(l=>{
     const label = linkLabel(l);
     const payload = JSON.stringify(l).replace(/"/g,'&quot;');
     return `<a href="#" class="chip link" data-link="${payload}" role="button">${escapeHTML(label)}</a>`;
-  }).join('')}</span>`;
+  }).join('')}</div>`;
 }
 
 function optionalToggleLabel(hidden, kid){
@@ -260,6 +594,22 @@ function loadState(){
   catch(e){ return {}; }
 }
 function saveState(s){ localStorage.setItem(STORAGE_KEY, JSON.stringify(s)); }
+
+function loadPreferences(){
+  try {
+    const stored = JSON.parse(localStorage.getItem(PREFERENCES_KEY));
+    if(stored && typeof stored === 'object'){
+      return { hideOptional: !!stored.hideOptional };
+    }
+  } catch(e){ /* ignore */ }
+  return { hideOptional: false };
+}
+
+function savePreferences(prefs){
+  try {
+    localStorage.setItem(PREFERENCES_KEY, JSON.stringify({ hideOptional: !!prefs.hideOptional }));
+  } catch(e){ /* ignore */ }
+}
 
 // --- Small helpers ---
 function escapeHTML(s){ return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }


### PR DESCRIPTION
## Summary
- persist the optional-step toggle and auto-expand the next incomplete chapter in the route planner
- add inline progress bars to the chapter timeline for quicker scanning
- refine route styles for mobile layouts and reduced-motion users, including stronger focus treatment

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc8c0583208331ae6c643c7e35ca82