### PR TITLE
Improve recommendation previews and suggestion card layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -508,30 +508,30 @@ gba(119,141,169,0.45)}
 .route-suggestions__detail{grid-area:detail}
 .route-suggestions__detail:not([data-route-id]){display:none}
 .route-suggestions__empty,.route-suggestions__placeholder{margin:0;color:var(--muted,rgba(224,225,221,0.72));font-size:.95rem;text-align:center;padding:12px}
-.route-suggestion-card{position:relative;display:grid;grid-template-columns:auto 1fr;gap:18px;align-items:stretch;padding:18px 20px;border-radius:24px;border:1px solid rgba(148,210,189,0.22);background-image:linear-gradient(155deg,var(--route-suggestion-overlay,rgba(10,24,38,0.94)),rgba(4,14,28,0.9)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat;box-shadow:0 18px 36px rgba(4,14,28,0.45);color:var(--text,#f0f4f8);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,background .25s ease;overflow:hidden;text-align:left;font:inherit;appearance:none}
+.route-suggestion-card{position:relative;display:grid;grid-template-columns:88px minmax(0,1fr);gap:16px;align-items:flex-start;padding:16px 20px;border-radius:24px;border:1px solid rgba(148,210,189,0.22);background-image:linear-gradient(155deg,var(--route-suggestion-overlay,rgba(10,24,38,0.94)),rgba(4,14,28,0.9)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat;box-shadow:0 18px 36px rgba(4,14,28,0.45);color:var(--text,#f0f4f8);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,background .25s ease;overflow:hidden;text-align:left;font:inherit;appearance:none}
 .route-suggestion-card:focus{outline:none}
 .route-suggestion-card:focus-visible{box-shadow:0 0 0 3px rgba(148,210,189,0.4),0 18px 36px rgba(4,14,28,0.45)}
 .route-suggestion-card:hover{transform:translateY(-3px);border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 24px 48px rgba(4,14,28,0.55)}
 .route-suggestion-card--active{border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 26px 52px rgba(4,14,28,0.52);background-image:linear-gradient(155deg,rgba(14,32,52,0.95),rgba(6,18,34,0.92)),var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 48%));background-repeat:no-repeat}
-.route-suggestion-card__media{display:grid;gap:10px;align-content:start;justify-items:start}
-.route-suggestion-card__avatar{width:72px;height:72px;border-radius:22px;background-image:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.45)),var(--route-suggestion-avatar,var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp'))));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 50%));border:2px solid rgba(255,255,255,0.18);box-shadow:0 16px 28px rgba(0,0,0,0.45);position:relative;overflow:hidden}
+.route-suggestion-card__media{display:grid;align-content:start;justify-items:start}
+.route-suggestion-card__avatar{width:88px;height:88px;border-radius:24px;background-image:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.45)),var(--route-suggestion-avatar,var(--route-suggestion-image,var(--guide-card-image,url('../assets/images/palworld-full-map-2.webp'))));background-size:cover;background-position:var(--route-suggestion-position,var(--guide-card-position,center 50%));border:2px solid rgba(255,255,255,0.18);box-shadow:0 16px 28px rgba(0,0,0,0.45);position:relative;overflow:hidden}
 .route-suggestion-card__avatar::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.45))}
 .route-suggestion-card--active .route-suggestion-card__avatar{border-color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff))}
-.route-suggestion-card__tag{display:inline-flex;align-items:center;gap:6px;padding:4px 11px;border-radius:999px;background:rgba(8,16,32,0.68);border:1px solid rgba(255,255,255,0.18);font-size:.72rem;font-weight:650;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.78)}
-.route-suggestion-card__body{display:grid;gap:14px;min-width:0;align-content:start}
-.route-suggestion-card__top{display:flex;flex-wrap:wrap;align-items:flex-start;gap:12px}
+.route-suggestion-card__tag{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(8,16,32,0.68);border:1px solid rgba(255,255,255,0.18);font-size:.7rem;font-weight:650;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.78);max-width:100%;white-space:normal;word-break:break-word;line-height:1.2;text-align:left}
+.route-suggestion-card__body{display:grid;gap:12px;min-width:0;align-content:start}
+.route-suggestion-card__header{display:flex;gap:14px;align-items:flex-start}
 .route-suggestion-card__icon{flex:0 0 auto;width:44px;height:44px;border-radius:14px;background:rgba(0,0,0,0.38);display:grid;place-items:center;font-size:1.2rem;color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));box-shadow:0 12px 22px rgba(0,0,0,0.4)}
