### PR TITLE
Restore guide catalog fallback support

### DIFF
--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -9660,7 +9660,6004 @@
       "instruction",
       "citations"
     ],
-    "source": "palworld_complete_guide.md"
+    "source": "palworld_complete_guide.md",
+    "data": {
+      "guides": [
+        {
+          "id": "activate-great-eagle-statues",
+          "title": "Activate Great Eagle Statues",
+          "source_heading": "Activate Great Eagle Statues",
+          "category": "Missions",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player asks about fast-travel or Great Eagle statues",
+          "keywords": [
+            "fast travel",
+            "eagle statue",
+            "teleport"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Locate a Great Eagle Statue** in the region you\u2019re exploring.  These large statues emit a faint glow.",
+              "citations": [
+                "354485449518951\u2020L124-L131"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "**Interact with the statue** (press the interact key) to activate it.  Your character will touch the statue.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Once activated, **open your fast-travel map** and select any previously activated statue to teleport.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "first-gathering-run",
+          "title": "First Gathering Run",
+          "source_heading": "First Gathering Run",
+          "category": "Missions",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "New players learning how to gather basic materials",
+          "keywords": [
+            "early game",
+            "gather wood",
+            "branches"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Explore the starting area and **collect fallen branches or strike trees** to gather wood.",
+              "citations": [
+                "354485449518951\u2020L166-L169"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Pick up **stones and fiber** from the ground; these materials are needed for early tools.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Keep gathering until you have enough wood to craft your first **axe and pickaxe**.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "build-a-workbench",
+          "title": "Build a Workbench",
+          "source_heading": "Build a Workbench",
+          "category": "Missions",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players need to craft more complex items",
+          "keywords": [
+            "workbench",
+            "crafting bench",
+            "base setup"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Open the build menu** and select the basic workbench.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Place the workbench** near your Palbox or base location.",
+              "citations": [
+                "354485449518951\u2020L188-L191"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Gather the required materials (wood and stone) and **confirm construction**.  Use the bench to craft weapons and tools.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "unlock-technology",
+          "title": "Unlock Technology",
+          "source_heading": "Unlock Technology",
+          "category": "Missions",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player wants to access the technology tree",
+          "keywords": [
+            "tech tree",
+            "unlock tech"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Open the technology tree** from the menu.",
+              "citations": [
+                "354485449518951\u2020L207-L209"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Spend your accumulated **technology points** to unlock a new item or structure (e.g., Palbox or Pal Sphere blueprint).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Confirm the unlock**, then gather resources to craft the newly unlocked item.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "find-paldium-craft-pal-spheres",
+          "title": "Find Paldium & Craft Pal Spheres",
+          "source_heading": "Find Paldium & Craft Pal Spheres",
+          "category": "Resources",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players ask about obtaining Paldium fragments or making capture devices",
+          "keywords": [
+            "Paldium",
+            "capture device",
+            "Pal sphere"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Search near riversides and wetlands** for glowing blue rocks (Paldium nodes).",
+              "citations": [
+                "354485449518951\u2020L225-L231"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "**Mine Paldium fragments** with a pickaxe until you have enough pieces.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Combine Paldium fragments with wood and stone** at a workbench to craft Pal Spheres.",
+              "citations": [
+                "354485449518951\u2020L224-L252"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "catch-your-first-pal",
+          "title": "Catch Your First Pal",
+          "source_heading": "Catch Your First Pal",
+          "category": "Capturing",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Triggered when players ask how to catch a Pal or about Pal spheres",
+          "keywords": [
+            "capture Pal",
+            "first Pal"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Craft several Pal Spheres** using the method above.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Weaken a wild Pal** by reducing its HP with non-fatal attacks.",
+              "citations": [
+                "354485449518951\u2020L272-L274"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Aim and **throw a Pal Sphere** at the weakened Pal.  Repeat until capture is successful.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "build-a-palbox",
+          "title": "Build a Palbox",
+          "source_heading": "Build a Palbox",
+          "category": "Base Building",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player asks about storing or healing Pals",
+          "keywords": [
+            "Palbox",
+            "storage",
+            "healing"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Unlock the Palbox technology** in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather resources (Paldium fragments, wood, stone) and **build the Palbox**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Place the Palbox** at your base.  It can heal injured Pals and store extras.",
+              "citations": [
+                "354485449518951\u2020L288-L296"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "establish-a-starting-base",
+          "title": "Establish a Starting Base",
+          "source_heading": "Establish a Starting Base",
+          "category": "Base Building",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players want tips on their first base location",
+          "keywords": [
+            "first base",
+            "starting base",
+            "base location"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Choose an open area** near resources or at a recommended location.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Place your Palbox** to claim the base and unlock construction options.",
+              "citations": [
+                "354485449518951\u2020L310-L314"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Build essential structures: **workbench, campfire, storage** and assign Pals to work.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "assign-pals-to-work",
+          "title": "Assign Pals to Work",
+          "source_heading": "Assign Pals to Work",
+          "category": "Base Management",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player wants to automate tasks or assign Pals",
+          "keywords": [
+            "assign Pals",
+            "base work",
+            "management"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Open the base management menu** via the Palbox.",
+              "citations": [
+                "354485449518951\u2020L329-L332"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Select a Pal with relevant work suitability (e.g., transport, kindling) and **assign it to a task**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Ensure Pals have access to required stations (e.g., furnace, farm) and monitor their SAN to avoid overwork.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "gathering-food-red-berries",
+          "title": "Gathering Food & Red Berries",
+          "source_heading": "Gathering Food & Red Berries",
+          "category": "Resources",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players ask how to feed themselves or Pals",
+          "keywords": [
+            "food",
+            "hunger",
+            "red berries"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Search for bushes** bearing red berries in the starting area.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Harvest berries** by pressing the interact key.",
+              "citations": [
+                "354485449518951\u2020L347-L349"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Consume berries from your inventory to restore hunger or feed them to Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "craft-protective-clothing",
+          "title": "Craft Protective Clothing",
+          "source_heading": "Craft Protective Clothing",
+          "category": "Crafting",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player encounters extreme weather (cold/heat)",
+          "keywords": [
+            "clothing",
+            "cold resistant",
+            "armor"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Unlock the Cold-Resistant or Heat-Resistant armor** technology in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Collect materials** such as fiber, wool and leather from Pals or plants.",
+              "citations": [
+                "354485449518951\u2020L367-L370"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Craft the armor at your workbench and **equip it** before entering extreme climates.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "increase-character-stats",
+          "title": "Increase Character Stats",
+          "source_heading": "Increase Character Stats",
+          "category": "Mechanics",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players inquire about leveling up or improving stats",
+          "keywords": [
+            "level up",
+            "enhance stats"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Gain experience** by completing missions, defeating enemies and gathering resources.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "When you level up, open your **inventory/stats screen**.",
+              "citations": [
+                "354485449518951\u2020L382-L386"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Allocate the available stat points to Health, Stamina, Weight or other desired attributes.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "build-the-capturing-device",
+          "title": "Build the Capturing Device",
+          "source_heading": "Build the Capturing Device",
+          "category": "Crafting",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Questions about crafting Pal spheres",
+          "keywords": [
+            "Pal spheres",
+            "crafting device"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the **Capturing Device** (Pal Sphere) blueprint from the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Collect Paldium fragments, wood and stones**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use the workbench to **craft Pal Spheres** for capturing Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "put-pals-to-work",
+          "title": "Put Pals to Work",
+          "source_heading": "Put Pals to Work",
+          "category": "Base Management",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Triggered when players need to understand base automation",
+          "keywords": [
+            "base work",
+            "assignments"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Assign a Pal** to the base using the management menu.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Place the Pal near the desired production structure (e.g., farm, furnace).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Monitor the Pal\u2019s SAN and efficiency**; provide food and rest as needed.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "stay-alive-survival-options",
+          "title": "Stay Alive & Survival Options",
+          "source_heading": "Stay Alive & Survival Options",
+          "category": "Survival",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "Player asks about survival basics",
+          "keywords": [
+            "survival tips",
+            "health",
+            "hunger"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Keep your hunger bar filled** by eating berries, cooked meat or dishes.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Wear weather-appropriate armor** to avoid cold or heat damage.",
+              "citations": [
+                "354485449518951\u2020L367-L370"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Carry recovery items (medicine) and avoid dangerous regions until stronger.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "first-combat-tips",
+          "title": "First Combat Tips",
+          "source_heading": "First Combat Tips",
+          "category": "Combat",
+          "category_group": "Getting Started & Core Missions",
+          "trigger": "When players ask how to fight or defend early on",
+          "keywords": [
+            "combat basics",
+            "fighting"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Lock onto enemies** and learn their attack patterns.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Dodge roll** to avoid incoming attacks and strike when the enemy is vulnerable.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use your Pal\u2019s partner skill and **swap Pals** to exploit elemental weaknesses.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "choosing-a-base-location-plateau-of-beginnings",
+          "title": "Choosing a Base Location (Plateau of Beginnings)",
+          "source_heading": "Choosing a Base Location (Plateau of Beginnings)",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks about ideal base sites in early game",
+          "keywords": [
+            "base location",
+            "plateau of beginnings"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to coordinates **(264, -548)** on the southern coast.",
+              "citations": [
+                "633260338298658\u2020L112-L118"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "**Clear the area** of enemies and resources.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Place your **Palbox** and start constructing structures to take advantage of nearby Paldium nodes.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-location-small-settlement",
+          "title": "Base Location: Small Settlement",
+          "source_heading": "Base Location: Small Settlement",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Player looking for abundant ore & wood",
+          "keywords": [
+            "base location",
+            "small settlement"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Fast-travel to **Small Settlement** coordinates (8, -528).",
+              "citations": [
+                "633260338298658\u2020L120-L126"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "**Collect ore and wood** from abundant nodes around the site.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Set up your base near the fast-travel point for convenience.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-location-cinnamoth-forest",
+          "title": "Base Location: Cinnamoth Forest",
+          "source_heading": "Base Location: Cinnamoth Forest",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Mid-game players seeking ore and sulfur",
+          "keywords": [
+            "base location",
+            "Cinnamoth forest"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Journey to **-77, -310** and head south into Cinnamoth Forest.",
+              "citations": [
+                "633260338298658\u2020L128-L134"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Build your base there to take advantage of large ore nodes and nearby sulfur for gunpowder.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Protect the base from mid-game enemies.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-location-sealed-realm-of-the-guardian",
+          "title": "Base Location: Sealed Realm of the Guardian",
+          "source_heading": "Base Location: Sealed Realm of the Guardian",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "When players need coal for tech upgrades",
+          "keywords": [
+            "base location",
+            "coal farming"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to **180, -39**.",
+              "citations": [
+                "633260338298658\u2020L136-L141"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Mine **coal** nodes around the Sealed Realm for tech progression.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Construct your base with an emphasis on processing coal into refined materials.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-location-sakurajima-island",
+          "title": "Base Location: Sakurajima Island",
+          "source_heading": "Base Location: Sakurajima Island",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Late-game players farming crude oil",
+          "keywords": [
+            "base location",
+            "crude oil"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Reach **-646, 270** on Sakurajima Island.",
+              "citations": [
+                "633260338298658\u2020L143-L149"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Establish a base to farm **crude oil** and craft fuels for advanced weaponry.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defend against strong late-game enemies and environmental hazards.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "setting-up-your-first-base",
+          "title": "Setting Up Your First Base",
+          "source_heading": "Setting Up Your First Base",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks how to place Palbox and structures",
+          "keywords": [
+            "base setup",
+            "Palbox"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Place your Palbox** in a flat area to define the base.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Build basic structures**: campfire, workbench, bed, storage chest.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Surround the base with fences or walls for safety.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "upgrading-base-level",
+          "title": "Upgrading Base Level",
+          "source_heading": "Upgrading Base Level",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Triggered when players ask about increasing base size",
+          "keywords": [
+            "base level",
+            "upgrade"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Complete **base missions**, such as increasing build points or crafting specific items.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Accumulate enough **structures, furniture and decorations** to reach the build point requirement.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Interact with the Palbox** to upgrade the base level and unlock more structures.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-layout-design-ideas",
+          "title": "Base Layout & Design Ideas",
+          "source_heading": "Base Layout & Design Ideas",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Player wants inspiration for efficient or aesthetic bases",
+          "keywords": [
+            "base design",
+            "layout"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Plan distinct zones** for crafting, storage, Pals and farming.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use vertical space by adding **floors or platforms**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Connect work stations with **pathways and fences** to improve Pal efficiency.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "defensive-structures-fortifications",
+          "title": "Defensive Structures & Fortifications",
+          "source_heading": "Defensive Structures & Fortifications",
+          "category": "Base Building",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks how to defend against raids",
+          "keywords": [
+            "defenses",
+            "walls",
+            "turret"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock and craft **walls, gates and guard towers**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Place **turrets** or traps at chokepoints to deter raiders.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Ensure your Pals are assigned to guard duty when expecting raids.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "managing-base-sanity-pal-morale",
+          "title": "Managing Base Sanity & Pal Morale",
+          "source_heading": "Managing Base Sanity & Pal Morale",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Questions about Pal sanity or overwork",
+          "keywords": [
+            "SAN",
+            "morale",
+            "rest"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Monitor each Pal\u2019s **SAN meter**; high workloads reduce morale.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Provide beds and rest time** for Pals to recover SAN.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Offer varied tasks and feeding to prevent mental breakdowns.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "assigning-work-pals-transport-kindling",
+          "title": "Assigning Work Pals (Transport, Kindling)",
+          "source_heading": "Assigning Work Pals (Transport, Kindling)",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Player wants best Pals for tasks like carrying or kindling",
+          "keywords": [
+            "work Pals",
+            "transport",
+            "kindling"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Pals with **Transporting** or **Kindling** suitability (e.g., Wumpo, Jormuntide Ignis).",
+              "citations": [
+                "633260338298658\u2020L161-L166"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "**Assign them to storage chests or campfires** to haul items or light furnaces.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Monitor their work and replace them if SAN drops too low.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "assigning-work-pals-handiwork-mining",
+          "title": "Assigning Work Pals (Handiwork, Mining)",
+          "source_heading": "Assigning Work Pals (Handiwork, Mining)",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks about craft or mining Pals",
+          "keywords": [
+            "handiwork",
+            "mining"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Obtain Pals like **Anubis** or **Astegon** for handiwork/mining.",
+              "citations": [
+                "633260338298658\u2020L166-L172"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to crafting benches or mining nodes at your base.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Provide appropriate gear (e.g., gloves, pickaxes) if available.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "assigning-work-pals-watering-lumbering",
+          "title": "Assigning Work Pals (Watering, Lumbering)",
+          "source_heading": "Assigning Work Pals (Watering, Lumbering)",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Players need watering or wood-cutting Pals",
+          "keywords": [
+            "watering",
+            "lumbering"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Pals such as **Jormuntide**, **Broncherry Aqua** or **Wumpo Botan** for watering or lumbering.",
+              "citations": [
+                "633260338298658\u2020L161-L169"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to crop plots or logging sites.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Ensure water access by building wells or placing water tanks.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "assigning-work-pals-medicine-planting",
+          "title": "Assigning Work Pals (Medicine & Planting)",
+          "source_heading": "Assigning Work Pals (Medicine & Planting)",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks about medicine or planting tasks",
+          "keywords": [
+            "medicine production",
+            "planting"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use Pals with **Medicine Production** or **Planting** suitability (e.g., **Bellanoir**, **Lyleen**).",
+              "citations": [
+                "633260338298658\u2020L174-L177"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to medicine benches or farm plots.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Gather ingredients (herbs, berries) for medicine production.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "automating-resource-production-lines",
+          "title": "Automating Resource Production Lines",
+          "source_heading": "Automating Resource Production Lines",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "When players ask about continuous production",
+          "keywords": [
+            "automation",
+            "production lines"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Place conveyor belts** or item transfer stations if available (future updates may add automation).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Assign Pals to pick up produced items and deposit them into storage.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Monitor output to ensure the line does not clog or overflow.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "using-power-generators-batteries",
+          "title": "Using Power Generators & Batteries",
+          "source_heading": "Using Power Generators & Batteries",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Players wonder how to generate electricity",
+          "keywords": [
+            "electricity",
+            "generator"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock generator technology (wind, coal or electric).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Build generators** and connect them to machines that require power.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft **batteries** to store excess electricity and place them near production stations.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "managing-farming-plots-gardens",
+          "title": "Managing Farming Plots & Gardens",
+          "source_heading": "Managing Farming Plots & Gardens",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Player asks about growing crops",
+          "keywords": [
+            "farming",
+            "gardens"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Build **farm plots** on fertile ground.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Plant seeds such as berries, wheat or medicinal herbs.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Assign watering Pals to maintain soil moisture and harvest when ready.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "handling-weather-environmental-hazards",
+          "title": "Handling Weather & Environmental Hazards",
+          "source_heading": "Handling Weather & Environmental Hazards",
+          "category": "Survival",
+          "category_group": "Base Building & Management",
+          "trigger": "Questions about storms, heat, cold at base",
+          "keywords": [
+            "weather",
+            "hazards"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Equip appropriate clothing** for cold or hot biomes.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Provide **heaters or coolers** within your base for Pals.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Relocate your base or avoid extreme areas during harsh weather.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "palbase-upkeep-repairs",
+          "title": "Palbase Upkeep & Repairs",
+          "source_heading": "Palbase Upkeep & Repairs",
+          "category": "Base Management",
+          "category_group": "Base Building & Management",
+          "trigger": "Triggered when structures are damaged",
+          "keywords": [
+            "repairs",
+            "maintenance"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Regularly inspect structures for **damage or decay**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use a hammer or repair tool to **fix damaged walls and structures**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Rebuild destroyed items promptly to maintain base efficiency.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "gathering-wood-stone",
+          "title": "Gathering Wood & Stone",
+          "source_heading": "Gathering Wood & Stone",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player asks about collecting basic building materials",
+          "keywords": [
+            "wood",
+            "stone",
+            "gathering"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Craft a **stone axe** and **pickaxe** using wood and stone.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Chop down trees to gather wood; mine boulders for stone.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Store gathered resources in chests for later use.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "mining-ore-coal",
+          "title": "Mining Ore & Coal",
+          "source_heading": "Mining Ore & Coal",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "When players need ore for crafting or coal for tech",
+          "keywords": [
+            "ore",
+            "coal mining"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Locate **ore deposits** (grey rocks with metallic veins).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use a pickaxe to mine ore until nodes deplete.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Travel to coal-rich regions (e.g., Sealed Realm) and mine coal for advanced tech.",
+              "citations": [
+                "633260338298658\u2020L136-L141"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "harvesting-sulfur",
+          "title": "Harvesting Sulfur",
+          "source_heading": "Harvesting Sulfur",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player seeks sulfur for gunpowder",
+          "keywords": [
+            "sulfur",
+            "explosive materials"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Find sulfur deposits near volcanoes or **Cinnamoth Forest**.",
+              "citations": [
+                "633260338298658\u2020L128-L134"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Mine sulfur with a pickaxe.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use sulfur to craft gunpowder and explosives.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "farming-crude-oil-dog-coins",
+          "title": "Farming Crude Oil & Dog Coins",
+          "source_heading": "Farming Crude Oil & Dog Coins",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Triggered by questions about late-game fuel or currency",
+          "keywords": [
+            "crude oil",
+            "dog coins"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to **Sakurajima Island** to find crude oil nodes.",
+              "citations": [
+                "633260338298658\u2020L143-L149"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Mine crude oil using specialized equipment (oil extractor) and refine it into fuel.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat enemies or participate in events to earn **Dog Coins**, then farm additional coins by completing Dog Coin challenges.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "collecting-fiber-cloth",
+          "title": "Collecting Fiber & Cloth",
+          "source_heading": "Collecting Fiber & Cloth",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Players need cloth for clothing",
+          "keywords": [
+            "fiber",
+            "cloth"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gather **plant fibers** from bushes or grasses using a sickle.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Craft cloth at a loom or workbench by combining fibers.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use cloth for clothing and furniture.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "gathering-paldium-fragments",
+          "title": "Gathering Paldium Fragments",
+          "source_heading": "Gathering Paldium Fragments",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player asks how to get Paldium for spheres",
+          "keywords": [
+            "Paldium",
+            "pal spheres"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Search near water for glowing blue rocks (Paldium).",
+              "citations": [
+                "354485449518951\u2020L225-L231"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Mine them with a pickaxe to collect fragments.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Combine with wood and stone to craft Pal spheres.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "hunting-for-leather-wool",
+          "title": "Hunting for Leather & Wool",
+          "source_heading": "Hunting for Leather & Wool",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "When players need hides for armor or gear",
+          "keywords": [
+            "leather",
+            "wool",
+            "fur"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Hunt fluffy Pals (e.g., Lamball) for **wool and leather**.",
+              "citations": [
+                "354485449518951\u2020L367-L370"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Use a skinning knife or harvesting tool after defeating the Pal.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Process materials at a tanning rack or loom for use in armor.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "fishing-catching-water-pals",
+          "title": "Fishing & Catching Water Pals",
+          "source_heading": "Fishing & Catching Water Pals",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Questions about fishing mechanics or aquatic Pals",
+          "keywords": [
+            "fishing",
+            "water Pals"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Craft a **fishing rod** or net once unlocked.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Locate water bodies and cast your line.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Reel in fish or aquatic Pals; watch for splashes indicating a catch.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "farming-red-berries-crops",
+          "title": "Farming Red Berries & Crops",
+          "source_heading": "Farming Red Berries & Crops",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player wants to plant food or feed Pals",
+          "keywords": [
+            "farming",
+            "crops"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Till soil using a hoe and place farm plots.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Plant red berry seeds or other crop seeds.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Assign watering Pals to maintain the crops until harvest.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "mining-chromite-precious-metals",
+          "title": "Mining Chromite & Precious Metals",
+          "source_heading": "Mining Chromite & Precious Metals",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "When players need rare metals for late-game gear",
+          "keywords": [
+            "chromite",
+            "precious metals"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to late-game regions with chromite deposits (e.g., Astral Mountains).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Mine deposits with an upgraded pickaxe.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use chromite for high-level gear and technology.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "farming-life-fruit-skill-fruits",
+          "title": "Farming Life Fruit & Skill Fruits",
+          "source_heading": "Farming Life Fruit & Skill Fruits",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player asks about healing items or skill fruit",
+          "keywords": [
+            "life fruit",
+            "skill fruit"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Search dungeons and chests for **Life Fruits** and **Skill Fruits**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Harvest them from special plants in rare biomes.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use Life Fruit to heal and Skill Fruit to teach Pals new abilities.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "harvesting-nightstar-sand",
+          "title": "Harvesting Nightstar Sand",
+          "source_heading": "Harvesting Nightstar Sand",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Questions about special glowing sand for crafting",
+          "keywords": [
+            "nightstar sand",
+            "glowing sand"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Visit desert regions at night when **Nightstar Sand** glows.",
+              "citations": [
+                "92541297987896\u2020L117-L118"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Scoop up sand from sparkling patches.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use it for crafting luminous items or decorations.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "locating-meteorite-supply-drops",
+          "title": "Locating Meteorite & Supply Drops",
+          "source_heading": "Locating Meteorite & Supply Drops",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player wants to find rare drops from events",
+          "keywords": [
+            "meteorite",
+            "supply drop"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Watch the sky for streaking meteorites or airborne supply crates.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Head to the marked landing spot quickly; meteorites contain rare ores and supply drops hold valuable items.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Fight off enemies attracted to the drop and collect the loot.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "collecting-eggs-incubation",
+          "title": "Collecting Eggs & Incubation",
+          "source_heading": "Collecting Eggs & Incubation",
+          "category": "Breeding",
+          "category_group": "Resources & Crafting",
+          "trigger": "When players ask about finding eggs and hatching",
+          "keywords": [
+            "eggs",
+            "incubator"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Find eggs** in nests, dungeons or by defeating Alpha Pals.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Place eggs in an **incubator** (or Electric Incubator for faster hatching).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Wait for the required time; monitor temperature to ensure proper incubation.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "refreshing-vendor-stock",
+          "title": "Refreshing Vendor Stock",
+          "source_heading": "Refreshing Vendor Stock",
+          "category": "Economy",
+          "category_group": "Resources & Crafting",
+          "trigger": "Player asks how to refresh merchant inventory",
+          "keywords": [
+            "vendor stock",
+            "merchants"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Visit a Pal Merchant or Black Marketeer.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Purchase items or sell loot.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**Leave the area**, wait for a short period, and return to refresh their stock (may also refresh after daily resets).",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "selling-trading-items",
+          "title": "Selling & Trading Items",
+          "source_heading": "Selling & Trading Items",
+          "category": "Economy",
+          "category_group": "Resources & Crafting",
+          "trigger": "Players want to trade items or Pals for gold",
+          "keywords": [
+            "trade",
+            "sell",
+            "economy"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Collect valuable items (ores, crafted gear, rare drops).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Visit merchants or interact with other players in multiplayer.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Offer items for sale or trade in exchange for gold or other goods.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "unlocking-the-technology-tree",
+          "title": "Unlocking the Technology Tree",
+          "source_heading": "Unlocking the Technology Tree",
+          "category": "Technology",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player asks how to spend technology points",
+          "keywords": [
+            "tech tree",
+            "unlock technology"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gain **technology points** by leveling up and completing missions.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Open the **technology menu**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Spend points to unlock desired items; ensure you meet any level requirements.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-pal-gear-saddles",
+          "title": "Crafting Pal Gear & Saddles",
+          "source_heading": "Crafting Pal Gear & Saddles",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players need gear specific to each Pal",
+          "keywords": [
+            "pal gear",
+            "saddles"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the specific **Pal gear** (e.g., Jetragon saddle) in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect required materials (leather, ingots, cloth).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft the gear at a **Pal gear station** and equip your Pal to use it.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-weapons-crossbows-bows-guns",
+          "title": "Crafting Weapons: Crossbows, Bows & Guns",
+          "source_heading": "Crafting Weapons: Crossbows, Bows & Guns",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player asks about available weapons and recipes",
+          "keywords": [
+            "guns",
+            "bows",
+            "crossbows"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the appropriate weapon blueprint.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect materials (wood, ingots, sulfur, polymer).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft the weapon at a workbench or weapon station and equip it.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-heavy-weapons-rocket-launcher-minigun",
+          "title": "Crafting Heavy Weapons: Rocket Launcher, Minigun",
+          "source_heading": "Crafting Heavy Weapons: Rocket Launcher, Minigun",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players want high-damage weapons",
+          "keywords": [
+            "rocket launcher",
+            "minigun"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Reach the required tech level and unlock the heavy weapon blueprint.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather advanced materials (refined metal, high-quality oil, electronics).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft at an advanced weapon bench and stock up on ammunition.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "building-a-glider-upgrades",
+          "title": "Building a Glider & Upgrades",
+          "source_heading": "Building a Glider & Upgrades",
+          "category": "Technology",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player wants to glide or travel faster",
+          "keywords": [
+            "glider",
+            "travel"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock glider technology in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect cloth, leather and Paldium.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft the glider at a workbench and equip it; upgrade with better materials for improved flight.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-lockpicking-tools-v1-v3",
+          "title": "Crafting Lockpicking Tools (v1-v3)",
+          "source_heading": "Crafting Lockpicking Tools (v1-v3)",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player needs to open locked chests",
+          "keywords": [
+            "lockpicking tool",
+            "chest"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the **Lockpicking tool** technology (requires progression in Sakurajima update).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather Pal Metal Ingots, Paldium Fragments and Nails.",
+              "citations": [
+                "285876925291367\u2020L189-L203"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Craft the tool at a workbench; use it to open locked treasure chests.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "creating-armor-cold-heat-resistant-refinement",
+          "title": "Creating Armor: Cold/Heat-Resistant, Refinement",
+          "source_heading": "Creating Armor: Cold/Heat-Resistant & Refinement",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Questions about protective armor sets",
+          "keywords": [
+            "armor",
+            "cold resistant",
+            "heat resistant"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the desired armor blueprint.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect hide, fur, cloth and metal plates.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft at the armor workbench and equip before entering extreme environments.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "making-accessory-slots-accessories",
+          "title": "Making Accessory Slots & Accessories",
+          "source_heading": "Making Accessory Slots & Accessories",
+          "category": "Technology",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player wants extra accessory slots or rings",
+          "keywords": [
+            "accessories",
+            "slots"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock accessory slot upgrades via technology.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Craft the **slot expansion** using metals and Paldium.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft rings or trinkets and equip them to benefit from extra bonuses.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "building-explosives-bombs-grenades",
+          "title": "Building Explosives: Bombs & Grenades",
+          "source_heading": "Building Explosives: Bombs & Grenades",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players ask about demolitions or combat bombs",
+          "keywords": [
+            "explosives",
+            "grenades"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock explosive weapons in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather sulfur, charcoal (for gunpowder) and metal casings.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft bombs at the workbench; equip them to use in combat or mining.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-medicine-recovery-items",
+          "title": "Crafting Medicine & Recovery Items",
+          "source_heading": "Crafting Medicine & Recovery Items",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player asks how to cure sickness or injuries",
+          "keywords": [
+            "medicine",
+            "recovery"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock medicine production in the technology tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather herbs, berries and other ingredients.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft recovery potions or bandages at a medicine station; carry them for healing.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "cooking-food-recipes",
+          "title": "Cooking & Food Recipes",
+          "source_heading": "Cooking & Food Recipes",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players need better healing food for themselves or Pals",
+          "keywords": [
+            "cooking",
+            "recipes"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Build a **cooking station** or campfire.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Unlock recipes using the technology tree or by experimenting with ingredients.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Combine ingredients (meat, vegetables, spices) to cook nutritious meals for you and your Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "building-transport-airships-boats",
+          "title": "Building Transport: Airships & Boats",
+          "source_heading": "Building Transport: Airships & Boats",
+          "category": "Technology",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "If players ask about large mounts or vehicles",
+          "keywords": [
+            "airship",
+            "boat",
+            "transport"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Reach high tech levels to unlock airship or boat blueprints.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather large amounts of metal, wood and fuel.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build at a specialized station; pilot to explore inaccessible areas.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-taming-devices-traps",
+          "title": "Crafting Taming Devices & Traps",
+          "source_heading": "Crafting Taming Devices & Traps",
+          "category": "Crafting",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player asks about taming rare Pals",
+          "keywords": [
+            "trap",
+            "taming device"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock nets, traps or tranquilizer darts in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather materials (fiber, rope, tranquilizer chemicals).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Craft and place traps near rare Pals; lure them in to capture without combat.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "creating-electric-incubators",
+          "title": "Creating Electric Incubators",
+          "source_heading": "Creating Electric Incubators",
+          "category": "Breeding",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player wants to speed up egg hatching",
+          "keywords": [
+            "electric incubator",
+            "egg"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock **Electric Incubator** technology.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect electronics, Paldium fragments and refined metals.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build the incubator and place eggs inside to cut hatching time in half.",
+              "citations": [
+                "612653128208765\u2020L79-L83"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "building-fences-pens",
+          "title": "Building Fences & Pens",
+          "source_heading": "Building Fences & Pens",
+          "category": "Base Building",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players need to separate Pals or livestock",
+          "keywords": [
+            "fence",
+            "pen"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock fence and pen structures in the build menu.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather wood or metal to craft them.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Place fences to enclose animals or Pals and prevent them from wandering.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "installing-lighting-heating",
+          "title": "Installing Lighting & Heating",
+          "source_heading": "Installing Lighting & Heating",
+          "category": "Base Building",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "Player asks about base environment comfort",
+          "keywords": [
+            "lighting",
+            "heating",
+            "comfort"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock torches, lanterns, heaters and air conditioners.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather fuel or electricity sources.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Place lights and heaters in key areas of your base to improve comfort and SAN.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "building-battery-stations-power-infrastructure",
+          "title": "Building Battery Stations & Power Infrastructure",
+          "source_heading": "Building Battery Stations & Power Infrastructure",
+          "category": "Technology",
+          "category_group": "Technology & Crafting Tools",
+          "trigger": "When players want to store electricity",
+          "keywords": [
+            "battery",
+            "power grid"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock battery technology.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect Paldium, metals and wiring.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build batteries near generators; connect them to store energy for night or heavy use.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "combat-basics-controls",
+          "title": "Combat Basics & Controls",
+          "source_heading": "Combat Basics & Controls",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks how to fight or dodge",
+          "keywords": [
+            "combat basics",
+            "dodge",
+            "attack"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Familiarize yourself with **attack, block and dodge** buttons.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Lock onto enemies to maintain focus.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Practice timing dodges to avoid damage and counterattack.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "element-types-stab-explained",
+          "title": "Element Types & STAB Explained",
+          "source_heading": "Element Types & STAB Explained",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players need to understand element matchups",
+          "keywords": [
+            "element types",
+            "STAB"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Learn each Pal\u2019s **element type** (Fire, Water, Grass, Electric, etc.).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use element advantages (Water vs Fire, etc.) to deal extra damage.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Equip Pals with moves matching their element to gain **STAB** (Same Type Attack Bonus).",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "status-conditions-cures",
+          "title": "Status Conditions & Cures",
+          "source_heading": "Status Conditions & Cures",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks about burns, freezes, poison etc.",
+          "keywords": [
+            "status effects",
+            "cure"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Understand status effects: Burn, Freeze, Poison, Sleep and Stun.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Carry **antidotes or status-removing items** crafted at medicine stations.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Swap Pals or retreat if status effects accumulate.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "how-to-use-melee-weapons",
+          "title": "How to Use Melee Weapons",
+          "source_heading": "How to Use Melee Weapons",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players ask about swords, spears and clubs",
+          "keywords": [
+            "melee weapons",
+            "sword"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Equip a melee weapon such as a sword or spear.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use **heavy and light attacks** to chain combos.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Block or dodge before counter-attacking to avoid damage.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "how-to-use-ranged-weapons",
+          "title": "How to Use Ranged Weapons",
+          "source_heading": "How to Use Ranged Weapons",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks about firearms or bows",
+          "keywords": [
+            "ranged weapons",
+            "guns"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Equip a bow, crossbow or firearm.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use **aim mode** to line up your shot; account for projectile drop.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Reload when safe and switch to melee if enemies get too close.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tower-boss-zoe-grizzbolt",
+          "title": "Tower Boss: Zoe & Grizzbolt",
+          "source_heading": "Tower Boss: Zoe & Grizzbolt",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players need strategy for first tower",
+          "keywords": [
+            "tower boss",
+            "Zoe",
+            "Grizzbolt"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Prepare by leveling your character and capturing strong Fire/Electric Pals.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Enter the first tower and fight through waves of minions.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Focus on Grizzbolt\u2019s weak points, dodge its attacks and use Water-type moves to win.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tower-boss-lily-lyleen",
+          "title": "Tower Boss: Lily & Lyleen",
+          "source_heading": "Tower Boss: Lily & Lyleen",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks about second tower fight",
+          "keywords": [
+            "tower boss",
+            "Lily",
+            "Lyleen"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Train Pals with high Defense and Fire moves.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Progress through the second tower and avoid environmental hazards.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Burn down Lyleen\u2019s plant-type minions and stagger the boss to defeat it.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tower-boss-axel-orserk",
+          "title": "Tower Boss: Axel & Orserk",
+          "source_heading": "Tower Boss: Axel & Orserk",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Triggered when facing third tower",
+          "keywords": [
+            "tower boss",
+            "Axel",
+            "Orserk"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Ice or Grass Pals to counter Orserk\u2019s Dragon/Electric typing.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Dodge Axel\u2019s long-range attacks and close the distance quickly.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Focus your Pals\u2019 partner skills and heal frequently.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tower-boss-victor-shadowbeak",
+          "title": "Tower Boss: Victor & Shadowbeak",
+          "source_heading": "Tower Boss: Victor & Shadowbeak",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player wants to defeat final tower boss",
+          "keywords": [
+            "tower boss",
+            "Victor",
+            "Shadowbeak"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Assemble a team of Dark and Ice Pals to exploit weaknesses.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Avoid Victor\u2019s high-damage projectiles and stay mobile.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Burst Shadowbeak down during openings and use healing items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "raids-xenolord-blazamut-ryu",
+          "title": "Raids: Xenolord & Blazamut Ryu",
+          "source_heading": "Raids: Xenolord & Blazamut Ryu",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks about raid strategies",
+          "keywords": [
+            "raid boss",
+            "Xenolord",
+            "Blazamut Ryu"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gather a group of friends or NPC Pals; raids require multiple participants.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip top-tier gear and potions.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Focus on raid mechanics (e.g., avoid AoE attacks) and coordinate to stagger the boss.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "raid-bellanoir-bellanoir-libero",
+          "title": "Raid: Bellanoir & Bellanoir Libero",
+          "source_heading": "Raid: Bellanoir & Bellanoir Libero",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players join seasonal raids",
+          "keywords": [
+            "raid boss",
+            "Bellanoir"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Pals with strong Electric or Ice attacks.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Break Bellanoir\u2019s shields by focusing your attacks.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Avoid the Libero variant\u2019s rapid strikes and maintain healing.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "boss-bjorn-bastigor-feybreak",
+          "title": "Boss: Bjorn & Bastigor (Feybreak)",
+          "source_heading": "Boss: Bjorn & Bastigor (Feybreak)",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player needs to defeat Bjorn/Bastigor",
+          "keywords": [
+            "Bjorn",
+            "Bastigor",
+            "Feybreak"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Build fire-resistant armor and high DPS Pals.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Dodge Bjorn\u2019s area attacks; avoid standing in burning pools.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Switch to Water Pals to extinguish fires and finish off Bastigor.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "boss-eye-of-cthulu-terraria",
+          "title": "Boss: Eye of Cthulu (Terraria)",
+          "source_heading": "Boss: Eye of Cthulu (Terraria)",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Triggered by Terraria crossover event",
+          "keywords": [
+            "Eye of Cthulu",
+            "Terraria event"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Summon the boss by interacting with the event item or finding its spawn location.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip ranged weapons to hit the flying boss.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Focus on dodging sweeping laser beams; attack during its vulnerability phase.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "boss-moon-lord-raid",
+          "title": "Boss: Moon Lord Raid",
+          "source_heading": "Boss: Moon Lord Raid",
+          "category": "Boss",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players ask about Moon Lord fight",
+          "keywords": [
+            "Moon Lord",
+            "Terraria raid"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Prepare by equipping the best gear and assembling a full party.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Target the Moon Lord\u2019s hands and core; destroy each part in sequence.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Keep moving to avoid large AoE attacks; coordinate healing and damage phases.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "predator-pal-locations-tactics",
+          "title": "Predator Pal Locations & Tactics",
+          "source_heading": "Predator Pal Locations & Tactics",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Questions about strong wandering Pals",
+          "keywords": [
+            "predator Pals",
+            "location"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use the interactive map to locate predator Pals (e.g., Warsect, Necromus).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Approach cautiously; predator Pals have high damage and health.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Weaken them and capture or defeat them for rare drops.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "fighting-alpha-pals",
+          "title": "Fighting Alpha Pals",
+          "source_heading": "Fighting Alpha Pals",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks how to defeat alpha versions",
+          "keywords": [
+            "alpha Pals",
+            "fight"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Observe Alpha Pals roaming the world; they are larger and more aggressive.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Bring a team of complementary Pals to exploit their weaknesses.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use traps or stun items to make capturing easier.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pvp-combat-arena",
+          "title": "PVP Combat & Arena",
+          "source_heading": "PVP Combat & Arena",
+          "category": "PVP",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Questions about PVP arenas and rules",
+          "keywords": [
+            "PVP",
+            "arena",
+            "duel"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Visit the **PVP Arena** and register for a match.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip balanced gear and select Pals suited to player vs player combat.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Learn opponent patterns and adapt; remember that some moves have long wind-ups.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "best-pals-for-combat",
+          "title": "Best Pals for Combat",
+          "source_heading": "Best Pals for Combat",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player wants recommended combat Pals",
+          "keywords": [
+            "combat Pals",
+            "tier list"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Refer to the Best Pals Tier List; top combat Pals include **Jormuntide Ignis**, **Jetragon** and **Frostallion**.",
+              "citations": [
+                "213589709604736\u2020L156-L160"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Capture or breed these Pals; level them and teach powerful skills.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Equip them with appropriate gear and upgrade passive skills via breeding.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "best-weapons-loadouts",
+          "title": "Best Weapons & Loadouts",
+          "source_heading": "Best Weapons & Loadouts",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When players ask about the strongest weapons",
+          "keywords": [
+            "weapons",
+            "loadout"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Craft or obtain top-tier weapons (e.g., rocket launcher, AK-like rifles).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Combine weapons with gear that enhances attack power or stamina.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Keep a melee back-up weapon for enemies resistant to bullets.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "managing-stamina-dodging",
+          "title": "Managing Stamina & Dodging",
+          "source_heading": "Managing Stamina & Dodging",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player complains about low stamina in battle",
+          "keywords": [
+            "stamina",
+            "dodging"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Increase your **Stamina stat** when leveling up.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use stamina-conserving movement (sprinting only when necessary).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Roll or dodge at the last moment to avoid attacks without wasting stamina.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "breaking-enemy-shields-armor",
+          "title": "Breaking Enemy Shields & Armor",
+          "source_heading": "Breaking Enemy Shields & Armor",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Questions about dealing with armored foes",
+          "keywords": [
+            "shield",
+            "armor break"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use **heavy attacks** or explosive weapons to break shields quickly.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Focus attacks on shield emitters or armored plates.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Switch to fast weapons once the shield is broken to maximize damage.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crowd-control-aoe-strategies",
+          "title": "Crowd Control & AoE Strategies",
+          "source_heading": "Crowd Control & AoE Strategies",
+          "category": "Combat",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "When facing multiple enemies",
+          "keywords": [
+            "AoE",
+            "crowd control"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Equip Pals or weapons with **area-of-effect** skills (e.g., Tri-Lightning or Fireball).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Lure groups of enemies together and unleash AoE attacks.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Control the battlefield by slowing or stunning large groups.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "base-defense-against-raids",
+          "title": "Base Defense Against Raids",
+          "source_heading": "Base Defense Against Raids",
+          "category": "Base Defense",
+          "category_group": "Combat & Boss Guides",
+          "trigger": "Player asks how to protect base during raids",
+          "keywords": [
+            "base defense",
+            "raid"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Build walls, turrets and traps around your base.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Assign combat-capable Pals to guard duty.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "When a raid starts, lure enemies into chokepoints and defeat them with traps and Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "how-to-capture-pals",
+          "title": "How to Capture Pals",
+          "source_heading": "How to Capture Pals",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Player asks general question about capturing",
+          "keywords": [
+            "capture Pal",
+            "how to capture"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Craft **Pal Spheres** and track down the desired Pal.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Reduce the Pal\u2019s health without defeating it.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Throw the Pal Sphere and repeat until capture succeeds.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pal-sphere-tiers-catch-rates",
+          "title": "Pal Sphere Tiers & Catch Rates",
+          "source_heading": "Pal Sphere Tiers & Catch Rates",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Player needs to know differences between spheres",
+          "keywords": [
+            "Pal sphere",
+            "catch rate"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock higher-tier spheres (e.g., Giga Sphere, Ultra Sphere) via technology.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Gather rarer materials (chromite, polymer) to craft them.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use higher-tier spheres on strong or Alpha Pals for better catch rates.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "sneaking-back-attack-captures",
+          "title": "Sneaking & Back-Attack Captures",
+          "source_heading": "Sneaking & Back-Attack Captures",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "When players ask about stealth capture techniques",
+          "keywords": [
+            "sneak",
+            "back attack"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Approach a Pal from behind while crouched.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Throw a Pal Sphere for a **back-attack bonus** that increases capture chance.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Avoid making noise or startling the Pal.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "capturing-alpha-pals",
+          "title": "Capturing Alpha Pals",
+          "source_heading": "Capturing Alpha Pals",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Triggered when facing alpha versions in the wild",
+          "keywords": [
+            "alpha capture",
+            "boss capture"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Bring high-tier Pal Spheres and healing items.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Weaken the Alpha Pal and avoid its high-damage moves.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use traps or stun items to temporarily immobilize; throw spheres until captured.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "capturing-specific-legendary-pals",
+          "title": "Capturing Specific Legendary Pals",
+          "source_heading": "Capturing Specific Legendary Pals",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Player names a specific Pal (e.g., Jetragon)",
+          "keywords": [
+            "legendary Pal capture"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Learn the spawn location and conditions for the specific Legendary Pal (e.g., Jetragon spawns in late-game islands).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Prepare an element-appropriate team and high-tier spheres.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Engage the legendary Pal, reduce its HP and capture it.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "all-pal-locations-by-region",
+          "title": "All Pal Locations by Region",
+          "source_heading": "All Pal Locations by Region",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants to know where to find each Pal",
+          "keywords": [
+            "location",
+            "region",
+            "map"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Consult the interactive map or Palpedia for each Pal\u2019s coordinates.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Travel to the specified region and look for the Pal during the correct time of day/weather.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Capture or defeat the Pal as needed.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-by-element-fire-water-etc",
+          "title": "Pals by Element (Fire, Water, etc.)",
+          "source_heading": "Pals by Element (Fire, Water, etc.)",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player asks about element-based Pals",
+          "keywords": [
+            "element Pal list"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Determine which element type you need (e.g., Water for Fire bosses).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Check the Palpedia or map for Pals of that element.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Capture multiple Pals to have backups for breeding and combat.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-base-work-transport-kindling",
+          "title": "Pals for Base Work (Transport & Kindling)",
+          "source_heading": "Pals for Base Work (Transport & Kindling)",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "When players ask which Pals help around the base",
+          "keywords": [
+            "work Pals",
+            "base"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Identify Pals with **Transporting** or **Kindling** work suitability.",
+              "citations": [
+                "633260338298658\u2020L161-L166"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Capture or breed these Pals.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Assign them to base tasks (hauling materials, lighting furnaces).",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-crafting-handiwork",
+          "title": "Pals for Crafting & Handiwork",
+          "source_heading": "Pals for Crafting & Handiwork",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants to know which Pals craft items faster",
+          "keywords": [
+            "craft Pals",
+            "handiwork"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Pals like **Anubis** or **Lunaris** that excel at handiwork.",
+              "citations": [
+                "633260338298658\u2020L166-L167"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to the workbench or crafting stations.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Provide necessary materials and monitor production.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-mining-lumbering",
+          "title": "Pals for Mining & Lumbering",
+          "source_heading": "Pals for Mining & Lumbering",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player asks which Pals mine ore or chop wood",
+          "keywords": [
+            "mining Pals",
+            "lumbering"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture Pals such as **Blazamut**, **Astegon** or **Reptyro**.",
+              "citations": [
+                "633260338298658\u2020L170-L172"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to mine ore nodes or chop trees.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build storage near the worksite for efficient resource collection.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-farming-planting",
+          "title": "Pals for Farming & Planting",
+          "source_heading": "Pals for Farming & Planting",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "When players need help planting crops",
+          "keywords": [
+            "farming Pals",
+            "planting"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Acquire Pals with **Planting** suitability (e.g., **Lyleen**).",
+              "citations": [
+                "633260338298658\u2020L174-L177"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Place them near farming plots.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Provide seeds and fertilizer; harvest crops regularly.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-cooling-heating",
+          "title": "Pals for Cooling & Heating",
+          "source_heading": "Pals for Cooling & Heating",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants Pals to regulate base temperature",
+          "keywords": [
+            "cooling Pals",
+            "heat"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture **Frostallion**, **Cryolinx** or **Reptyro Cyst** for cooling duties.",
+              "citations": [
+                "633260338298658\u2020L178-L179"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to cooling stations or base areas that overheat.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use heat-producing Pals (like **Blazamut**) in cold areas for warmth.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pals-for-electricity-generation",
+          "title": "Pals for Electricity Generation",
+          "source_heading": "Pals for Electricity Generation",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player needs power generation",
+          "keywords": [
+            "electricity Pals",
+            "power"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture **Orserk**, **Relaxaurus Lux** or **Grizzbolt**.",
+              "citations": [
+                "633260338298658\u2020L168-L169"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Assign them to generators or electric equipment.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Manage their energy output and provide rest breaks.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "passive-skills-explained",
+          "title": "Passive Skills Explained",
+          "source_heading": "Passive Skills Explained",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "Player asks about passive skill categories",
+          "keywords": [
+            "passive skills",
+            "categories"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Each Pal has up to four passive skills, such as **Legend**, **Lucky** or **Artisan**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Passive skills enhance stats or provide unique benefits (e.g., increasing work speed).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Breed or catch Pals to obtain desirable passives; combine them through chain breeding.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "active-partner-skills-explained",
+          "title": "Active & Partner Skills Explained",
+          "source_heading": "Active & Partner Skills Explained",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "When players want to understand Pal skills",
+          "keywords": [
+            "active skills",
+            "partner skill"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Active skills** are combat moves used when Pals are in battle.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Partner skills** are triggered when Pals accompany you in the overworld (e.g., Jetragon\u2019s fast flight).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Switch Pals to access different partner skills based on the situation.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "how-to-increase-pal-affinity-trust",
+          "title": "How to Increase Pal Affinity & Trust",
+          "source_heading": "How to Increase Pal Affinity & Trust",
+          "category": "Pal Care",
+          "category_group": "Pals & Capture",
+          "trigger": "Player asks how to improve bond with Pals",
+          "keywords": [
+            "affinity",
+            "trust"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Feed your Pals regularly and ensure they are rested.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Avoid overworking them or letting their SAN drop.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Interact with them (petting) and fight alongside them to build trust.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pal-morale-sanity",
+          "title": "Pal Morale & Sanity",
+          "source_heading": "Pal Morale & Sanity",
+          "category": "Pal Care",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants to prevent overwork or insanity",
+          "keywords": [
+            "SAN",
+            "morale"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Monitor each Pal\u2019s SAN bar; low SAN results in reduced efficiency or refusal to work.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Provide **beds and play items** to restore SAN.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Rotate tasks and avoid leaving Pals unattended for too long.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pal-skins-cosmetics",
+          "title": "Pal Skins & Cosmetics",
+          "source_heading": "Pal Skins & Cosmetics",
+          "category": "Pal Customization",
+          "category_group": "Pals & Capture",
+          "trigger": "Questions about different skins and how to unlock them",
+          "keywords": [
+            "Pal skins",
+            "cosmetics"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Obtain skins through events, raids or the item shop.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Access your Pal\u2019s **appearance menu** via the Palbox or inventory.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Apply the skin to change your Pal\u2019s appearance.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pal-gear-equipment",
+          "title": "Pal Gear & Equipment",
+          "source_heading": "Pal Gear & Equipment",
+          "category": "Pal Customization",
+          "category_group": "Pals & Capture",
+          "trigger": "Player needs to equip harnesses or saddles",
+          "keywords": [
+            "gear",
+            "saddle"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock Pal gear such as saddles or harnesses in the tech tree.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Craft the gear with required materials.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Equip your Pal to enable riding, gliding or enhanced abilities.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "element-swap-subspecies",
+          "title": "Element Swap & Subspecies",
+          "source_heading": "Element Swap & Subspecies",
+          "category": "Palpedia",
+          "category_group": "Pals & Capture",
+          "trigger": "When players ask about changing element or obtaining subspecies",
+          "keywords": [
+            "element swap",
+            "subspecies"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Collect special items (Element Swap Stone) from raids or missions.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use the item on a Pal to change its element.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Breed specific pairs to obtain subspecies with alternate typings.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "evolving-leveling-up-pals",
+          "title": "Evolving & Leveling Up Pals",
+          "source_heading": "Evolving & Leveling Up Pals",
+          "category": "Pal Progression",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants to improve Pal stats quickly",
+          "keywords": [
+            "leveling Pals",
+            "evolution"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gain experience for Pals by defeating enemies or completing tasks.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use **experience candies or books** to speed up leveling.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "While Palworld does not have Pok\u00e9mon-style evolutions, some Pals have **subspecies** accessible via breeding.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pal-stat-distribution-ivs",
+          "title": "Pal Stat Distribution & IVs",
+          "source_heading": "Pal Stat Distribution & IVs",
+          "category": "Mechanics",
+          "category_group": "Pals & Capture",
+          "trigger": "Questions about IVs and how to check them",
+          "keywords": [
+            "IV",
+            "stats"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use an **IV checker** or the Pal IV Stat Calculator to view hidden stats.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Breed Pals with high IVs to produce stronger offspring.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Focus on HP, ATK and DEF for combat Pals; Work Speed for base Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "capturing-pals-without-damage",
+          "title": "Capturing Pals Without Damage",
+          "source_heading": "Capturing Pals Without Damage",
+          "category": "Capturing",
+          "category_group": "Pals & Capture",
+          "trigger": "Player wants non-lethal capture methods",
+          "keywords": [
+            "non lethal",
+            "capture"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use **nets or traps** to capture weaker Pals without injuring them.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Toss a Pal Sphere from stealth for a higher success rate.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Avoid attacking the Pal; patience may be necessary.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "unlocking-the-breeding-farm",
+          "title": "Unlocking the Breeding Farm",
+          "source_heading": "Unlocking the Breeding Farm",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player asks how to start breeding",
+          "keywords": [
+            "breeding farm",
+            "tech level 19"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Reach **technology level 19** and unlock the Breeding Farm.",
+              "citations": [
+                "612653128208765\u2020L51-L55"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Collect wood, stone and Paldium fragments to build the farm.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Place the farm within your base.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "making-cake-feeding-pals",
+          "title": "Making Cake & Feeding Pals",
+          "source_heading": "Making Cake & Feeding Pals",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player needs to craft cake to breed Pals",
+          "keywords": [
+            "cake recipe",
+            "breeding fuel"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gather **flour, berries, milk, eggs and honey**.",
+              "citations": [
+                "612653128208765\u2020L53-L55"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Combine the ingredients at a cooking station to bake **cake**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Place cake in the Breeding Farm\u2019s inventory to encourage Pals to mate.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "basic-breeding-mechanics",
+          "title": "Basic Breeding Mechanics",
+          "source_heading": "Basic Breeding Mechanics",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player asks how breeding works or stat inheritance",
+          "keywords": [
+            "breeding mechanics",
+            "inheritance"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Place one **male** and one **female** Pal in the Breeding Farm.",
+              "citations": [
+                "612653128208765\u2020L53-L55"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Provide cake and wait about **five minutes** for an egg to appear.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Eggs inherit the average breeding power of the parents.",
+              "citations": [
+                "612653128208765\u2020L56-L58"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "breeding-for-passive-skills",
+          "title": "Breeding for Passive Skills",
+          "source_heading": "Breeding for Passive Skills",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Triggered when players want to pass Legend or Lucky skills",
+          "keywords": [
+            "passive skills",
+            "chain breeding"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture or breed Pals with rare passives (Legend, Lucky, Artisan).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Pair Pals so that desirable passives are present in both parents.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Hatch eggs; check offspring for inherited passives and repeat if necessary.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "best-breeding-combos-for-top-pals",
+          "title": "Best Breeding Combos for Top Pals",
+          "source_heading": "Best Breeding Combos for Top Pals",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player needs combinations for strong offspring",
+          "keywords": [
+            "breeding combos",
+            "top Pals"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use recommended combinations like **Relaxaurus + Sparkit \u2192 Relaxaurus Lux** or **Lyleen + Menasting \u2192 Lyleen Noct**.",
+              "citations": [
+                "612653128208765\u2020L64-L77"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Breed the specified pairs and incubate the resulting eggs.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Raise the offspring; assign them to combat or support roles.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "early-game-breeding-combos",
+          "title": "Early-Game Breeding Combos",
+          "source_heading": "Early-Game Breeding Combos",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player seeks combos using common Pals",
+          "keywords": [
+            "early breeding",
+            "beginner"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Combine **Penking + Bushi** to produce **Anubis** for early DPS.",
+              "citations": [
+                "612653128208765\u2020L87-L100"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Use **Rushoar + Surfent** or **Swee + Sweepa** to get **Digtoise**.",
+              "citations": [
+                "612653128208765\u2020L87-L105"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Breed **Nitewing + Cinnamoth** to obtain **Sibelyx**.",
+              "citations": [
+                "612653128208765\u2020L87-L111"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "breeding-combos-by-role-work-pals",
+          "title": "Breeding Combos by Role: Work Pals",
+          "source_heading": "Breeding Combos by Role: Work Pals",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "When players ask for base-worker combos",
+          "keywords": [
+            "work breeding",
+            "artisan"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Breed **Penking + Penking** for Penking with the **Artisan** passive.",
+              "citations": [
+                "612653128208765\u2020L120-L124"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Breed **Penking + Wumpo Botan** for random work passives.",
+              "citations": [
+                "612653128208765\u2020L120-L127"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Repeat until you get desired passives and assign the offspring to your base.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "breeding-combos-by-role-combat-dps-pals",
+          "title": "Breeding Combos by Role: Combat DPS Pals",
+          "source_heading": "Breeding Combos by Role: Combat DPS",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player wants to breed DPS Pals",
+          "keywords": [
+            "combat breeding",
+            "DPS"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Breed **Relaxaurus + Sparkit** for **Relaxaurus Lux**.",
+              "citations": [
+                "612653128208765\u2020L132-L134"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Breed **Incineram + Maraith** for **Incineram Noct**.",
+              "citations": [
+                "612653128208765\u2020L132-L135"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Breed **Frostallion + Anubis** for **Bastigor**.",
+              "citations": [
+                "612653128208765\u2020L132-L136"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "breeding-combos-by-role-defense-tank-pals",
+          "title": "Breeding Combos by Role: Defense/Tank Pals",
+          "source_heading": "Breeding Combos by Role: Defense/Tank",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "When players need tanks or defenders",
+          "keywords": [
+            "tank breeding",
+            "defense"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Combine **Lamball + Fielfox** to create **Digtoise Terra**.",
+              "citations": [
+                "612653128208765\u2020L141-L144"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Breed **Mammorest + Wumpo** for **Mammorest Cryst**.",
+              "citations": [
+                "612653128208765\u2020L141-L145"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Pair **Lyleen + Menasting** for **Lyleen Noct** as a healer-tank hybrid.",
+              "citations": [
+                "612653128208765\u2020L141-L146"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "breeding-combos-by-role-mobility-utility-pals",
+          "title": "Breeding Combos by Role: Mobility/Utility Pals",
+          "source_heading": "Breeding Combos by Role: Mobility/Utility",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player asks for mounts or utility Pals",
+          "keywords": [
+            "mobility breeding",
+            "mount"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Breed **Elphidran + Surfent Aqua** for **Elphidran Aqua** (flying water mount).",
+              "citations": [
+                "612653128208765\u2020L149-L154"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Pair **Eikthyrdeer + Hangyu** for **Eikthyrdeer Terra**.",
+              "citations": [
+                "612653128208765\u2020L151-L154"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Combine **Surfent + Dumud** for **Surfent Terra**.",
+              "citations": [
+                "612653128208765\u2020L149-L154"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "breeding-combos-by-role-support-healing-pals",
+          "title": "Breeding Combos by Role: Support/Healing Pals",
+          "source_heading": "Breeding Combos by Role: Support/Healing",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "When players want healers or support Pals",
+          "keywords": [
+            "support breeding",
+            "healing"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Breed **Lyleen + Menasting** again for **Lyleen Noct** (healer/support).",
+              "citations": [
+                "612653128208765\u2020L160-L166"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Pair **Mau + Pengullet** for **Mau Cryst** (budget healer).",
+              "citations": [
+                "612653128208765\u2020L160-L166"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Breed **Dinossom + Rayhound** for **Dinossom Lux** (speed buff support).",
+              "citations": [
+                "612653128208765\u2020L160-L166"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "hatching-eggs-using-incubators",
+          "title": "Hatching Eggs & Using Incubators",
+          "source_heading": "Hatching Eggs & Using Incubators",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player asks about egg incubation times",
+          "keywords": [
+            "egg hatching",
+            "incubator"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Collect eggs from the Breeding Farm or in the wild.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Place them in a standard incubator or **Electric Incubator** to reduce hatching time.",
+              "citations": [
+                "612653128208765\u2020L79-L83"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Monitor temperature and wait for the incubation timer to finish.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "obtaining-alpha-eggs-huge-eggs",
+          "title": "Obtaining Alpha Eggs & Huge Eggs",
+          "source_heading": "Obtaining Alpha Eggs & Huge Eggs",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "When players want Alpha or subspecies eggs",
+          "keywords": [
+            "Alpha egg",
+            "huge egg"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Breed high-level Pals; there is about a **5 % chance** to produce a Huge/Alpha Egg.",
+              "citations": [
+                "612653128208765\u2020L60-L62"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Collect eggs from raid bosses or treasure chests for guaranteed Alpha eggs.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use an Electric Incubator for efficient hatching.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "breeding-cross-species-subspecies",
+          "title": "Breeding Cross-Species & Subspecies",
+          "source_heading": "Breeding Cross-Species & Subspecies",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Questions about cross-breeding for special Pals",
+          "keywords": [
+            "cross breed",
+            "subspecies"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Pair two Pals from different species as outlined in breeding charts.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Provide cake and wait for the resulting hybrid egg.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Hatch the egg to obtain a subspecies with mixed elements or unique traits.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "passive-skill-probability-inheritance",
+          "title": "Passive Skill Probability & Inheritance",
+          "source_heading": "Passive Skill Probability & Inheritance",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "Player asks about the chances of passives transferring",
+          "keywords": [
+            "passive probability",
+            "inheritance"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Understand that 40 % of offspring get one passive, 30 % get two, 20 % get three and 10 % get four.",
+              "citations": [
+                "612653128208765\u2020L56-L59"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Breed Pals with multiple passives to increase the number of inherited skills.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Repeat breeding cycles until you obtain the desired combination.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "breeding-farm-efficiency-tips",
+          "title": "Breeding Farm Efficiency Tips",
+          "source_heading": "Breeding Farm Efficiency Tips",
+          "category": "Breeding",
+          "category_group": "Breeding & Eggs",
+          "trigger": "When players want to speed up breeding or reduce wait time",
+          "keywords": [
+            "efficiency",
+            "breeding tips"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use **Electric Incubators** to reduce wait time by 1.5\u00d7.",
+              "citations": [
+                "612653128208765\u2020L79-L83"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Always supply cake to keep Pals breeding continuously.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Maintain multiple breeding farms for parallel breeding projects.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "interactive-map-overview",
+          "title": "Interactive Map Overview",
+          "source_heading": "Interactive Map Overview",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player wants to see map or markers for chests/effigies",
+          "keywords": [
+            "map",
+            "interactive map"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Access the official or community-made interactive map through a browser.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Enable or disable markers for Pals, effigies, chests and dungeons.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Plan your route by setting waypoints and referencing coordinates.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "all-alpha-pal-locations",
+          "title": "All Alpha Pal Locations",
+          "source_heading": "All Alpha Pal Locations",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players ask where to find Alpha Pals",
+          "keywords": [
+            "alpha locations",
+            "world boss"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Select the **Alpha Pals** filter on the interactive map.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Travel to the indicated coordinates with an experienced team.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat or capture the Alpha Pals using high-tier spheres.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-hillside-cavern",
+          "title": "Dungeon Guide: Hillside Cavern",
+          "source_heading": "Dungeon Guide: Hillside Cavern",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player wants to clear Hillside Cavern",
+          "keywords": [
+            "dungeon guide",
+            "hillside"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Locate the entrance in a low-level region.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Bring a torch or light source; the cavern is dark.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat mobs inside and loot the final chest at the deepest chamber.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-mountain-stream-grotto",
+          "title": "Dungeon Guide: Mountain Stream Grotto",
+          "source_heading": "Dungeon Guide: Mountain Stream Grotto",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Questions about low-level dungeon",
+          "keywords": [
+            "mountain stream",
+            "grotto"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to the grotto entrance near a river.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Prepare for water-type enemies.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Explore the winding tunnels and defeat the final mini-boss for loot.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-isolated-island-cavern",
+          "title": "Dungeon Guide: Isolated Island Cavern",
+          "source_heading": "Dungeon Guide: Isolated Island Cavern",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player needs to explore island cave",
+          "keywords": [
+            "isolated island",
+            "cavern"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Reach the island via glider or boat.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Enter the cavern; expect stronger enemies than on the mainland.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Collect unique materials and a treasure chest at the end.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-ravine-grotto",
+          "title": "Dungeon Guide: Ravine Grotto",
+          "source_heading": "Dungeon Guide: Ravine Grotto",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players ask about ravine dungeon",
+          "keywords": [
+            "ravine",
+            "dungeon"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Find the ravine entrance in mountainous terrain.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use grappling hooks or gliders to traverse vertical passages.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat the Alpha Pal inside and claim the rare items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-cavern-of-the-dunes",
+          "title": "Dungeon Guide: Cavern of the Dunes",
+          "source_heading": "Dungeon Guide: Cavern of the Dunes",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Exploring desert dungeon",
+          "keywords": [
+            "dunes",
+            "cavern"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to the desert region; locate the cavern entrance.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip heat-resistant gear and bring water.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat sand-type monsters and avoid traps.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-frozen-abyss",
+          "title": "Dungeon Guide: Frozen Abyss",
+          "source_heading": "Dungeon Guide: Frozen Abyss",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player asks about tundra/ice dungeon",
+          "keywords": [
+            "frozen abyss",
+            "ice dungeon"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Wear warm clothing to resist cold.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Navigate icy platforms and slippery slopes.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat the Ice-type boss and loot its chest for Frost items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-astral-mountain-ruins",
+          "title": "Dungeon Guide: Astral Mountain Ruins",
+          "source_heading": "Dungeon Guide: Astral Mountain Ruins",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players explore the Astral Mountains",
+          "keywords": [
+            "astral mountain",
+            "ruins"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Ascend the Astral Mountains to reach ancient ruins.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Fight celestial-type enemies and solve simple puzzles.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Open the final chest containing high-level schematics.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dungeon-guide-ocean-depths",
+          "title": "Dungeon Guide: Ocean Depths",
+          "source_heading": "Dungeon Guide: Ocean Depths",
+          "category": "Dungeon",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player wants underwater dungeon tips",
+          "keywords": [
+            "ocean",
+            "underwater"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Craft an underwater breathing device or ride an aquatic Pal.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Dive into the depths to find the dungeon entrance.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat aquatic monsters and harvest unique materials.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "map-effigies-totems-locations",
+          "title": "Map: Effigies & Totems Locations",
+          "source_heading": "Map: Effigies & Totems Locations",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player asks about upgrading skill points",
+          "keywords": [
+            "effigy",
+            "totem location"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use the interactive map to find all **effigies**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect them to increase your maximum skill points.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Activate totems to gain buffs or unlock hidden areas.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "map-treasure-chests-lockboxes",
+          "title": "Map: Treasure Chests & Lockboxes",
+          "source_heading": "Map: Treasure Chests & Lockboxes",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players ask for chest locations",
+          "keywords": [
+            "treasure chest",
+            "lockbox"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Enable chest markers on the interactive map.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use lockpicking tools to open locked chests.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Collect schematics, materials and coins from each chest.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "map-egg-breeding-locations",
+          "title": "Map: Egg & Breeding Locations",
+          "source_heading": "Map: Egg & Breeding Locations",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player asks where to find eggs",
+          "keywords": [
+            "egg location",
+            "egg map"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Search for egg markers on the interactive map.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Visit nests or cave locations to collect eggs.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Some eggs only appear during specific weather or times; be patient.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "map-meteorite-supply-drop-locations",
+          "title": "Map: Meteorite & Supply Drop Locations",
+          "source_heading": "Map: Meteorite & Supply Drop Locations",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players want to farm event items",
+          "keywords": [
+            "meteorite map",
+            "supply drop"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Monitor notifications for falling meteorites or supply drops.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Check the map for their landing sites.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Rush to the spot, defeat surrounding mobs and collect the loot.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "weather-biomes-explained",
+          "title": "Weather & Biomes Explained",
+          "source_heading": "Weather & Biomes Explained",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player asks how weather affects exploration",
+          "keywords": [
+            "biome",
+            "weather"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Understand that different biomes (desert, tundra, volcanic, forest) have unique temperatures and hazards.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip appropriate gear before entering a biome.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Adjust your base\u2019s position or use Pals to mitigate weather effects.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "traversal-tips-climbing-gliding-swimming",
+          "title": "Traversal Tips: Climbing, Gliding, Swimming",
+          "source_heading": "Traversal Tips: Climbing, Gliding, Swimming",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Questions about mobility skills",
+          "keywords": [
+            "traversal",
+            "climbing",
+            "swimming"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use the glider to cross gaps or descend safely.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Climb vines or rocky surfaces with the jump and grab controls.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Ride aquatic Pals to swim quickly across water bodies.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "secrets-hidden-areas",
+          "title": "Secrets & Hidden Areas",
+          "source_heading": "Secrets & Hidden Areas",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player wants to find hidden caves or easter eggs",
+          "keywords": [
+            "secret area",
+            "hidden"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Explore corners of the map often; look for unusual rock formations or structures.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use bombs or explosives to blow open cracked walls.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Keep note of suspicious locations and return after gaining new abilities.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "sanctuary-wildlife-reserve-guide",
+          "title": "Sanctuary & Wildlife Reserve Guide",
+          "source_heading": "Sanctuary & Wildlife Reserve Guide",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "When players ask about wildlife sanctuaries or safe zones",
+          "keywords": [
+            "sanctuary",
+            "wildlife"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to wildlife sanctuaries marked on the map.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Capture or observe rare Pals in a non-hostile environment.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Respect sanctuary rules; some areas restrict combat or capture.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "fast-travel-network-guide",
+          "title": "Fast Travel Network Guide",
+          "source_heading": "Fast Travel Network Guide",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Player needs to use or unlock fast travel points",
+          "keywords": [
+            "fast travel",
+            "network"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Activate every Great Eagle Statue you encounter.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use fast travel to move quickly across the map.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build small outposts near statues for convenience.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "collecting-journals-lore-entries",
+          "title": "Collecting Journals & Lore Entries",
+          "source_heading": "Collecting Journals & Lore Entries",
+          "category": "Exploration",
+          "category_group": "Exploration, Maps & Dungeons",
+          "trigger": "Questions about story or lore items",
+          "keywords": [
+            "journals",
+            "lore"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Search abandoned camps and ruins for glowing books or tablets.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Interact with them to collect the journal entry.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Read entries in your log to learn more about Palworld\u2019s story.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tides-of-terraria-content-overview",
+          "title": "Tides of Terraria Content Overview",
+          "source_heading": "Tides of Terraria Content Overview",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player asks what\u2019s included in the Terraria collaboration",
+          "keywords": [
+            "Terraria update",
+            "new island"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Update your game to the **Tides of Terraria** version.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Access new islands and dungeons introduced in the collaboration.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Hunt Terraria-themed Pals and items (Herbil, Icelyn, etc.).",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tides-of-terraria-new-pals",
+          "title": "Tides of Terraria: New Pals",
+          "source_heading": "Tides of Terraria: New Pals",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Questions about Herbil, Icelyn, Frostplume and other new Pals",
+          "keywords": [
+            "Terraria pals",
+            "new pals"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to the Tides of Terraria islands.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Capture or breed new Pals such as **Herbil** and **Icelyn**.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Study their work suitability and incorporate them into your base.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tides-of-terraria-how-to-get-terraria-items",
+          "title": "Tides of Terraria: How to Get Terraria Items",
+          "source_heading": "Tides of Terraria: How to Get Terraria Items",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player wants to obtain Terraria crossover items",
+          "keywords": [
+            "Terraria items",
+            "crossover"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Defeat Terraria bosses or complete missions on the new islands.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Collect drops that reference Terraria items (swords, wings, etc.).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use or equip these items to gain unique abilities.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "how-to-recruit-zoe-terraria-npc",
+          "title": "How to Recruit Zoe (Terraria NPC)",
+          "source_heading": "How to Recruit Zoe (Terraria NPC)",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "When players ask about recruiting the NPC Zoe",
+          "keywords": [
+            "recruit Zoe",
+            "Terraria NPC"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Locate Zoe on the Tides of Terraria island.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Complete her quests or meet her requirements.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Recruit her to unlock new services or items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "tides-of-terraria-dungeon-guide",
+          "title": "Tides of Terraria Dungeon Guide",
+          "source_heading": "Tides of Terraria Dungeon Guide",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player seeks info on Terraria dungeons",
+          "keywords": [
+            "Terraria dungeon",
+            "Moon Lord"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Enter the Terraria dungeon and fight through themed enemies.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Avoid traps unique to Terraria (e.g., spike balls).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat **Moon Lord** at the end and collect loot.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "feybreak-update-overview-release-date",
+          "title": "Feybreak Update Overview & Release Date",
+          "source_heading": "Feybreak Update Overview & Release Date",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player wants details on Feybreak update",
+          "keywords": [
+            "Feybreak update",
+            "new content"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Ensure you have downloaded the **Feybreak** update.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Read patch notes to learn about new features and Pals (e.g., Xenolord Raid).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Visit new locations such as the Oil Rig stronghold.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "feybreak-oil-rig-guide",
+          "title": "Feybreak Oil Rig Guide",
+          "source_heading": "Feybreak Oil Rig Guide",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "When players ask about oil rig stronghold",
+          "keywords": [
+            "oil rig",
+            "Feybreak"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to the oil rig\u2019s coordinates.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Defeat guards and navigate the multi-level platform.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Secure the rig and collect resources or kill the raid boss.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "messenger-of-love-locations",
+          "title": "Messenger of Love Locations",
+          "source_heading": "Messenger of Love Locations",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player asks about special messenger event",
+          "keywords": [
+            "messenger of love",
+            "event"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Receive the mission to find the Messenger of Love NPC.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Travel to the indicated coordinates; the messenger may move between locations.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Complete tasks given by the messenger to receive rewards.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "level-30-oil-rig-strategy",
+          "title": "Level 30 Oil Rig Strategy",
+          "source_heading": "Level 30 Oil Rig Strategy",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "When players tackle the Level 30 oil rig",
+          "keywords": [
+            "level 30",
+            "oil rig"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Ensure your team is at least level 30.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Equip high-tier weapons and armor.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Coordinate with a group to clear out waves of enemies and defeat the boss.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "all-predator-pal-locations",
+          "title": "All Predator Pal Locations",
+          "source_heading": "All Predator Pal Locations",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Players ask where predator Pals appear",
+          "keywords": [
+            "predator Pals",
+            "location"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Identify predator Pals like **Warsect** or **Necromus**.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Use the map to locate their roaming zones.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Approach carefully; capture or defeat them for unique rewards.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "sakurajima-summer-update-features",
+          "title": "Sakurajima Summer Update Features",
+          "source_heading": "Sakurajima Summer Update Features",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Questions about new content from summer update",
+          "keywords": [
+            "Sakurajima update",
+            "features"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Read the patch notes to understand new features: PVP arena, Lockpicking Tool v3, dog coins and more.",
+              "citations": [
+                "285876925291367\u2020L181-L184"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Explore Sakurajima island to discover new dungeons and Pals.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Participate in new events to earn exclusive skins and items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pvp-arena-guide",
+          "title": "PVP Arena Guide",
+          "source_heading": "PVP Arena Guide",
+          "category": "Update",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player asks about PVP arena and how to start",
+          "keywords": [
+            "PVP arena",
+            "new feature"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to the PVP arena on Sakurajima island.",
+              "citations": [
+                "675291985780246\u2020L470-L474"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Register for matches and choose your ruleset.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Fight other players; adapt strategies based on their Pals and playstyles.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "meteorite-event-guide",
+          "title": "Meteorite Event Guide",
+          "source_heading": "Meteorite Event Guide",
+          "category": "Event",
+          "category_group": "Special Updates & Events",
+          "trigger": "When players want to find meteor events",
+          "keywords": [
+            "meteorite event",
+            "meteor"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Watch for meteor showers; they occur randomly after the update.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Follow the event marker to the crash site.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Defeat enemies around the meteor and mine the ore inside.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "dog-coin-farming-guide",
+          "title": "Dog Coin Farming Guide",
+          "source_heading": "Dog Coin Farming Guide",
+          "category": "Event",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player asks how to farm Dog Coins",
+          "keywords": [
+            "dog coins",
+            "currency"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Complete Sakurajima side quests that reward Dog Coins.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Defeat special enemies or open dog coin chests.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Spend Dog Coins on unique items or save them for later updates.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "supply-drop-guide-items",
+          "title": "Supply Drop Guide & Items",
+          "source_heading": "Supply Drop Guide & Items",
+          "category": "Event",
+          "category_group": "Special Updates & Events",
+          "trigger": "Questions about supply drop mechanics",
+          "keywords": [
+            "supply drop",
+            "items"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Locate the falling supply crate via map markers.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Clear out surrounding enemies and open the crate.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Collect items such as ammo, tech manuals and rare resources.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "halloween-skins-how-to-change-pal-skins",
+          "title": "Halloween Skins & How to Change Pal Skins",
+          "source_heading": "Halloween Skins & How to Change Pal Skins",
+          "category": "Event",
+          "category_group": "Special Updates & Events",
+          "trigger": "When players ask about seasonal skins",
+          "keywords": [
+            "Halloween skins",
+            "Pal skins"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Participate in Halloween events to earn limited skins.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Access the skin menu for your Pal via the Palbox.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Apply the new skin; some skins may also change partner skills.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "seasonal-festival-events-rewards",
+          "title": "Seasonal Festival Events & Rewards",
+          "source_heading": "Seasonal Festival Events & Rewards",
+          "category": "Event",
+          "category_group": "Special Updates & Events",
+          "trigger": "Player needs info on limited-time events",
+          "keywords": [
+            "seasonal event",
+            "festival"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Check event schedules from official announcements.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Participate in time-limited quests or mini-games.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Earn event currencies and trade them for festive items.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "setting-up-multiplayer-co-op",
+          "title": "Setting Up Multiplayer & Co-op",
+          "source_heading": "Setting Up Multiplayer & Co-op",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Player asks how to play with friends",
+          "keywords": [
+            "multiplayer",
+            "co-op"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "From the main menu, select **multiplayer** and choose to host or join a world.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Share your world code with friends or input theirs.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Collaborate on building, exploring and fighting bosses.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "running-a-dedicated-server",
+          "title": "Running a Dedicated Server",
+          "source_heading": "Running a Dedicated Server",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Questions about hosting private servers",
+          "keywords": [
+            "dedicated server",
+            "hosting"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Install the dedicated server software from the official site or Steam.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Configure server settings (player cap, difficulty, world seed).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Launch the server and invite players to join via IP address.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "trading-pals-items-with-others",
+          "title": "Trading Pals & Items with Others",
+          "source_heading": "Trading Pals & Items with Others",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "When players ask about trades and exchanges",
+          "keywords": [
+            "trading",
+            "exchange"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Approach another player and open the trade interface.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Select Pals or items to offer; confirm trade terms.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Complete the trade; transferred Pals retain their levels and passives.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "joining-the-pvp-arena",
+          "title": "Joining the PVP Arena",
+          "source_heading": "Joining the PVP Arena",
+          "category": "PVP",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Player wants to battle others",
+          "keywords": [
+            "PVP",
+            "arena"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Travel to a PVP arena location and speak with the arena NPC.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Choose a match type (1v1, 3v3, etc.).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Equip your Pals and gear; fight until one team is defeated.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "pvp-etiquette-rules",
+          "title": "PVP Etiquette & Rules",
+          "source_heading": "PVP Etiquette & Rules",
+          "category": "PVP",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Questions about PVP rules and sportsmanship",
+          "keywords": [
+            "PVP rules",
+            "etiquette"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Respect match rules (no healing items if prohibited).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Avoid exploiting glitches or unfair mechanics.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Congratulate opponents and maintain sportsmanship.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "clan-guild-system",
+          "title": "Clan & Guild System",
+          "source_heading": "Clan & Guild System",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "If players ask about joining or creating guilds",
+          "keywords": [
+            "guild",
+            "clan"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Create a guild via the guild board at a major settlement.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Invite friends or players to join.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Complete guild quests to earn shared resources and perks.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "raid-party-coordination",
+          "title": "Raid Party Coordination",
+          "source_heading": "Raid Party Coordination",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Player needs tips for organizing raid parties",
+          "keywords": [
+            "raid coordination",
+            "group"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Form a group of players with complementary Pals and roles.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Designate a leader to call out mechanics and phases.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Distribute loot fairly after defeating the raid boss.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "cross-platform-play-compatibility",
+          "title": "Cross-Platform Play & Compatibility",
+          "source_heading": "Cross-Platform Play & Compatibility",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "Questions about playing across platforms",
+          "keywords": [
+            "crossplay",
+            "compatibility"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Check whether your version supports cross-play.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Add friends via cross-platform friend codes.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Join each other\u2019s games by inputting the provided codes.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "voice-chat-communication-tips",
+          "title": "Voice & Chat Communication Tips",
+          "source_heading": "Voice & Chat Communication Tips",
+          "category": "Multiplayer",
+          "category_group": "Multiplayer & PVP",
+          "trigger": "When players ask about communicating in-game",
+          "keywords": [
+            "voice chat",
+            "communication"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use an external voice chat program (e.g., Discord) or the in-game voice chat.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Communicate boss mechanics and resource needs clearly.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Respect other players\u2019 privacy and follow community guidelines.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "understanding-hp-atk-def",
+          "title": "Understanding HP, ATK & DEF",
+          "source_heading": "Understanding HP, ATK & DEF",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks about basic stats",
+          "keywords": [
+            "HP",
+            "ATK",
+            "DEF"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**HP** determines how much damage you or your Pal can take before fainting.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**ATK** affects physical and elemental damage output.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "**DEF** reduces incoming damage; increase via leveling, gear and passives.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "work-speed-explained",
+          "title": "Work Speed Explained",
+          "source_heading": "Work Speed Explained",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Questions about work speed and productivity",
+          "keywords": [
+            "work speed",
+            "productivity"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Work Speed influences how quickly a Pal completes assigned tasks.",
+              "citations": [
+                "633260338298658\u2020L160-L170"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "High Work Speed Pals (e.g., Penking) finish jobs faster.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Breed or capture Pals with the **Artisan** passive to boost work speed.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "stamina-weight-systems",
+          "title": "Stamina & Weight Systems",
+          "source_heading": "Stamina & Weight Systems",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks why they can\u2019t run or carry more",
+          "keywords": [
+            "stamina",
+            "weight"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "**Stamina** governs sprinting, dodging and climbing; increase it when leveling up.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "**Weight** is the amount of gear and materials you can carry; upgrade the stat or use Pals to transport goods.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Overloading weight slows movement; drop items or use storage.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "rarity-pal-star-ratings",
+          "title": "Rarity & Pal Star Ratings",
+          "source_heading": "Rarity & Pal Star Ratings",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "When players ask about pal rarity tiers",
+          "keywords": [
+            "rarity",
+            "star rating"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Pals have rarity levels (common to legendary) indicated by stars.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Higher rarity Pals often have better base stats and unique passives.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Capture rare Pals in difficult regions or via breeding subspecies.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "sicknesses-injuries",
+          "title": "Sicknesses & Injuries",
+          "source_heading": "Sicknesses & Injuries",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Questions about illness and how to cure Pals",
+          "keywords": [
+            "sickness",
+            "injury"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Pals can become sick or injured if overworked, starved or damaged.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Craft medicine or visit a healer NPC to cure them.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Provide rest and food to prevent illness.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "san-sanity-system",
+          "title": "SAN (Sanity) System",
+          "source_heading": "SAN (Sanity) System",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks about Pal mental health",
+          "keywords": [
+            "SAN",
+            "sanity"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Each Pal has a SAN (sanity) meter; low SAN leads to tantrums or refusal to work.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Keep Pals happy with rest, varied tasks and comfortable base conditions.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Use special items or activities to restore SAN.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "weather-effects-on-players-pals",
+          "title": "Weather Effects on Players & Pals",
+          "source_heading": "Weather Effects on Players & Pals",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "When players want to know how weather affects them",
+          "keywords": [
+            "weather effects",
+            "cold",
+            "heat"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Extreme cold causes frostbite; extreme heat causes heatstroke.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Wear appropriate armor and bring temperature-regulating Pals to mitigate effects.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Build shelters in hazardous biomes to protect Pals.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "passive-skill-ranks-categories",
+          "title": "Passive Skill Ranks & Categories",
+          "source_heading": "Passive Skill Ranks & Categories",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player needs to understand Legend, Lucky, etc.",
+          "keywords": [
+            "passive ranks",
+            "categories"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Passives range from common to **Legend** (highest tier).",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Each passive affects specific stats or work efficiency (e.g., **Lucky** increases drop rates).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Breed Pals or use skill fruits to obtain high-rank passives.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "damage-types-resistances",
+          "title": "Damage Types & Resistances",
+          "source_heading": "Damage Types & Resistances",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Questions about physical vs elemental damage",
+          "keywords": [
+            "damage types",
+            "resistance"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Physical and elemental damage types interact with Pal resistances.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Match your attacks to enemy weaknesses (e.g., Water vs Fire).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Equip gear that reduces damage from the enemy\u2019s dominant element.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "experience-leveling-mechanics",
+          "title": "Experience & Leveling Mechanics",
+          "source_heading": "Experience & Leveling Mechanics",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks how EXP works for players or Pals",
+          "keywords": [
+            "experience",
+            "leveling"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Gain experience by defeating enemies, completing missions and crafting items.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Pals gain experience even when assigned to base tasks.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "When leveling up, allocate stat points to suit your playstyle.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "resource-respawn-timers",
+          "title": "Resource Respawn & Timers",
+          "source_heading": "Resource Respawn & Timers",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "When players wonder when resources respawn",
+          "keywords": [
+            "respawn timer",
+            "resources"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Trees, ore nodes and berry bushes respawn after an in-game day or more.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Rare resources take longer to respawn; plan resource runs accordingly.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Dungeons reset after a set period, allowing you to re-farm them.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "vendor-merchant-mechanics",
+          "title": "Vendor & Merchant Mechanics",
+          "source_heading": "Vendor & Merchant Mechanics",
+          "category": "Economy",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Questions about how vendor stock refreshes",
+          "keywords": [
+            "vendor",
+            "merchant"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Vendors restock their inventory after a daily reset or when you leave the area.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Black Marketeers sell rare items but may charge more.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Buying and selling prices vary depending on your negotiation skill or passives.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "crafting-queue-work-prioritization",
+          "title": "Crafting Queue & Work Prioritization",
+          "source_heading": "Crafting Queue & Work Prioritization",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player wants to know how tasks are prioritized",
+          "keywords": [
+            "queue",
+            "work priority"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Pals will tackle the top item in a crafting queue first.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Assign high Work Speed Pals to time-sensitive tasks.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Reorder tasks manually if certain items are needed urgently.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "achievement-trophy-guide",
+          "title": "Achievement & Trophy Guide",
+          "source_heading": "Achievement & Trophy Guide",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks how to unlock achievements",
+          "keywords": [
+            "achievement",
+            "trophy"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "View achievements in your profile menu.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Complete specific tasks (e.g., capture 50 Pals, defeat all tower bosses).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Collect rewards or recognition for 100 % completion.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "settings-accessibility-options",
+          "title": "Settings & Accessibility Options",
+          "source_heading": "Settings & Accessibility Options",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "When players need help adjusting settings",
+          "keywords": [
+            "options",
+            "settings"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Navigate to the options menu from the pause screen.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Adjust controls, sound, display and accessibility features (colorblind modes, subtitles).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Save settings to apply changes.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "saving-auto-save-system",
+          "title": "Saving & Auto-Save System",
+          "source_heading": "Saving & Auto-Save System",
+          "category": "Mechanics",
+          "category_group": "Stats & Mechanics",
+          "trigger": "Player asks how saving works",
+          "keywords": [
+            "save system",
+            "autosave"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "The game auto-saves at regular intervals and after key events.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Manually save by interacting with your bed or Palbox.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Back up save files to avoid data loss.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "joining-events-festivals",
+          "title": "Joining Events & Festivals",
+          "source_heading": "Joining Events & Festivals",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "Player asks about community events",
+          "keywords": [
+            "events",
+            "festival"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Monitor in-game announcements and social channels for event schedules.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Travel to the event location or speak with the event NPC.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Participate in mini-games and complete tasks to earn rewards.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "participating-in-community-challenges",
+          "title": "Participating in Community Challenges",
+          "source_heading": "Participating in Community Challenges",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "When players want to join special challenges",
+          "keywords": [
+            "community challenge",
+            "contest"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Join official or fan-run challenges through forums or social media.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Complete the specified goals (e.g., build a castle, breed a rare Pal).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Submit proof to organizers and earn recognition or prizes.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "reporting-bugs-feedback",
+          "title": "Reporting Bugs & Feedback",
+          "source_heading": "Reporting Bugs & Feedback",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "Player needs to report a bug or provide feedback",
+          "keywords": [
+            "report bug",
+            "support"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Collect screenshots or videos of the issue.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Visit the official support site or email the developers.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Describe the bug with steps to reproduce and your system information.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "modding-custom-content",
+          "title": "Modding & Custom Content",
+          "source_heading": "Modding & Custom Content",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "Questions about mods or custom assets",
+          "keywords": [
+            "modding",
+            "custom content"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Check the game\u2019s terms of service to ensure modding is allowed.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Download mods from trusted sources.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Install according to instructions; backup files beforehand.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "content-creators-streaming",
+          "title": "Content Creators & Streaming",
+          "source_heading": "Content Creators & Streaming",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "When players want tips for streaming Palworld",
+          "keywords": [
+            "streaming",
+            "content creator"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use streaming software (OBS, Streamlabs) to capture your gameplay.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Engage your audience by explaining mechanics and sharing tips.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Follow platform guidelines for monetization and community behavior.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "role-playing-storytelling",
+          "title": "Role-Playing & Storytelling",
+          "source_heading": "Role-Playing & Storytelling",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "Player asks about role-play opportunities",
+          "keywords": [
+            "role-play",
+            "storytelling"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Create a backstory for your character and Pals.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Build themed bases and set personal goals (e.g., conservationist, trader).",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Join RP communities to share stories.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "sharing-builds-base-tours",
+          "title": "Sharing Builds & Base Tours",
+          "source_heading": "Sharing Builds & Base Tours",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "When players want to showcase their bases",
+          "keywords": [
+            "base tour",
+            "sharing"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Capture screenshots or record video of your base.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Upload to social media or community forums.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Provide build details, resources used and design inspiration.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "accessibility-colorblind-control-options",
+          "title": "Accessibility: Colorblind & Control Options",
+          "source_heading": "Accessibility: Colorblind & Control Options",
+          "category": "Accessibility",
+          "category_group": "Social & Community",
+          "trigger": "Questions about accessible features",
+          "keywords": [
+            "accessibility",
+            "colorblind"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Open the settings menu and enable **colorblind mode** if needed.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Remap control inputs to suit your playstyle or hardware.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Adjust font sizes and contrast for easier reading.",
+              "citations": []
+            }
+          ]
+        },
+        {
+          "id": "parental-controls-safe-play",
+          "title": "Parental Controls & Safe Play",
+          "source_heading": "Parental Controls & Safe Play",
+          "category": "Social",
+          "category_group": "Social & Community",
+          "trigger": "Player asks about safe play for kids",
+          "keywords": [
+            "parental control",
+            "safety"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Use console or PC parental controls to limit play time.",
+              "citations": []
+            },
+            {
+              "order": 2,
+              "instruction": "Disable multiplayer features if necessary.",
+              "citations": []
+            },
+            {
+              "order": 3,
+              "instruction": "Monitor younger players\u2019 interactions and ensure they play in safe environments.",
+              "citations": []
+            }
+          ]
+        }
+      ]
+    }
   },
   "sourceRegistry": null,
   "extras": [

--- a/index.html
+++ b/index.html
@@ -10517,23 +10517,71 @@
       };
     }
 
-    async function loadGuideCatalog(meta){
-      if(!meta || !meta.path){
+    function cloneGuideCatalog(value){
+      if(!value || typeof value !== 'object') return null;
+      if(typeof structuredClone === 'function'){
+        try {
+          return structuredClone(value);
+        } catch(err){
+          console.warn('structuredClone failed for guide catalog; using JSON fallback.', err);
+        }
+      }
+      try {
+        return JSON.parse(JSON.stringify(value));
+      } catch(err){
+        console.warn('JSON clone failed for guide catalog fallback.', err);
         return null;
       }
-      const source = meta.path;
-      try {
-        const res = await fetch(source);
-        if(!res.ok){
-          throw new Error(`HTTP ${res.status}`);
+    }
+
+    async function loadGuideCatalog(meta){
+      const inlineData = meta && typeof meta === 'object'
+        ? (meta.inline ?? meta.data ?? null)
+        : null;
+      if(inlineData){
+        const clonedInline = cloneGuideCatalog(inlineData);
+        if(clonedInline){
+          return clonedInline;
         }
-        const payload = await res.json();
-        if(payload && typeof payload === 'object'){
-          return payload;
-        }
-      } catch(err){
-        console.warn('Failed to load guide catalog', err);
       }
+
+      const source = meta?.path;
+      if(source){
+        try {
+          const res = await fetch(source);
+          if(!res.ok){
+            throw new Error(`HTTP ${res.status}`);
+          }
+          const payload = await res.json();
+          if(payload && typeof payload === 'object'){
+            return payload;
+          }
+        } catch(err){
+          console.warn('Failed to load guide catalog', err);
+        }
+      }
+
+      const fallbackPromise = window.__GUIDE_CATALOG_FALLBACK_PROMISE__;
+      if(fallbackPromise && typeof fallbackPromise.then === 'function'){
+        try {
+          const fallback = await fallbackPromise;
+          const clonedFallback = cloneGuideCatalog(fallback);
+          if(clonedFallback){
+            return clonedFallback;
+          }
+        } catch(err){
+          console.warn('Guide catalog fallback promise rejected', err);
+        }
+      }
+
+      const fallback = window.__GUIDE_CATALOG_FALLBACK__;
+      if(fallback){
+        const cloned = cloneGuideCatalog(fallback);
+        if(cloned){
+          return cloned;
+        }
+      }
+
       return null;
     }
 

--- a/js/guide-bundle.js
+++ b/js/guide-bundle.js
@@ -1,4 +1,5 @@
 import bundle from '../data/guides.bundle.json' assert { type: 'json' };
+import guideCatalog from '../data/guide_catalog.json' assert { type: 'json' };
 
 const cloneBundle = (payload) => {
   if (!payload || typeof payload !== 'object') return null;
@@ -37,3 +38,18 @@ ready.then((data) => {
     window.__GUIDE_BUNDLE__ = data;
   }
 });
+
+const catalogReady = Promise.resolve(guideCatalog)
+  .then(cloneBundle)
+  .then((data) => {
+    if (data) {
+      window.__GUIDE_CATALOG_FALLBACK__ = data;
+    }
+    return data;
+  })
+  .catch((err) => {
+    console.error('Failed to import fallback guide catalog.', err);
+    return null;
+  });
+
+window.__GUIDE_CATALOG_FALLBACK_PROMISE__ = catalogReady;


### PR DESCRIPTION
## Summary
- embed the full guide catalog dataset directly inside the bundled guide payload so every client has offline access to all 201 encyclopedia entries
- expose the catalog bundle as a global fallback alongside the existing guide bundle loader
- update the runtime catalog loader to prefer inline data and gracefully fall back to the embedded bundle when fetch() is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd9675ffe08331a00d52799376cf07