### PR TITLE
Improve route overview collapse and goal selection controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -212,7 +212,7 @@ gba(119,141,169,0.45)}
 .route-grid{display:grid;gap:clamp(22px,2.2vw,28px)}
 .route-grid--primary,.route-grid--secondary{grid-template-columns:1fr}
 .route-grid--primary>.card,.route-grid--secondary>.card{height:auto}
-@media (min-width:960px){.route-grid--primary{grid-template-columns:minmax(0,1.65fr) minmax(0,1fr);align-items:start}}
+@media (min-width:1200px){.route-grid--primary{grid-template-columns:minmax(0,1.65fr) minmax(0,1fr);align-items:start}}
 @media (min-width:1200px){.route-grid--secondary:not(:last-of-type){grid-template-columns:repeat(2,minmax(0,1fr));align-items:start}}
 @media (min-width:1440px){
   .route-shell{grid-template-columns:repeat(12,minmax(0,1fr))}
@@ -387,7 +387,10 @@ gba(119,141,169,0.45)}
 .route-goal-option__icon{display:grid;place-items:center;width:42px;height:42px;border-radius:14px;background:rgba(119,141,169,0.2);color:var(--accent,#778da9);font-size:1.1rem}
 .route-goal-option__label{font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.92)}
 .route-goal-option--active{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 32px rgba(148,210,189,0.2);transform:translateY(-1px)}
-.route-goal-drawer__footer{display:flex;justify-content:flex-end}
+.route-goal-drawer__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px}
+.route-goal-drawer__bulk{display:flex;flex-wrap:wrap;gap:8px}
+.route-goal-drawer__bulk-btn{min-height:36px;padding:6px 14px;font-size:.78rem;letter-spacing:.06em;text-transform:uppercase;background:rgba(0,0,0,0.3);border:1px solid rgba(119,141,169,0.4);color:var(--text,#f0f4f8);border-radius:999px;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.route-goal-drawer__bulk-btn:hover,.route-goal-drawer__bulk-btn:focus-visible{background:rgba(0,0,0,0.45);border-color:rgba(148,210,189,0.55);color:var(--text,#f0f4f8);outline:none}
 .route-goal-drawer__close{background:rgba(0,0,0,0.35);border-color:rgba(119,141,169,0.4);color:var(--text,#f0f4f8)}
 .route-goal-drawer__close:hover{background:rgba(0,0,0,0.45)}
 .route-goal-drawer--open .route-goal-drawer__toggle{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}

--- a/index.html
+++ b/index.html
@@ -13306,6 +13306,10 @@
         : root.querySelector ? root.querySelector('#routeContextCard') : null;
       if(contextCard){
         contextCard.classList.toggle('route-context--collapsed', !!routeOverviewCollapsed);
+        const controlsRegion = contextCard.querySelector('.route-hero__controls');
+        if(controlsRegion){
+          controlsRegion.hidden = !!routeOverviewCollapsed;
+        }
       }
       const container = root.querySelector('[data-route-role="overview"]');
       if(container){
@@ -13398,6 +13402,8 @@
         const icon = routeGoalIcon(normalized);
         return `<label class="${optionClasses.join(' ')}"><input type="checkbox" data-context-goal value="${escapeHTML(normalized)}" ${active ? 'checked' : ''} /><span class="route-goal-option__icon"><i class="fa-solid ${escapeHTML(icon)}"></i></span><span class="route-goal-option__label">${escapeHTML(capitalize(normalized))}</span></label>`;
       }).join('');
+      const selectAllLabel = kidMode ? 'Select all goals' : 'Select all goals';
+      const clearAllLabel = kidMode ? 'Clear goals' : 'Deselect all goals';
       return `
         <div class="${classes.join(' ')}" data-goal-picker>
           <button type="button" class="route-goal-drawer__toggle" data-goal-toggle aria-expanded="${routeGoalDrawerOpen ? 'true' : 'false'}" aria-label="${escapeHTML(`${toggleLabel}: ${summary}`)}" title="${escapeHTML(summary)}">
@@ -13409,6 +13415,10 @@
               ${options}
             </div>
             <div class="route-goal-drawer__footer">
+              <div class="route-goal-drawer__bulk">
+                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="select-all">${escapeHTML(selectAllLabel)}</button>
+                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="clear">${escapeHTML(clearAllLabel)}</button>
+              </div>
               <button type="button" class="chip route-goal-drawer__close" data-goal-close>${escapeHTML(kidMode ? 'Done picking' : 'Lock selections')}</button>
             </div>
           </div>
@@ -13736,6 +13746,21 @@
               .map(el => el.value)
               .filter(Boolean);
             updateRouteContextState({ goals: selected });
+          }, { signal });
+        });
+        goalPicker.querySelectorAll('[data-goal-bulk]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const action = btn.dataset.goalBulk;
+            const boxes = Array.from(goalPicker.querySelectorAll('[data-context-goal]'));
+            if(!boxes.length) return;
+            if(action === 'select-all'){
+              boxes.forEach(box => { box.checked = true; });
+              const selected = boxes.map(box => box.value).filter(Boolean);
+              updateRouteContextState({ goals: selected });
+            } else if(action === 'clear'){
+              boxes.forEach(box => { box.checked = false; });
+              updateRouteContextState({ goals: [] });
+            }
           }, { signal });
         });
         applyDrawerState();


### PR DESCRIPTION
## Summary
- ensure the route snapshot toggle hides the full context controls so the card collapses into the button
- add select-all and deselect-all actions to the goal picker along with supporting styles
- adjust responsive breakpoints so Tonight’s Adventure Paths and the adventure queue stack vertically on tablet widths

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd3d8f74b08331afffa68709f171de