### PR TITLE
Refine adventure queue layout and expand route art mapping

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -100,8 +100,8 @@ gba(119,141,169,0.45)}
 0.25);border:1px solid rgba(255,255,255,0.08)}
 .tech-materials span:last-child{font-variant-numeric:tabular-nums;font-weight:600;color:rgba(224,225,221,0.95)}
 .step-group{margin:12px 0}
-.step-list{display:grid;gap:16px;margin:12px 0}
-@media (min-width:1080px){.step-list{grid-template-columns:repeat(auto-fit,minmax(420px,1fr));gap:clamp(16px,1.8vw,26px)}}
+.step-list{display:grid;grid-template-columns:1fr;gap:clamp(16px,2vw,22px);margin:12px 0}
+.step-list>*{min-width:0}
 .step{position:relative;display:grid;grid-template-columns:34px minmax(0,1fr);align-items:flex-start;gap:16px;padding:20px 22px;border-radius:22px;background:linear-gradient(140deg,rgba(16,32,52,0.94),rgba(8,18,34,0.88));border:1px solid rgba(119,141,169,0.32);box-shadow:0 22px 44px rgba(0,0,0,0.48);transition:transform .22s ease,border-color .28s ease,box-shadow .28s ease,background .28s ease}
 .step::before{content:"";position:absolute;inset:1px;border-radius:inherit;background:radial-gradient(circle at top left,rgba(148,210,189,0.22),transparent 65%);opacity:.35;pointer-events:none;transition:opacity .3s ease}
 .step:hover,.step:focus-within{transform:translateY(-2px);border-color:rgba(148,210,189,0.65);box-shadow:0 28px 54px rgba(0,0,0,0.55)}
