### PR TITLE
Add modal preview for route library search results

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -455,7 +455,7 @@ gba(119,141,169,0.45)}
 .route-library__list::-webkit-scrollbar-thumb{background:rgba(119,141,169,0.35);border-radius:999px}
 .route-library__empty{margin:0;font-size:.95rem;color:var(--muted,rgba(224,225,221,0.72));text-align:center;padding:18px 0}
 .route-library__hint,.guide-catalog__hint{margin:0;font-size:.85rem;color:rgba(224,225,221,0.65);text-align:center;padding:8px 0 0}
-.route-library-card{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:18px;padding:16px;border-radius:18px;background:rgba(12,24,40,0.74);border:1px solid rgba(119,141,169,0.26);box-shadow:0 18px 36px rgba(0,0,0,0.45);transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease}
+.route-library-card{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:18px;padding:16px;border-radius:18px;background:rgba(12,24,40,0.74);border:1px solid rgba(119,141,169,0.26);box-shadow:0 18px 36px rgba(0,0,0,0.45);transition:transform .2s ease,border-color .2s ease,box-shadow .2s ease;cursor:pointer}
 .route-library-card:hover{transform:translateY(-3px);border-color:rgba(255,255,255,0.24);box-shadow:0 24px 42px rgba(0,0,0,0.5)}
 .route-library-card__media{position:relative;width:88px;height:88px;border-radius:20px;overflow:hidden;flex:0 0 auto;background:rgba(8,16,32,0.86);box-shadow:0 18px 34px rgba(0,0,0,0.46)}
 .route-library-card__media::before{content:"";position:absolute;inset:0;background-image:linear-gradient(150deg,var(--route-visual-overlay,rgba(12,24,40,0.8)),rgba(10,20,34,0.9)),var(--route-visual-image, url('../assets/images/palworld-full-map-2.webp'));background-size:cover;background-position:center}
@@ -465,7 +465,10 @@ gba(119,141,169,0.45)}
 .route-library-card__meta{margin:0;font-size:.85rem;color:rgba(224,225,221,0.75)}
 .route-library-card__tags{display:flex;flex-wrap:wrap;gap:6px}
 .route-library-card__tag{background:rgba(119,141,169,0.2);border-color:rgba(119,141,169,0.38);font-size:.75rem}
