### PR TITLE
Stack route planner cards and retire guide encyclopedia

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -212,19 +212,6 @@ gba(119,141,169,0.45)}
 .route-grid{display:grid;gap:clamp(22px,2.2vw,28px)}
 .route-grid--primary,.route-grid--secondary{grid-template-columns:1fr}
 .route-grid--primary>.card,.route-grid--secondary>.card{height:auto}
-@media (min-width:1200px){.route-grid--primary{grid-template-columns:minmax(0,1.65fr) minmax(0,1fr);align-items:start}}
-@media (min-width:1200px){.route-grid--secondary:not(:last-of-type){grid-template-columns:repeat(2,minmax(0,1fr));align-items:start}}
-@media (min-width:1440px){
-  .route-shell{grid-template-columns:repeat(12,minmax(0,1fr))}
-  .route-hero{grid-column:1/-1}
-  .route-grid--primary{grid-column:1/-1;grid-template-columns:repeat(12,minmax(0,1fr))}
-  .route-grid--primary>.route-suggestions-card{grid-column:1/span 7}
-  .route-grid--primary>.route-active-card{grid-column:8/span 5}
-  .route-grid--secondary{grid-column:1/-1;grid-template-columns:repeat(12,minmax(0,1fr))}
-  .route-grid--secondary>.route-recommendations-card{grid-column:1/span 7}
-  .route-grid--secondary>.route-library{grid-column:8/span 5}
-  .route-grid--secondary:last-of-type>.guide-catalog{grid-column:1/-1}
-}
 .route-hero,.route-suggestions-card,.route-active-card,.route-recommendations-card,.route-library,.guide-catalog,.route-tonight-card{position:relative;overflow:hidden;padding:22px 24px 26px;background-image:linear-gradient(155deg,var(--route-card-overlay,rgba(14,32,52,0.9)),rgba(8,18,34,0.94)),var(--route-card-backdrop, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-card-position,center 48%);background-repeat:no-repeat;border:1px solid rgba(148,210,189,0.24);box-shadow:0 32px 64px rgba(4,14,28,0.58);backdrop-filter:blur(10px)}
 .route-suggestions-card,.route-active-card,.route-recommendations-card,.route-library,.guide-catalog,.route-tonight-card{padding:clamp(20px,2.4vw,28px)}
 .route-hero::before,.route-suggestions-card::before,.route-active-card::before,.route-recommendations-card::before,.route-library::before,.guide-catalog::before,.route-tonight-card::before{content:"";position:absolute;inset:-45% auto auto -30%;width:260px;height:260px;background:radial-gradient(circle at center,rgba(148,210,189,0.35),transparent 72%);opacity:.32;pointer-events:none;animation:routeGlow 22s linear infinite}

--- a/index.html
+++ b/index.html
@@ -12821,17 +12821,6 @@
           const recommendationLead = kidMode
             ? 'Need other ideas? These extra adventures re-rank when your context changes.'
             : 'Want alternatives? The rest of the ranked library updates whenever your context shifts.';
-          const catalog = routeGuideData?.guideCatalog;
-          const catalogCount = catalog?.count != null ? catalog.count : (Array.isArray(catalog?.entries) ? catalog.entries.length : 0);
-          const catalogLead = catalogCount
-            ? (kidMode
-              ? `Browse ${catalogCount} quick guides covering Palworld adventures.`
-              : `Browse ${catalogCount} structured guides across Palworld systems.`)
-            : (kidMode
-              ? 'Browse the full guide index once data loads.'
-              : 'Browse the complete guide catalog as soon as it loads.');
-          const groupOptions = renderGuideCatalogGroupOptions(catalog);
-          const categoryOptions = renderGuideCatalogCategoryOptions(catalog);
           const plannerLead = kidMode
             ? 'Tell Palmate what you need tonight and we’ll build the perfect plan.'
             : 'Dial in your context and Palmate will surface the routes that matter most.';
@@ -12967,32 +12956,6 @@
                 </details>
               </section>
             </div>