-.route-suggestion-card__text{display:flex;flex-direction:column;gap:4px;min-width:0}
-.route-suggestion-card__title{margin:0;font-size:1.08rem;line-height:1.25}
-.route-suggestion-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.78)}
-.route-suggestion-card__status{display:inline-flex;align-items:center;gap:6px;margin-top:4px;padding:4px 10px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.16);font-size:.76rem;font-weight:650;color:rgba(255,255,255,0.9);letter-spacing:.06em;text-transform:uppercase}
-.route-suggestion-card__score{margin-left:auto;font-weight:700;font-size:1.1rem;color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff))}
-.route-suggestion-card__progress{display:flex;align-items:center;gap:12px}
+.route-suggestion-card__headline{display:grid;gap:6px;min-width:0}
+.route-suggestion-card__title{margin:0;font-size:1.05rem;line-height:1.3;word-break:break-word}
+.route-suggestion-card__meta{margin:0;font-size:.82rem;color:rgba(224,225,221,0.78);word-break:break-word}
+.route-suggestion-card__status{display:inline-flex;align-items:center;gap:6px;margin-top:4px;padding:4px 10px;border-radius:999px;background:rgba(0,0,0,0.35);border:1px solid rgba(255,255,255,0.16);font-size:.72rem;font-weight:650;color:rgba(255,255,255,0.9);letter-spacing:.06em;text-transform:uppercase}
+.route-suggestion-card__score{margin-left:auto;font-weight:700;font-size:1rem;color:var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff));flex:0 0 auto;padding-left:12px}
+.route-suggestion-card__progress{display:flex;align-items:center;gap:10px;margin-top:4px}
 .route-suggestion-card__progress-bar{flex:1;height:6px;border-radius:999px;background:rgba(255,255,255,0.12);overflow:hidden}
 .route-suggestion-card__progress-bar span{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--route-suggestion-accent,var(--guide-card-accent,#9bd4ff)),rgba(255,255,255,0.85));transition:width .35s ease}
-.route-suggestion-card__progress-label{font-size:.82rem;color:rgba(224,225,221,0.82)}
+.route-suggestion-card__progress-label{font-size:.78rem;color:rgba(224,225,221,0.82)}
 .route-suggestion-card__highlights{display:flex;flex-wrap:wrap;gap:8px}
-.route-suggestion-card__reason{margin:0;font-size:.85rem;color:rgba(224,225,221,0.88);line-height:1.45;min-height:0}
+.route-suggestion-card__reason{margin:0;font-size:.85rem;color:rgba(224,225,221,0.88);line-height:1.4;min-height:0;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis}
 .route-highlight{display:grid;gap:6px;justify-items:center;text-align:center;color:rgba(224,225,221,0.8);font-size:.75rem}
 .route-highlight img{width:60px;height:60px;border-radius:18px;object-fit:cover;box-shadow:0 16px 30px rgba(0,0,0,0.45);border:1px solid rgba(255,255,255,0.16)}
 .route-highlight__label{display:block;max-width:12ch;line-height:1.25}
@@ -539,6 +539,30 @@ gba(119,141,169,0.45)}
 .route-highlight--small img{width:44px;height:44px;border-radius:14px}
 .route-highlight--obtained img{filter:saturate(.5) brightness(1.05)}
 .route-suggestions__detail{position:relative;display:grid;gap:0;border-radius:24px;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(12,24,40,0.72)),rgba(8,16,32,0.9)),var(--route-suggestion-image, var(--guide-card-image, url('../assets/images/palworld-full-map-2.webp')));background-size:cover;background-position:var(--route-suggestion-position,center 42%);border:1px solid rgba(119,141,169,0.28);overflow:hidden;box-shadow:0 26px 52px rgba(0,0,0,0.5)}
