### PR TITLE
Add quick select controls to goal picker

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -403,10 +403,12 @@ gba(119,141,169,0.45)}
 .route-goal-option__icon{display:grid;place-items:center;width:42px;height:42px;border-radius:14px;background:rgba(119,141,169,0.2);color:var(--accent,#778da9);font-size:1.1rem}
 .route-goal-option__label{font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.92)}
 .route-goal-option--active{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 32px rgba(148,210,189,0.2);transform:translateY(-1px)}
-.route-goal-drawer__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px}
+.route-goal-drawer__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:flex-end;gap:10px}
 .route-goal-drawer__bulk{display:flex;flex-wrap:wrap;gap:8px}
+.route-goal-drawer__bulk--quick{justify-content:flex-start;margin-bottom:12px}
 .route-goal-drawer__bulk-btn{min-height:36px;padding:6px 14px;font-size:.78rem;letter-spacing:.06em;text-transform:uppercase;background:rgba(0,0,0,0.3);border:1px solid rgba(119,141,169,0.4);color:var(--text,#f0f4f8);border-radius:999px;transition:background .2s ease,border-color .2s ease,color .2s ease}
 .route-goal-drawer__bulk-btn:hover,.route-goal-drawer__bulk-btn:focus-visible{background:rgba(0,0,0,0.45);border-color:rgba(148,210,189,0.55);color:var(--text,#f0f4f8);outline:none}
+.route-goal-drawer__bulk-btn[disabled]{opacity:.5;cursor:not-allowed;pointer-events:none}
 .route-goal-drawer__close{background:rgba(0,0,0,0.35);border-color:rgba(119,141,169,0.4);color:var(--text,#f0f4f8)}
 .route-goal-drawer__close:hover{background:rgba(0,0,0,0.45)}
 .route-goal-drawer--open .route-goal-drawer__toggle{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}

--- a/index.html
+++ b/index.html
@@ -14141,6 +14141,9 @@
       const classes = ['route-goal-drawer'];
       if(routeGoalDrawerOpen) classes.push('route-goal-drawer--open');
       const panelHiddenAttr = routeGoalDrawerOpen ? '' : ' hidden';
+      const hasGoals = tags.length > 0;
+      const allSelected = hasGoals && selectedSet.size === tags.length;
+      const anySelected = selectedSet.size > 0;
       const options = tags.map(tag => {
         const normalized = String(tag);
         const active = selectedSet.has(normalized);
@@ -14151,6 +14154,8 @@
       }).join('');
       const selectAllLabel = kidMode ? 'Select all goals' : 'Select all goals';
       const clearAllLabel = kidMode ? 'Clear goals' : 'Deselect all goals';
+      const selectAllDisabledAttr = (!hasGoals || allSelected) ? ' disabled' : '';
+      const clearAllDisabledAttr = anySelected ? '' : ' disabled';
       return `
         <div class="${classes.join(' ')}" data-goal-picker>
           <button type="button" class="route-goal-drawer__toggle" data-goal-toggle aria-expanded="${routeGoalDrawerOpen ? 'true' : 'false'}" aria-label="${escapeHTML(`${toggleLabel}: ${summary}`)}" title="${escapeHTML(summary)}">
@@ -14158,14 +14163,14 @@
             <div class="route-goal-drawer__summary" data-goal-summary data-goal-summary-text="${escapeHTML(summary)}">${summaryMarkup}</div>
           </button>
           <div class="route-goal-drawer__panel"${panelHiddenAttr}>
+            <div class="route-goal-drawer__bulk route-goal-drawer__bulk--quick">
+              <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="select-all"${selectAllDisabledAttr}>${escapeHTML(selectAllLabel)}</button>
+              <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="clear"${clearAllDisabledAttr}>${escapeHTML(clearAllLabel)}</button>
+            </div>
             <div class="route-goal-drawer__list">
               ${options}
             </div>
             <div class="route-goal-drawer__footer">
-              <div class="route-goal-drawer__bulk">
-                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="select-all">${escapeHTML(selectAllLabel)}</button>
-                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="clear">${escapeHTML(clearAllLabel)}</button>
-              </div>
               <button type="button" class="chip route-goal-drawer__close" data-goal-close>${escapeHTML(kidMode ? 'Done picking' : 'Lock selections')}</button>
             </div>
           </div>
@@ -14633,6 +14638,7 @@
         });
         goalPicker.querySelectorAll('[data-goal-bulk]').forEach(btn => {
           btn.addEventListener('click', () => {
+            if(btn.disabled) return;
             const action = btn.dataset.goalBulk;
             const boxes = Array.from(goalPicker.querySelectorAll('[data-context-goal]'));
             if(!boxes.length) return;


### PR DESCRIPTION
## Summary
- surface select-all and clear-all controls at the top of the goal picker to make bulk changes quicker
- disable bulk action buttons when the action isn’t applicable and update styling to fit the new layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de6964d80c8331af297e720eb98371