### PR TITLE
Fix route card artwork paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -11931,7 +11931,20 @@
 
     function sanitizeImageUrl(url){
       const raw = typeof url === 'string' ? url.trim() : '';
-      const safe = raw ? raw : ROUTE_ART_IMAGE;
+      let safe = raw || ROUTE_ART_IMAGE;
+      if(!safe){
+        safe = '';
+      }
+      const lower = safe.toLowerCase();
+      const isAbsolute = /^(https?:|data:|blob:|\/{1,2})/.test(lower);
+      if(!isAbsolute){
+        // Remove leading './' segments so we can normalise relative paths cleanly.
+        safe = safe.replace(/^\.\/+/,'');
+        // Keep any existing '../' segments (some assets already specify them).
+        if(!safe.startsWith('../')){
+          safe = `../${safe}`;
+        }
+      }
       return safe.replace(/'/g, "\\'");
     }
 


### PR DESCRIPTION
## Summary
- normalise route artwork URLs so relative assets resolve outside the css folder
- ensure every guide and suggestion card on the Route page renders its artwork instead of a blank backdrop

## Testing
- [x] Manually verified the Route page in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dddb62e7c08331b9bf7af35c323db2