+.route-preview{position:relative;display:grid;gap:clamp(18px,2.5vw,26px);padding:clamp(22px,3vw,30px);border-radius:28px;border:1px solid rgba(148,210,189,0.28);background-image:linear-gradient(160deg,var(--route-preview-overlay,rgba(12,24,40,0.86)),rgba(6,14,28,0.9)),var(--route-preview-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-preview-position,center 48%);color:var(--text,#f0f4f8);box-shadow:0 32px 64px rgba(4,16,32,0.6);overflow:hidden}
+.route-preview::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 18% -10%,rgba(148,210,189,0.28),transparent 60%);opacity:.5;pointer-events:none}
+.route-preview>*{position:relative;z-index:1}
+.route-preview__header{display:flex;align-items:flex-start;gap:18px}
+.route-preview__avatar{width:96px;height:96px;border-radius:28px;background-image:linear-gradient(180deg,rgba(0,0,0,0.08),rgba(0,0,0,0.45)),var(--route-preview-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-preview-position,center 50%);border:2px solid rgba(255,255,255,0.22);box-shadow:0 22px 44px rgba(0,0,0,0.5)}
+.route-preview__heading{display:grid;gap:10px;min-width:0}
+.route-preview__heading h3{margin:0;font-size:1.4rem;letter-spacing:.02em;text-shadow:0 2px 14px rgba(0,0,0,0.55)}
+.route-preview__heading .route-card__meta{margin-top:4px}
+.route-preview__reasons-wrap{display:grid;gap:8px}
+.route-preview__reasons-wrap h4{margin:0;font-size:1rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(224,225,221,0.76)}
+.route-preview__reasons{margin:0;padding-left:20px;display:grid;gap:6px;font-size:.92rem;color:rgba(224,225,221,0.85)}
+.route-preview__highlights{display:flex;flex-wrap:wrap;gap:10px}
+.route-preview__steps{display:grid;gap:12px}
+.route-preview__steps h4{margin:0;font-size:1.05rem;letter-spacing:.03em;text-transform:uppercase;color:rgba(224,225,221,0.78)}
+.route-preview__steps-list{margin:0;padding-left:22px;display:grid;gap:10px;font-size:.95rem;color:rgba(224,225,221,0.9)}
+.route-preview__steps-list li{list-style:decimal;list-style-position:outside}
+.route-preview__step-meta{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.route-preview__step-index{display:none}
+.route-preview__step-tag{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:rgba(8,16,32,0.68);border:1px solid rgba(255,255,255,0.16);font-size:.75rem;font-weight:650;letter-spacing:.06em;text-transform:uppercase;color:rgba(224,225,221,0.85)}
+.route-preview__step-optional{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:999px;background:rgba(255,196,77,0.16);border:1px solid rgba(255,196,77,0.32);font-size:.72rem;font-weight:650;letter-spacing:.05em;text-transform:uppercase;color:rgba(255,220,160,0.85)}
+.route-preview__step-text{margin:0;font-size:.95rem;line-height:1.5}
+.route-preview__more{list-style:none;font-size:.9rem;font-style:italic;color:rgba(224,225,221,0.75)}
+.route-preview__empty{margin:0;font-size:.95rem;color:rgba(224,225,221,0.75)}
+.route-preview__actions{display:flex;flex-wrap:wrap;gap:12px;align-items:center}
 .route-suggestion-detail__hero{position:relative;display:grid;gap:14px;padding:26px;background-image:linear-gradient(160deg,var(--route-suggestion-overlay,rgba(8,16,32,0.85)),rgba(8,16,32,0.92)),var(--route-suggestion-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:var(--route-suggestion-position,center);overflow:hidden}
 .route-suggestion-detail__hero::before{content:"";position:absolute;z-index:0;width:var(--route-suggestion-marker-size,30px);height:var(--route-suggestion-marker-size,30px);border-radius:50%;top:var(--route-suggestion-marker-top,50%);left:var(--route-suggestion-marker-left,50%);transform:translate(-50%,-50%);opacity:var(--route-suggestion-marker-opacity,0);background:radial-gradient(circle at center,var(--route-suggestion-accent,#9bd4ff)0%,var(--route-suggestion-accent,#9bd4ff)55%,rgba(0,0,0,0)70%);box-shadow:0 0 0 6px rgba(0,0,0,0.45),0 18px 34px rgba(0,0,0,0.5);pointer-events:none;transition:opacity .2s ease,transform .2s ease}
 .route-suggestion-detail__hero>*{position:relative;z-index:1}

--- a/index.html
+++ b/index.html
@@ -9904,7 +9904,8 @@
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
-    const ROUTE_LIBRARY_DEFAULT_LIMIT = 12;
+    const ROUTE_LIBRARY_DEFAULT_LIMIT = Number.POSITIVE_INFINITY;
+    const ROUTE_PREVIEW_STEP_LIMIT = 8;
     const ROUTE_THEME_ART_SOURCES = {
       generic: 'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1623730/058bd87dc17a7179e07c446aa64d0574ca43ab9d/header.jpg?t=1759163961',
       pal: 'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1623730/ss_f81b7c4f20be3b99f76a1415c4cdb9b444c99b97.1920x1080.jpg?t=1759163961',
@@ -10125,6 +10126,7 @@
       boss_requirement_alignment: 3.8
     };
     let currentRouteSuggestionEntries = [];
+    let currentRouteRecommendationEntries = [];
     let activeSuggestedRouteId = null;
     let routeSuggestionsAbort = null;
     let activeRouteIds = new Set();
@@ -12292,12 +12294,12 @@
         <button type="button" class="route-suggestion-card${active ? ' route-suggestion-card--active' : ''}" ${dataAttributes.join(' ')}>
           <div class="route-suggestion-card__media">
             <div class="route-suggestion-card__avatar" aria-hidden="true"></div>
-            ${typeLabel ? `<span class="route-suggestion-card__tag">${escapeHTML(typeLabel)}</span>` : ''}
           </div>
           <div class="route-suggestion-card__body">
-            <div class="route-suggestion-card__top">
+            <div class="route-suggestion-card__header">
               <span class="route-suggestion-card__icon"><i class="fa-solid ${escapeHTML(art.icon)}"></i></span>
-              <div class="route-suggestion-card__text">
+              <div class="route-suggestion-card__headline">
+                ${typeLabel ? `<span class="route-suggestion-card__tag">${escapeHTML(typeLabel)}</span>` : ''}
                 <h4 class="route-suggestion-card__title">${escapeHTML(route.title)}</h4>
                 ${metaLine ? `<p class="route-suggestion-card__meta">${escapeHTML(metaLine)}</p>` : ''}
                 ${queued ? `<span class="route-suggestion-card__status">${escapeHTML(kidMode ? 'In your queue' : 'In queue')}</span>` : ''}
@@ -13514,6 +13516,7 @@
       if(!pool.length){
         list.innerHTML = `<p class="route-recommendations__empty">${escapeHTML(kidMode ? 'Add goals or mark progress to unlock fresh adventures.' : 'Adjust your goals or progress to unlock new recommendations.')}</p>`;
         updateRouteRecommendationBackdrop([]);
+        currentRouteRecommendationEntries = [];
       } else {
         const suggestionIds = new Set(
           Array.isArray(currentRouteSuggestionEntries)
@@ -13531,6 +13534,7 @@
         }
         const visible = extras.slice(0, 5);
         list.innerHTML = visible.map(renderRouteRecommendation).join('');
+        currentRouteRecommendationEntries = visible.map(entry => ({ ...entry }));
         updateRouteRecommendationBackdrop(visible);
       }
       if(routeRecommendationsAbort){
@@ -13539,6 +13543,17 @@
       routeRecommendationsAbort = new AbortController();
       const { signal } = routeRecommendationsAbort;
       list.addEventListener('click', event => {
+        const previewBtn = event.target.closest('[data-route-preview]');
+        if(previewBtn){
+          const routeId = previewBtn.dataset.routePreview;
+          if(routeId){
+            const entry = currentRouteRecommendationEntries.find(item => item && item.route && item.route.id === routeId);
+            const stepId = previewBtn.dataset.routeStep;
+            openRoutePreviewById(routeId, { entry, stepId });
+          }
+          event.preventDefault();
+          return;
+        }
         const btn = event.target.closest('[data-route-focus]');
         if(!btn) return;
         const routeId = btn.dataset.routeFocus;
@@ -13577,11 +13592,14 @@
         ? `<ul class="route-recommendation__reasons">${entry.reasons.map(reason => `<li>${escapeHTML(reason)}</li>`).join('')}</ul>`
         : `<p class="route-recommendation__fallback">${escapeHTML(kidMode ? 'Palmate picked this route for balanced fun and progress.' : 'Palmate selected this route based on your context.')}</p>`;
       const focusStep = entry.nextStepId || route?.chapter?.steps?.[0]?.id || '';
+      const stepAttr = focusStep ? ` data-route-step="${escapeHTML(focusStep)}"` : '';
       const roleLabel = routePlaystyleLabel(route);
       const attributes = [`data-route-id="${escapeHTML(route.id)}"`];
       if(styleAttr){
         attributes.push(styleAttr);
       }
+      const previewLabel = kidMode ? 'Show steps' : 'Show steps';
+      const plannerLabel = kidMode ? 'Open planner' : 'Open in planner';
       return `
         <article class="guide-card route-recommendation" ${attributes.join(' ')}>
           <div class="guide-card__header">
@@ -13599,11 +13617,113 @@
           <div class="guide-card__footer">
             ${tags}
             <div class="guide-card__actions">
-              <button type="button" class="btn" data-route-focus="${escapeHTML(route.id)}" data-route-step="${escapeHTML(focusStep)}">${escapeHTML(kidMode ? 'View steps' : 'Open route')}</button>
+              <button type="button" class="btn" data-route-preview="${escapeHTML(route.id)}"${stepAttr}>${escapeHTML(previewLabel)}</button>
+              <button type="button" class="btn btn--ghost" data-route-focus="${escapeHTML(route.id)}"${stepAttr}>${escapeHTML(plannerLabel)}</button>
             </div>
           </div>
         </article>
       `;
+    }
+
+    function openRoutePreviewById(routeId, { entry = null, stepId } = {}){
+      if(!routeId) return;
+      const route = routeGuideData?.routeLookup?.[routeId];
+      if(!route) return;
+      openRoutePreviewModal(route, { entry, stepId });
+    }
+
+    function buildRoutePreviewSteps(chapter, { limit = ROUTE_PREVIEW_STEP_LIMIT } = {}){
+      if(!chapter) return '';
+      const steps = Array.isArray(chapter.steps) ? chapter.steps : [];
+      if(!steps.length){
+        return `<p class="route-preview__empty">${escapeHTML(kidMode ? 'Step list coming soon.' : 'Step list coming soon.')}</p>`;
+      }
+      const bounded = limit > 0 ? steps.slice(0, limit) : steps.slice();
+      const items = bounded.map((step, index) => {
+        const text = routeStepText(step) || cleanGuideText(step?.raw?.summary || step?.raw?.detail || '') || `Step ${index + 1}`;
+        const category = step.category ? escapeHTML(step.category) : escapeHTML(kidMode ? 'Step' : 'Step');
+        const optional = step.optional ? `<span class="route-preview__step-optional">${escapeHTML(kidMode ? 'Bonus' : 'Optional')}</span>` : '';
+        return `
+          <li>
+            <div class="route-preview__step-meta">
+              <span class="route-preview__step-index">${index + 1}</span>
+              <span class="route-preview__step-tag">${category}</span>
+              ${optional}
+            </div>
+            <p class="route-preview__step-text">${escapeHTML(text)}</p>
+          </li>
+        `;
+      }).join('');
+      const remainder = steps.length - bounded.length;
+      const more = remainder > 0
+        ? `<li class="route-preview__more">${escapeHTML(kidMode ? `+${remainder} more step${remainder === 1 ? '' : 's'}` : `+${remainder} additional step${remainder === 1 ? '' : 's'}`)}</li>`
+        : '';
+      return `<ol class="route-preview__steps-list">${items}${more}</ol>`;
+    }
+
+    function openRoutePreviewModal(route, { entry = null, stepId } = {}){
+      if(!route) return;
+      const chapter = route?.chapter;
+      if(!chapter) return;
+      const art = routeArtFor(route);
+      const reasons = Array.isArray(entry?.reasons) ? entry.reasons.filter(Boolean) : [];
+      const reasonsHtml = reasons.length
+        ? `<div class="route-preview__reasons-wrap"><h4>${escapeHTML(kidMode ? 'Why try it' : 'Why this route')}</h4><ul class="route-preview__reasons">${reasons.map(reason => `<li>${escapeHTML(reason)}</li>`).join('')}</ul></div>`
+        : '';
+      const highlights = routeHighlightMedia(route, { limit: 4 });
+      const highlightsHtml = highlights.length
+        ? `<div class="route-preview__highlights">${highlights.map(item => renderRouteHighlight(item, { showLabel: true, size: 'small' })).join('')}</div>`
+        : '';
+      const stepList = buildRoutePreviewSteps(chapter);
+      const meta = renderRouteMeta(route);
+      const targetStep = stepId
+        || entry?.nextStepId
+        || (findFirstIncompleteStepForRoute(route, { includeOptional: true })?.id || '')
+        || (chapter.steps && chapter.steps[0] ? chapter.steps[0].id : '');
+      const previewMarkup = `
+        <article class="route-preview" style="--route-preview-image: url('${sanitizeImageUrl(art.image)}'); --route-preview-overlay: ${art.overlay}; --route-preview-accent: ${art.accent}; --route-preview-position: ${art.position};">
+          <header class="route-preview__header">
+            <div class="route-preview__avatar" aria-hidden="true"></div>
+            <div class="route-preview__heading">
+              <h3>${escapeHTML(route.title)}</h3>
+              ${meta || ''}
+              ${reasonsHtml}
+            </div>
+          </header>
+          ${highlightsHtml}
+          <div class="route-preview__steps">
+            <h4>${escapeHTML(kidMode ? 'Step preview' : 'Step preview')}</h4>
+            ${stepList}
+          </div>
+          <footer class="route-preview__actions">
+            <button type="button" class="btn" data-preview-focus="${escapeHTML(route.id)}" data-preview-step="${escapeHTML(targetStep || '')}">${escapeHTML(kidMode ? 'Open in planner' : 'Open in planner')}</button>
+            <button type="button" class="btn btn--ghost" data-preview-activate="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Add to queue' : 'Add to active')}</button>
+          </footer>
+        </article>
+      `;
+      modalBody.innerHTML = previewMarkup;
+      openModal();
+      const focusBtn = modalBody.querySelector('[data-preview-focus]');
+      if(focusBtn){
+        focusBtn.addEventListener('click', () => {
+          const focusStepId = focusBtn.dataset.previewStep;
+          if(focusStepId){
+            queueRouteFocus(focusStepId);
+          }
+          switchPage('route');
+          closeModal();
+          playSound(clickSound);
+        });
+      }
+      const activateBtn = modalBody.querySelector('[data-preview-activate]');
+      if(activateBtn){
+        activateBtn.addEventListener('click', () => {
+          addActiveRoute(route.id);
+          activateBtn.disabled = true;
+          activateBtn.textContent = kidMode ? 'Added to queue' : 'Added to active';
+          playSound(clickSound);
+        });
+      }
     }
 
     let routeContextControlAbort = null;


### PR DESCRIPTION
## Summary
- tighten the Tonight’s Adventure Paths layout so long quest labels wrap cleanly and metadata stays readable
- add a modal route preview for “More adventures to consider” entries so the Show steps button reveals guide details
- lift the Browse every guide cap so the drawer lists the entire catalog of guides

## Testing
- None

------
https://chatgpt.com/codex/tasks/task_e_68dd82798f748331b2d528f918e861ab