-.route-library-card__actions{display:flex;flex-direction:column;gap:10px;align-items:flex-end}
+.route-library-card__actions{display:grid;gap:10px;justify-items:end}
+.route-library-card__preview{background:rgba(148,210,189,0.24);border-color:rgba(148,210,189,0.55);color:rgba(224,225,221,0.92);transition:background .2s ease,border-color .2s ease,color .2s ease}
+.route-library-card__preview:hover{background:rgba(148,210,189,0.32);border-color:rgba(148,210,189,0.75);color:rgba(244,247,250,0.96)}
+.route-library-card__preview:focus-visible{outline:2px solid rgba(148,210,189,0.75);outline-offset:2px;background:rgba(148,210,189,0.35);border-color:rgba(148,210,189,0.75)}
 .route-library-card__highlights{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
 .route-library-card__status{font-size:.85rem;font-weight:600;color:var(--success,#2a9d8f);background:rgba(42,157,143,0.18);padding:4px 12px;border-radius:999px}
 .route-library-card__activate{background:rgba(0,0,0,0.38);border-color:rgba(255,255,255,0.18);color:var(--text,#f0f4f8)}

--- a/index.html
+++ b/index.html
@@ -9906,6 +9906,7 @@
     let guideCatalogSearchTerm = '';
     let guideCatalogGroupFilter = 'all';
     let guideCatalogCategoryFilter = 'all';
+    let routeLibraryListAbort = null;
     let pendingRouteFocus = null;
     let pendingTechFocus = null;
     const ROUTE_ART_IMAGE = 'assets/images/palworld-full-map-2.webp';
@@ -12971,6 +12972,10 @@
       if(!list){
         return;
       }
+      if(routeLibraryListAbort){
+        routeLibraryListAbort.abort();
+        routeLibraryListAbort = null;
+      }
       const updateControlState = () => {
         document.querySelectorAll('[data-route-library-filter]').forEach(btn => {
           const key = btn.dataset.routeLibraryFilter || '';
@@ -13119,6 +13124,7 @@
       list.innerHTML = displayRoutes
         .map(entry => renderRouteLibraryCard(entry.route, { matchContext: shouldMatchContext && entry.contextMatch }))
         .join('');
+      bindRouteLibraryListInteractions(list);
       if(!usingAnyFilter && totalMatches > limit){
         const hint = kidMode
           ? 'Refine your search or filters to see more guides.'
@@ -13126,6 +13132,29 @@
         list.insertAdjacentHTML('beforeend', `<p class="route-library__hint">${escapeHTML(hint)}</p>`);
       }
       updateControlState();
+    }
+
+    function bindRouteLibraryListInteractions(list){
+      if(!list) return;
+      if(routeLibraryListAbort){
+        routeLibraryListAbort.abort();
+      }
+      routeLibraryListAbort = new AbortController();
+      const { signal } = routeLibraryListAbort;
+      list.addEventListener('click', event => {
+        const actionBtn = event.target.closest('button[data-action]');
+        if(actionBtn){
+          handleRouteClick(event);
+          return;
+        }
+        if(event.target.closest('.route-library-card__actions')) return;
+        const card = event.target.closest('.route-library-card');
+        if(!card) return;
+        const routeId = card.dataset.routeId;
+        if(!routeId) return;
+        event.preventDefault();
+        openRoutePreviewById(routeId);
+      }, { signal });
     }
 
     function renderRouteLibraryCard(route, { matchContext = false } = {}){
@@ -13155,6 +13184,7 @@
       const cardClasses = ['route-library-card'];
       if(complete) cardClasses.push('route-library-card--complete');
       if(matchContext) cardClasses.push('route-library-card--context');
+      const previewLabel = kidMode ? 'Preview guide' : 'Preview guide';
       return `
         <article class="${cardClasses.join(' ')}" data-route-id="${escapeHTML(route.id)}">
           <div class="route-library-card__media" style="--route-visual-image: url('${art.image}'); --route-visual-overlay: ${art.overlay}; --route-visual-accent: ${art.accent};">
@@ -13168,6 +13198,7 @@
           </div>
           <div class="route-library-card__actions">
             ${complete ? `<span class="route-library-card__status">${escapeHTML(kidMode ? 'Complete' : 'Complete')}</span>` : ''}
+            <button type="button" class="chip route-library-card__preview" data-action="previewRoute" data-route-id="${escapeHTML(route.id)}">${escapeHTML(previewLabel)}</button>
             <button type="button" class="chip route-library-card__activate" data-action="activateRoute" data-route-id="${escapeHTML(route.id)}">${escapeHTML(kidMode ? 'Add to queue' : 'Add to active')}</button>
           </div>
         </article>
@@ -15782,6 +15813,14 @@
       const btn = event.target.closest('button[data-action]');
       if(!btn) return;
       const action = btn.dataset.action;
+      if(action === 'previewRoute'){
+        const routeId = btn.dataset.routeId || btn.dataset.route;
+        if(routeId){
+          openRoutePreviewById(routeId);
+        }
+        event.preventDefault();
+        return;
+      }
       if(action === 'activateRoute'){
         const routeId = btn.dataset.routeId || btn.dataset.route;
         if(routeId){


### PR DESCRIPTION
## Summary
- add a preview control to each route library entry so clicking search results opens the existing guide modal
- refresh the route library card styling to reinforce the new preview action
- attach abortable listeners for the route library list so card clicks and buttons route through the preview modal logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dde1acfc488331b92cc05cd75cbf6d