### PR TITLE
Refine route layout and search flows

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -173,21 +173,11 @@ gba(119,141,169,0.45)}
 }
 .route-shell{display:grid;gap:28px}
 .route-shell>*{min-width:0}
-.route-grid{display:grid;gap:24px}
-.route-grid--primary>.card,.route-grid--secondary>.card{height:100%}
-@media (min-width:960px){
-  .route-grid--primary{grid-template-columns:minmax(0,1fr) minmax(0,1fr);align-items:start}
-  .route-grid--secondary{grid-template-columns:minmax(0,1fr) minmax(0,1fr);align-items:start}
-}
-@media (min-width:1280px){
-  .route-grid--secondary{grid-template-columns:minmax(0,0.95fr) minmax(0,1.05fr)}
-}
+.route-grid{display:flex;flex-direction:column;gap:24px}
+.route-grid--primary>.card,.route-grid--secondary>.card{height:auto}
 .route-hero{padding:22px 24px 26px}
 .route-hero.route-context{display:block}
-.route-hero__layout{display:grid;gap:24px}
-@media (min-width:1024px){
-  .route-hero__layout{grid-template-columns:minmax(0,0.9fr) minmax(0,1.1fr);align-items:start}
-}
+.route-hero__layout{display:flex;flex-direction:column;gap:24px}
 .route-hero__overview,.route-hero__controls{display:grid;gap:20px}
 .route-hero__controls .route-context__controls{height:100%}
 .route-card{display:grid;gap:22px}
@@ -454,7 +444,9 @@ gba(119,141,169,0.45)}
 .route-active__filters .route-filters__chips{max-width:100%;overflow-x:auto;padding-bottom:4px}
 .route-active__filters .route-filters__chips::-webkit-scrollbar{height:6px}
 .route-active__filters .route-filters__chips::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.45);border-radius:999px}
-.route-active__list{display:grid;gap:22px}
+.route-active__list{display:grid;gap:22px;max-height:min(70vh,560px);overflow:auto;padding-right:4px}
+.route-active__list::-webkit-scrollbar{width:8px}
+.route-active__list::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.35);border-radius:999px}
 .route-active__list .card{margin:0}
 .route-active__empty{margin:0;font-size:.97rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:24px 12px}
 
@@ -486,10 +478,7 @@ gba(119,141,169,0.45)}
 .route-suggestions__header{grid-area:header}
 .route-suggestions__list{grid-area:list}
 .route-suggestions__detail{grid-area:detail}