-            <div class="route-grid route-grid--secondary">
-              <section class="card guide-catalog" id="guideCatalogCard">
-                <div class="guide-catalog__header">
-                  <h3>${escapeHTML(kidMode ? 'Guide encyclopedia' : 'Complete guide index')}</h3>
-                  <p>${escapeHTML(catalogLead)}</p>
-                  <span class="guide-catalog__count" data-guide-catalog-count></span>
-                </div>
-                <div class="guide-catalog__controls">
-                  <label class="guide-catalog__search">
-                    <span class="sr-only">${escapeHTML(kidMode ? 'Search guides' : 'Search guide catalog')}</span>
-                    <input type="search" id="guideCatalogSearch" placeholder="${escapeHTML(kidMode ? 'Search all guides' : 'Search the catalog')}" value="${escapeHTML(guideCatalogSearchTerm)}" />
-                  </label>
-                  <div class="guide-catalog__filters">
-                    <label>
-                      <span>${escapeHTML(kidMode ? 'Category group' : 'Category group')}</span>
-                      <select id="guideCatalogGroup">${groupOptions}</select>
-                    </label>
-                    <label>
-                      <span>${escapeHTML(kidMode ? 'Focus' : 'Focus')}</span>
-                      <select id="guideCatalogCategory">${categoryOptions}</select>
-                    </label>
-                  </div>
-                </div>
-                <div class="guide-catalog__list" id="guideCatalogList"></div>
-              </section>
-            </div>
           </div>
         `;
           const wrap = node.querySelector('#routeChapters');
@@ -13000,7 +12963,6 @@
           pruneCompletedActiveRoutes();
           renderActiveRoutesList();
           renderRouteLibraryList();
-          renderGuideCatalogList();
           const librarySearch = node.querySelector('#routeLibrarySearch');
           if(librarySearch && !librarySearch.dataset.bound){
             librarySearch.value = routeLibrarySearchTerm;
@@ -13011,7 +12973,6 @@
             });
           }
           bindRouteLibraryControls(node);
-          bindGuideCatalogControls(node);
           wrap.addEventListener('change', handleRouteCheckboxChange);
           wrap.addEventListener('click', handleRouteClick);
           bindRouteActionButtons();
@@ -13476,13 +13437,31 @@
     function renderRouteRecommendationsList(recommendations, { offset = 0 } = {}){
       const list = document.getElementById('routeRecommendationsList');
       if(!list) return;
-      if(!Array.isArray(recommendations) || recommendations.length <= offset){
-        list.innerHTML = `<p class="route-recommendations__empty">${escapeHTML(kidMode ? 'Set your level or add goals to see suggestions.' : 'Adjust your context to surface tailored recommendations.')}</p>`;
+      const pool = Array.isArray(recommendations)
+        ? recommendations.filter(entry => entry && entry.route)
+        : [];
+      if(!pool.length){
+        list.innerHTML = `<p class="route-recommendations__empty">${escapeHTML(kidMode ? 'Add goals or mark progress to unlock fresh adventures.' : 'Adjust your goals or progress to unlock new recommendations.')}</p>`;
+        updateRouteRecommendationBackdrop([]);
       } else {
-        const cards = recommendations.slice(offset, offset + 5).map(renderRouteRecommendation).join('');
-        list.innerHTML = cards;
+        const suggestionIds = new Set(
+          Array.isArray(currentRouteSuggestionEntries)
+            ? currentRouteSuggestionEntries
+                .map(entry => entry && entry.route ? entry.route.id : null)
+                .filter(Boolean)
+            : []
+        );
+        let extras = pool.filter(entry => entry && entry.route && !suggestionIds.has(entry.route.id));
+        if(offset > 0 && extras.length > offset){
+          extras = extras.slice(offset);
+        }
+        if(!extras.length){
+          extras = pool.slice();
+        }
+        const visible = extras.slice(0, 5);
+        list.innerHTML = visible.map(renderRouteRecommendation).join('');
+        updateRouteRecommendationBackdrop(visible);
       }
-      updateRouteRecommendationBackdrop(recommendations, offset);
       if(routeRecommendationsAbort){
         routeRecommendationsAbort.abort();
       }


### PR DESCRIPTION
## Summary
- keep every card on the routes page in a single-column stack so tonight's plan and the active queue never sit side-by-side
- hide the unused guide encyclopedia drawer so the routes interface focuses on actionable tools
- tweak the "More adventures" logic to reuse recommendation entries when needed instead of showing an empty state

## Testing
- manual inspection of http://127.0.0.1:8000/index.html#route

------
https://chatgpt.com/codex/tasks/task_e_68dd4e157fd48331adcd8c9942d2ef2b