### PR TITLE
Restyle adventure queue layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -253,8 +253,13 @@ gba(119,141,169,0.45)}
 .route-suggestions__list .guide-card:hover,.route-recommendations__list .guide-card:hover{border-color:rgba(148,210,189,0.5);box-shadow:0 28px 54px rgba(4,14,28,0.6)}
 .route-suggestions__detail{border:1px solid rgba(148,210,189,0.28);box-shadow:0 28px 54px rgba(4,14,28,0.6)}
 .route-active__actions{display:flex;flex-wrap:wrap;gap:12px}
-.route-active__list{display:grid;gap:clamp(18px,2.2vw,26px);grid-template-columns:repeat(auto-fit,minmax(420px,1fr))}
-.route-active__list>.route-card{height:100%}
+.route-active__list{--queue-line-offset:clamp(26px,3vw,46px);position:relative;display:flex;flex-direction:column;gap:clamp(22px,2.6vw,34px);padding-left:calc(var(--queue-line-offset)+6px);counter-reset:routeQueue}
+.route-active__list::before{content:"";position:absolute;inset:16px auto 16px calc(var(--queue-line-offset)/2);width:2px;background:linear-gradient(180deg,rgba(148,210,189,0.65),rgba(63,123,190,0.15));border-radius:999px;opacity:.9;pointer-events:none}
+.route-active__list:empty{padding-left:0}
+.route-active__list:empty::before{display:none}
+.route-active__list>.route-card{position:relative;height:auto;margin:0}
+.route-active__list>.route-card::before{counter-increment:routeQueue;content:counter(routeQueue,decimal-leading-zero);position:absolute;left:calc(-1*var(--queue-line-offset));top:28px;display:flex;align-items:center;justify-content:center;width:calc(var(--queue-line-offset)-10px);height:calc(var(--queue-line-offset)-10px);border-radius:16px;background:linear-gradient(160deg,rgba(148,210,189,0.18),rgba(17,42,70,0.9));border:1px solid rgba(148,210,189,0.35);box-shadow:0 18px 36px rgba(4,18,36,0.55);font-weight:700;letter-spacing:.08em;font-size:.85rem;color:#f4faf8}
+.route-active__list>.route-card::after{content:"";position:absolute;left:calc(-1*var(--queue-line-offset)/2);top:calc(var(--queue-line-offset)/2 + 12px);width:10px;height:10px;border-radius:999px;background:rgba(148,210,189,0.85);box-shadow:0 0 0 4px rgba(148,210,189,0.18)}
 .route-library__filter-btn{transition:transform .2s ease,box-shadow .2s ease}
 .route-library__filter-btn:hover,.route-library__filter-btn:focus-visible{transform:translateY(-2px);box-shadow:0 12px 24px rgba(0,0,0,0.35)}
 .route-library__match{transition:transform .2s ease,box-shadow .2s ease}
@@ -268,6 +273,13 @@ gba(119,141,169,0.45)}
 .route-error p{margin:0;font-size:.98rem;color:rgba(255,224,214,0.86)}
 .route-error__retry{align-self:center}
 .route-card{display:grid;gap:22px}
+.route-card--stacked{padding:clamp(24px,2.8vw,34px);border-radius:26px;background:linear-gradient(150deg,rgba(11,28,46,0.96),rgba(5,16,32,0.9));border:1px solid rgba(148,210,189,0.28);box-shadow:0 32px 64px rgba(3,10,24,0.55);backdrop-filter:blur(12px)}
+.route-card--stacked .route-card__header{gap:clamp(18px,2vw,26px)}
+.route-card--stacked .route-card__toolbar{justify-content:flex-start;gap:16px}
+.route-card--stacked .route-card__toolbar>*{flex-shrink:0}
+.route-card--stacked .route-card__thumb{flex-basis:116px;width:116px;height:116px;border-radius:26px}
+.route-card--stacked .route-card__progress{background:rgba(6,18,34,0.82);border:1px solid rgba(148,210,189,0.18);box-shadow:inset 0 0 0 1px rgba(148,210,189,0.08)}
+.route-card--stacked .route-card__details{background:rgba(4,14,28,0.84);border-color:rgba(148,210,189,0.22)}
 .route-card__header{display:flex;justify-content:space-between;gap:22px;flex-wrap:wrap;align-items:flex-start}
 .route-card__info{display:flex;align-items:flex-start;gap:18px;flex:1 1 360px;min-width:0}
 .route-card__thumb{position:relative;flex:0 0 104px;width:104px;height:104px;border-radius:22px;overflow:hidden;background:rgba(8,16,32,0.86);box-shadow:0 22px 46px rgba(0,0,0,0.55)}

--- a/index.html
+++ b/index.html
@@ -14738,7 +14738,7 @@
 
     function renderChapterCard(chapter, openByDefault, route){
       const section = document.createElement('section');
-      section.className = 'card route-card';
+      section.className = 'card route-card route-card--stacked';
       section.id = `chapter-${chapter.id}`;
       section.dataset.chapterId = chapter.id;
       section.innerHTML = buildRouteCardInnerHTML(chapter, openByDefault, route);


### PR DESCRIPTION
## Summary
- stack the adventure queue cards vertically to eliminate layout shifts when expanding steps
- refresh the queue cards with enhanced styling to create a more polished presentation

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd5610e2088331b1fae85a85854d85