@@ -255,11 +255,9 @@ gba(119,141,169,0.45)}
 .route-suggestions__toggle{appearance:none;border:1px solid rgba(255,255,255,0.18);background:rgba(8,16,32,0.55);color:var(--light,#e0e1dd);border-radius:999px;padding:6px 14px;font-size:.8rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;display:inline-flex;align-items:center;gap:6px;cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
 .route-suggestions__toggle:hover,.route-suggestions__toggle:focus-visible{background:rgba(12,28,46,0.75);border-color:rgba(148,210,189,0.38);color:var(--text,#f0f4f8);outline:none}
 .route-suggestions__toggle i{font-size:.75rem}
-.route-suggestions-card--slim .route-suggestions__list{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px;margin-right:-4px;scroll-snap-type:x proximity}
-.route-suggestions-card--slim .route-suggestion-card{flex:0 0 clamp(260px,22vw,340px);scroll-snap-align:start}
-.route-suggestions-card--slim .route-suggestions__list::-webkit-scrollbar{height:6px}
-.route-suggestions-card--slim .route-suggestions__list::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.4);border-radius:999px}
-.route-suggestions-card--slim .route-suggestions__list::-webkit-scrollbar-track{background:rgba(8,16,32,0.5)}
+.route-suggestions-card--slim .route-suggestions__list{display:grid;grid-template-columns:1fr;gap:clamp(16px,2vw,22px);padding-bottom:0;margin-right:0}
+.route-suggestions-card--slim .route-suggestion-card{width:100%;min-width:0}
+@media (min-width:720px){.route-suggestions-card--slim .route-suggestions__list{grid-template-columns:repeat(auto-fit,minmax(320px,1fr))}}
 .route-suggestions-card--slim .route-suggestions__detail{border-radius:18px;overflow:hidden;max-height:420px}
 .route-suggestions__detail{display:grid;align-content:start;min-height:220px}
 .route-suggestions__detail>p{margin:0}
@@ -510,18 +508,18 @@ gba(119,141,169,0.45)}
 .route-suggestions__detail{grid-area:detail}
 .route-suggestions__detail:not([data-route-id]){display:none}
 .route-suggestions__empty,.route-suggestions__placeholder{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem;text-align:center;padding:12px}
-.route-suggestion-card{position:relative;display:grid;grid-template-columns:auto 1fr;gap:18px;align-items:start;padding:18px 20px;border-radius:24px;border:1px solid rgba(148,210,189,0.22);background-image:linear-gradient(155deg,var(--route-suggestion-overlay,rgba(10,24,38,0.94)),rgba(4,14,28,0.9)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat;box-shadow:0 18px 36px rgba(4,14,28,0.45);color:var(--text,#f0f4f8);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,background .25s ease;overflow:hidden;text-align:left;font:inherit;appearance:none}
+.route-suggestion-card{position:relative;display:grid;grid-template-columns:auto 1fr;gap:18px;align-items:stretch;padding:18px 20px;border-radius:24px;border:1px solid rgba(148,210,189,0.22);background-image:linear-gradient(155deg,var(--route-suggestion-overlay,rgba(10,24,38,0.94)),rgba(4,14,28,0.9)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat;box-shadow:0 18px 36px rgba(4,14,28,0.45);color:var(--text,#f0f4f8);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,background .25s ease;overflow:hidden;text-align:left;font:inherit;appearance:none}
 .route-suggestion-card:focus{outline:none}
 .route-suggestion-card:focus-visible{box-shadow:0 0 0 3px rgba(148,210,189,0.4),0 18px 36px rgba(4,14,28,0.45)}
 .route-suggestion-card:hover{transform:translateY(-3px);border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 24px 48px rgba(4,14,28,0.55)}
 .route-suggestion-card--active{border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 26px 52px rgba(4,14,28,0.52);background-image:linear-gradient(155deg,rgba(14,32,52,0.95),rgba(6,18,34,0.92)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat}
-.route-suggestion-card__media{display:grid;gap:10px;align-content:start;justify-items:center}
+.route-suggestion-card__media{display:grid;gap:10px;align-content:start;justify-items:start}
 .route-suggestion-card__avatar{width:72px;height:72px;border-radius:22px;background-image:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.45)),var(--route-suggestion-avatar,var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp'))));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 50%));border:2px solid rgba(255,255,255,0.18);box-shadow:0 16px 28px rgba(0,0,0,0.45);position:relative;overflow:hidden}
 .route-suggestion-card__avatar::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.45))}
 .route-suggestion-card--active .route-suggestion-card__avatar{border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff))}
 .route-suggestion-card__tag{display:inline-flex;align-items:center;gap:6px;padding:4px 11px;border-radius:999px;background:rgba(8,16,32,0.68);border:1px solid rgba(255,255,255,0.18);font-size:.72rem;font-weight:650;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.78)}
-.route-suggestion-card__body{display:grid;gap:14px;min-width:0}
-.route-suggestion-card__top{display:flex;align-items:flex-start;gap:12px}
+.route-suggestion-card__body{display:grid;gap:14px;min-width:0;align-content:start}
+.route-suggestion-card__top{display:flex;flex-wrap:wrap;align-items:flex-start;gap:12px}
 .route-suggestion-card__icon{flex:0 0 auto;width:44px;height:44px;border-radius:14px;background:rgba(0,0,0,0.38);display:grid;place-items:center;font-size:1.2rem;color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 12px 22px rgba(0,0,0,0.4)}
 .route-suggestion-card__text{display:flex;flex-direction:column;gap:4px;min-width:0}
 .route-suggestion-card__title{margin:0;font-size:1.08rem;line-height:1.25}

--- a/index.html
+++ b/index.html
@@ -9951,19 +9951,54 @@
     const ROUTE_ART_LIBRARY = {
       boss: { ...ROUTE_VISUAL_THEMES.boss },
       tower: { ...ROUTE_VISUAL_THEMES.boss },
+      'tower-boss': { ...ROUTE_VISUAL_THEMES.boss, overlay: 'rgba(155, 107, 255, 0.6)', icon: 'fa-chess-knight', position: 'center 28%' },
+      dungeon: { ...ROUTE_VISUAL_THEMES.boss, overlay: 'rgba(148, 87, 235, 0.62)', icon: 'fa-skull', position: 'center 32%' },
+      raid: { ...ROUTE_VISUAL_THEMES.boss, overlay: 'rgba(236, 72, 153, 0.6)', accent: '#f9a8d4', icon: 'fa-users', position: 'center 40%' },
       farming: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(42, 157, 143, 0.6)', accent: '#8ff0b5', icon: 'fa-seedling', position: 'center 62%' },
       gather: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(42, 157, 143, 0.6)', accent: '#8ff0b5', icon: 'fa-seedling', position: 'center 62%' },
+      'resource-gathering': { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(74, 201, 155, 0.55)', accent: '#9ff2c5', icon: 'fa-seedling', position: 'center 60%' },
+      resource: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(74, 201, 155, 0.55)', accent: '#9ff2c5', icon: 'fa-seedling', position: 'center 60%' },
       capture: { ...ROUTE_VISUAL_THEMES.pal, overlay: 'rgba(255, 170, 102, 0.6)', accent: '#ffd6a5', icon: 'fa-paw', position: 'center 58%' },
+      breeding: { ...ROUTE_VISUAL_THEMES.pal, overlay: 'rgba(249, 168, 212, 0.55)', accent: '#ffbde6', icon: 'fa-egg', position: 'center 56%' },
+      egg: { ...ROUTE_VISUAL_THEMES.pal, overlay: 'rgba(249, 168, 212, 0.55)', accent: '#ffbde6', icon: 'fa-egg', position: 'center 56%' },
+      hatch: { ...ROUTE_VISUAL_THEMES.pal, overlay: 'rgba(249, 168, 212, 0.55)', accent: '#ffbde6', icon: 'fa-egg', position: 'center 56%' },
+      combat: { ...ROUTE_VISUAL_THEMES.boss, overlay: 'rgba(255, 107, 107, 0.58)', accent: '#ffb4b4', icon: 'fa-crosshairs', position: 'center 34%' },
       exploration: { ...ROUTE_VISUAL_THEMES.map },
+      progression: { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(118, 206, 255, 0.58)', accent: '#8dd9ff', icon: 'fa-compass', position: 'center 44%' },
+      core: { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(118, 206, 255, 0.58)', accent: '#8dd9ff', icon: 'fa-compass', position: 'center 44%' },
+      support: { ...ROUTE_VISUAL_THEMES.tech, overlay: 'rgba(120, 180, 255, 0.55)', accent: '#a7c5ff', icon: 'fa-toolbox', position: 'center 52%' },
+      starter: { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(148, 210, 189, 0.55)', accent: '#a5f2d5', icon: 'fa-seedling', position: 'center 46%' },
+      'early-game': { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(148, 210, 189, 0.55)', accent: '#a5f2d5', icon: 'fa-seedling', position: 'center 46%' },
+      'mid-game': { ...ROUTE_VISUAL_THEMES.tech, overlay: 'rgba(255, 196, 77, 0.55)', accent: '#ffd166', icon: 'fa-chart-line', position: 'center 48%' },
+      'late-game': { ...ROUTE_VISUAL_THEMES.boss, overlay: 'rgba(185, 109, 255, 0.6)', accent: '#deb7ff', icon: 'fa-trophy', position: 'center 30%' },
       travel: { ...ROUTE_VISUAL_THEMES.map, image: ROUTE_THEME_ART_SOURCES.travel },
+      'fast-travel': { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(123, 201, 255, 0.55)', accent: '#9fd8ff', icon: 'fa-location-arrow', position: 'center 48%' },
       craft: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(255, 214, 102, 0.58)', accent: '#ffe599', icon: 'fa-hammer', position: 'center 44%' },
-      base: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' }
+      base: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' },
+      'base-building': { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(90, 126, 255, 0.58)', accent: '#b8c3ff', icon: 'fa-house-flag', position: 'center 66%' },
+      'base-management': { ...ROUTE_VISUAL_THEMES.tech, overlay: 'rgba(90, 126, 255, 0.5)', accent: '#b8c3ff', icon: 'fa-gears', position: 'center 52%' },
+      mount: { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(255, 196, 77, 0.55)', accent: '#ffd166', icon: 'fa-horse', position: 'center 58%' },
+      saddle: { ...ROUTE_VISUAL_THEMES.map, overlay: 'rgba(255, 196, 77, 0.55)', accent: '#ffd166', icon: 'fa-horse', position: 'center 58%' },
+      ore: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(147, 197, 253, 0.55)', accent: '#b4d7ff', icon: 'fa-gem', position: 'center 62%' },
+      ingot: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(255, 214, 102, 0.52)', accent: '#ffe59f', icon: 'fa-cubes', position: 'center 60%' },
+      quartz: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(185, 220, 255, 0.58)', accent: '#e0f0ff', icon: 'fa-gem', position: 'center 62%' },
+      paldium: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(120, 180, 255, 0.58)', accent: '#9ed0ff', icon: 'fa-bolt', position: 'center 58%' },
+      coal: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(255, 138, 101, 0.55)', accent: '#ffb199', icon: 'fa-fire', position: 'center 60%' },
+      lumber: { ...ROUTE_VISUAL_THEMES.item, overlay: 'rgba(148, 210, 189, 0.6)', accent: '#a5f2d5', icon: 'fa-tree', position: 'center 62%' },
+      medicine: { ...ROUTE_VISUAL_THEMES.tech, overlay: 'rgba(72, 187, 255, 0.55)', accent: '#8edbff', icon: 'fa-kit-medical', position: 'center 52%' },
+      healing: { ...ROUTE_VISUAL_THEMES.tech, overlay: 'rgba(72, 187, 255, 0.55)', accent: '#8edbff', icon: 'fa-kit-medical', position: 'center 52%' },
+      technology: { ...ROUTE_VISUAL_THEMES.tech },
+      research: { ...ROUTE_VISUAL_THEMES.tech }
     };
     const ROUTE_ART_VARIANTS = [
       { image: ROUTE_THEME_ART_SOURCES.generic, overlay: 'rgba(148, 187, 233, 0.55)', accent: '#9bd4ff', icon: 'fa-route', position: 'center 40%' },
       { image: ROUTE_THEME_ART_SOURCES.item, overlay: 'rgba(255, 123, 123, 0.52)', accent: '#ffb3c1', icon: 'fa-fire', position: 'center 64%' },
       { image: ROUTE_THEME_ART_SOURCES.pal, overlay: 'rgba(92, 225, 230, 0.52)', accent: '#bde7f8', icon: 'fa-compass', position: 'center 28%' },
-      { image: ROUTE_THEME_ART_SOURCES.tech, overlay: 'rgba(255, 196, 77, 0.5)', accent: '#ffd6a5', icon: 'fa-sun', position: 'center 52%' }
+      { image: ROUTE_THEME_ART_SOURCES.tech, overlay: 'rgba(255, 196, 77, 0.5)', accent: '#ffd6a5', icon: 'fa-sun', position: 'center 52%' },
+      { image: ROUTE_THEME_ART_SOURCES.map, overlay: 'rgba(118, 206, 255, 0.5)', accent: '#8dd9ff', icon: 'fa-compass', position: 'center 42%' },
+      { image: ROUTE_THEME_ART_SOURCES.boss, overlay: 'rgba(185, 109, 255, 0.58)', accent: '#deb7ff', icon: 'fa-chess-knight', position: 'center 32%' },
+      { image: ROUTE_THEME_ART_SOURCES.npc, overlay: 'rgba(249, 168, 212, 0.5)', accent: '#f9a8d4', icon: 'fa-user-astronaut', position: 'center 46%' },
+      { image: ROUTE_THEME_ART_SOURCES.travel, overlay: 'rgba(255, 196, 77, 0.5)', accent: '#ffd166', icon: 'fa-map-location-dot', position: 'center 52%' }
     ];
     const NPC_ART_LIBRARY = {
       zoe: ROUTE_THEME_ART_SOURCES.npc,
@@ -11605,6 +11640,14 @@
     function routeVisualFromTags(route){
       if(!route) return {};
       const keys = [];
+      if(route.progression_role) keys.push(String(route.progression_role).toLowerCase());
+      if(route.route_id){
+        String(route.route_id)
+          .toLowerCase()
+          .split(/[^a-z0-9]+/)
+          .filter(Boolean)
+          .forEach(part => keys.push(part));
+      }
       if(route.category) keys.push(String(route.category).toLowerCase());
       if(Array.isArray(route.tags)){
         route.tags.forEach(tag => keys.push(String(tag).toLowerCase()));


### PR DESCRIPTION
## Summary
- stack active queue steps vertically and reshape tonight suggestions into a responsive grid with improved spacing
- align suggestion card content for consistent presentation within each card
- broaden route artwork matching by expanding the art library, adding new variants, and using more route metadata

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd7e0a4a2c8331984c0e17b8563b2e