-@media (min-width:900px){
-  .route-suggestions-card{grid-template-columns:minmax(0,0.95fr) minmax(0,1.05fr);grid-template-areas:"header header" "list detail"}
-  .route-suggestions__list{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-}
+.route-suggestions__detail:not([data-route-id]){display:none}
 .route-suggestions__empty,.route-suggestions__placeholder{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem;text-align:center;padding:12px}
 .route-suggestion-card{position:relative;display:grid;gap:12px;align-items:flex-start;padding:20px;border-radius:22px;color:var(--text,#f0f4f8);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;overflow:hidden;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,var(--guide-card-overlay,rgba(12,24,40,0.78))),rgba(12,24,40,0.92)),var(--route-suggestion-image, var(--guide-card-image, url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 40%))}
 .route-suggestion-card::before{content:"";position:absolute;z-index:0;width:var(--route-suggestion-marker-size,26px);height:var(--route-suggestion-marker-size,26px);border-radius:50%;top:var(--route-suggestion-marker-top,50%);left:var(--route-suggestion-marker-left,50%);transform:translate(-50%,-50%);background:radial-gradient(circle at center,var(--route-suggestion-accent,#9bd4ff)0%,var(--route-suggestion-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);opacity:var(--route-suggestion-marker-opacity,0);box-shadow:0 0 0 5px rgba(0,0,0,0.4),0 16px 30px rgba(0,0,0,0.45);pointer-events:none;transition:opacity .2s ease,transform .2s ease}

--- a/index.html
+++ b/index.html
@@ -11998,13 +11998,38 @@
       if(!list){
         return;
       }
+      const updateControlState = () => {
+        document.querySelectorAll('[data-route-library-filter]').forEach(btn => {
+          const key = btn.dataset.routeLibraryFilter || '';
+          const activeState = key === routeLibraryFilter;
+          btn.classList.toggle('route-library__filter-btn--active', activeState);
+          btn.setAttribute('aria-pressed', activeState ? 'true' : 'false');
+        });
+        const matchBtn = document.querySelector('[data-route-library-match]');
+        if(matchBtn){
+          const disabled = !Array.isArray(routeContext?.goals) || routeContext.goals.length === 0;
+          matchBtn.disabled = disabled;
+          const pressed = !disabled && routeLibraryMatchContext;
+          matchBtn.classList.toggle('route-library__match--active', pressed);
+          matchBtn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+        }
+      };
       if(!routeGuideData || !Array.isArray(routeGuideData.routes) || !routeGuideData.routes.length){
         list.innerHTML = `<p class="route-library__empty">${escapeHTML(kidMode ? 'Guides are still loading…' : 'Guide library is still loading.')}</p>`;
         if(countNode) countNode.textContent = '';
+        updateControlState();
+        return;
+      }
+      const query = (routeLibrarySearchTerm || '').trim().toLowerCase();
+      if(!query){
+        list.innerHTML = `<p class="route-library__empty">${escapeHTML(kidMode
+          ? 'Use the search box above to find a guide.'
+          : 'Search above to load specific guides.')}</p>`;
+        if(countNode) countNode.textContent = kidMode ? 'Search guides' : 'Search guides';
+        updateControlState();
         return;
       }
       const active = new Set(activeRouteIds);
-      const query = (routeLibrarySearchTerm || '').trim().toLowerCase();
       const statusFilter = routeLibraryFilter || 'incomplete';
       const shouldMatchContext = routeLibraryMatchContext && Array.isArray(routeContext?.goals) && routeContext.goals.length;
       const goalSet = shouldMatchContext
@@ -12033,15 +12058,13 @@
         if(statusFilter === 'complete' && !complete) return;
         const contextMatch = matchesContext(route);
         if(!contextMatch) return;
-        if(query){
-          const haystack = [
-            route.title,
-            route.category,
-            ...(Array.isArray(route.tags) ? route.tags : []),
-            ...(Array.isArray(route.objectives) ? route.objectives : [])
-          ].filter(Boolean).join(' ').toLowerCase();
-          if(!haystack.includes(query)) return;
-        }
+        const haystack = [
+          route.title,
+          route.category,
+          ...(Array.isArray(route.tags) ? route.tags : []),
+          ...(Array.isArray(route.objectives) ? route.objectives : [])
+        ].filter(Boolean).join(' ').toLowerCase();
+        if(!haystack.includes(query)) return;
         availableRoutes.push({ route, contextMatch });
       });
       if(countNode){
@@ -12052,28 +12075,14 @@
         countNode.textContent = label;
       }
       if(!availableRoutes.length){
-        list.innerHTML = `<p class="route-library__empty">${escapeHTML(query
-          ? (kidMode ? 'No guides match that search.' : 'No guides match your search.')
-          : (kidMode ? 'Everything up here is in your queue.' : 'Every remaining guide is already active.'))}</p>`;
+        list.innerHTML = `<p class="route-library__empty">${escapeHTML(kidMode ? 'No guides match that search.' : 'No guides match your search.')}</p>`;
+        updateControlState();
         return;
       }
       list.innerHTML = availableRoutes
         .map(entry => renderRouteLibraryCard(entry.route, { matchContext: shouldMatchContext && entry.contextMatch }))
         .join('');
-      document.querySelectorAll('[data-route-library-filter]').forEach(btn => {
-        const key = btn.dataset.routeLibraryFilter || '';
-        const activeState = key === routeLibraryFilter;
-        btn.classList.toggle('route-library__filter-btn--active', activeState);
-        btn.setAttribute('aria-pressed', activeState ? 'true' : 'false');
-      });
-      const matchBtn = document.querySelector('[data-route-library-match]');
-      if(matchBtn){
-        const disabled = !Array.isArray(routeContext?.goals) || routeContext.goals.length === 0;
-        matchBtn.disabled = disabled;
-        const pressed = !disabled && routeLibraryMatchContext;
-        matchBtn.classList.toggle('route-library__match--active', pressed);
-        matchBtn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
-      }
+      updateControlState();
     }
 
     function renderRouteLibraryCard(route, { matchContext = false } = {}){
@@ -12358,6 +12367,14 @@
         entries = entries.filter(entry => entry.categoryId === guideCatalogCategoryFilter);
       }
       const query = (guideCatalogSearchTerm || '').trim().toLowerCase();
+      const usingFilters = guideCatalogGroupFilter !== 'all' || guideCatalogCategoryFilter !== 'all';
+      if(!query && !usingFilters){
+        list.innerHTML = `<p class="guide-catalog__empty">${escapeHTML(kidMode
+          ? 'Search to open the encyclopedia.'
+          : 'Search above to browse the full index.')}</p>`;
+        if(countNode) countNode.textContent = kidMode ? 'Search guides' : 'Search guides';
+        return;
+      }
       if(query){
         entries = entries.filter(entry => entry.searchText.includes(query));
       }
@@ -12369,7 +12386,10 @@
         countNode.textContent = countLabel;
       }
       if(!entries.length){
-        list.innerHTML = `<p class="guide-catalog__empty">${escapeHTML(kidMode ? 'No guides match those filters yet.' : 'No guides match your filters yet.')}</p>`;
+        const emptyMessage = query
+          ? (kidMode ? 'No guides match that search yet.' : 'No guides match your search yet.')
+          : (kidMode ? 'No guides match those filters yet.' : 'No guides match your filters yet.');
+        list.innerHTML = `<p class="guide-catalog__empty">${escapeHTML(emptyMessage)}</p>`;
         return;
       }
       list.innerHTML = entries.map(renderGuideCatalogCard).join('');


### PR DESCRIPTION
## Summary
- stack every card in the Route planner vertically and hide the suggestion preview until a guide is selected
- constrain the active guide list to a scrollable panel so the page height stays manageable
- require search input before rendering the route library or encyclopedia, keeping the drawers light-weight by default

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc9e97c1148331b638ab85964a5bca