### PR TITLE
Refine Tonight’s goals quick actions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -377,16 +377,25 @@ gba(119,141,169,0.45)}
 .route-context__toggle{border:1px solid rgba(119,141,169,0.35);background:rgba(119,141,169,0.18);color:var(--text,#f0f4f8);padding:8px 14px;border-radius:999px;font-weight:600;cursor:pointer;transition:background .2s ease,border-color .2s ease}
 .route-context__toggle--active{background:rgba(42,157,143,0.25);border-color:rgba(42,157,143,0.6)}
 .route-context__goals{position:relative}
-.route-goal-drawer{position:relative;display:grid;gap:10px}
-.route-goal-drawer__toggle{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:10px;width:100%;padding:16px 18px;border-radius:18px;background:linear-gradient(135deg,rgba(42,157,143,0.22),rgba(17,36,60,0.92));border:1px solid rgba(119,141,169,0.45);color:var(--text,#f0f4f8);cursor:pointer;box-shadow:0 0 24px rgba(42,157,143,0.35);transition:box-shadow .25s ease,transform .25s ease,border-color .25s ease}
-.route-goal-drawer__toggle::before{content:"";position:absolute;inset:-1px;border-radius:inherit;background:radial-gradient(circle at top left,rgba(148,210,189,0.45),rgba(148,210,189,0)60%);opacity:.7;pointer-events:none;transition:opacity .3s ease}
-.route-goal-drawer__toggle:hover,.route-goal-drawer__toggle:focus-visible{transform:translateY(-1px);box-shadow:0 0 28px rgba(119,141,169,0.5);border-color:rgba(148,210,189,0.7);outline:none}
-.route-goal-drawer__toggle:hover::before,.route-goal-drawer__toggle:focus-visible::before{opacity:1}
+.route-goal-drawer{position:relative;display:grid;gap:14px}
+.route-goal-drawer__surface{position:relative;display:flex;flex-direction:column;gap:18px;padding:20px 22px;border-radius:20px;background:linear-gradient(135deg,rgba(42,157,143,0.22),rgba(17,36,60,0.92));border:1px solid rgba(119,141,169,0.45);color:var(--text,#f0f4f8);box-shadow:0 0 24px rgba(42,157,143,0.35);transition:box-shadow .25s ease,border-color .25s ease}
+.route-goal-drawer__surface::before{content:"";position:absolute;inset:-1px;border-radius:inherit;background:radial-gradient(circle at top left,rgba(148,210,189,0.45),rgba(148,210,189,0)60%);opacity:.7;pointer-events:none;transition:opacity .3s ease}
+.route-goal-drawer__surface:focus-within,.route-goal-drawer__surface:hover{box-shadow:0 0 28px rgba(119,141,169,0.5);border-color:rgba(148,210,189,0.7)}
+.route-goal-drawer__surface:focus-within::before,.route-goal-drawer__surface:hover::before{opacity:1}
+.route-goal-drawer__header{display:flex;flex-wrap:wrap;align-items:flex-start;gap:16px}
+.route-goal-drawer__title-block{display:flex;flex-direction:column;gap:10px;flex:1 1 220px}
 .route-goal-drawer__title{font-size:.82rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.72)}
-.route-goal-drawer__summary{position:relative;display:flex;flex-wrap:wrap;align-items:center;gap:8px;width:100%;min-height:42px;padding:10px 12px;border-radius:14px;background:linear-gradient(135deg,rgba(11,26,44,0.92),rgba(12,32,54,0.88));box-shadow:0 0 18px rgba(42,157,143,0.35);border:1px solid rgba(119,141,169,0.35)}
-.route-goal-summary__placeholder{font-size:1rem;font-weight:600;color:rgba(224,225,221,0.78)}
-.route-goal-summary__chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(42,157,143,0.18);border:1px solid rgba(148,210,189,0.65);box-shadow:0 6px 16px rgba(0,0,0,0.35);font-size:.85rem;font-weight:600;color:rgba(224,225,221,0.92);letter-spacing:.03em;text-transform:capitalize}
-.route-goal-summary__chip--more{background:rgba(148,210,189,0.22);border-color:rgba(148,210,189,0.85);color:rgba(255,255,255,0.92)}
+.route-goal-drawer__summary{position:relative;display:flex;align-items:center;gap:10px;width:100%;min-height:46px;padding:12px 16px;border-radius:14px;background:linear-gradient(135deg,rgba(11,26,44,0.92),rgba(12,32,54,0.88));box-shadow:0 0 18px rgba(42,157,143,0.35);border:1px solid rgba(119,141,169,0.35)}
+.route-goal-summary__count{font-size:1.05rem;font-weight:650;letter-spacing:.04em;color:rgba(224,225,221,0.92)}
+.route-goal-summary__count--empty{color:rgba(224,225,221,0.65)}
+.route-goal-drawer__manage{display:inline-flex;align-items:center;gap:8px;padding:10px 18px;border-radius:999px;border:1px solid rgba(119,141,169,0.4);background:rgba(0,0,0,0.25);color:var(--text,#f0f4f8);font-size:.8rem;letter-spacing:.08em;text-transform:uppercase;cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease,box-shadow .2s ease}
+.route-goal-drawer__manage:hover,.route-goal-drawer__manage:focus-visible{background:rgba(0,0,0,0.4);border-color:rgba(148,210,189,0.55);color:var(--text,#f0f4f8);box-shadow:0 0 0 2px rgba(148,210,189,0.3);outline:none}
+.route-goal-drawer__manage i{font-size:.9rem}
+.route-goal-drawer__actions{display:flex;flex-wrap:wrap;align-items:center;gap:10px}
+.route-goal-drawer__action{min-height:38px;padding:8px 18px;font-size:.78rem;letter-spacing:.06em;text-transform:uppercase;background:rgba(0,0,0,0.3);border:1px solid rgba(119,141,169,0.4);color:var(--text,#f0f4f8);border-radius:999px;transition:background .2s ease,border-color .2s ease,color .2s ease,box-shadow .2s ease}
+.route-goal-drawer__action:hover,.route-goal-drawer__action:focus-visible{background:rgba(0,0,0,0.45);border-color:rgba(148,210,189,0.55);color:var(--text,#f0f4f8);outline:none;box-shadow:0 0 0 2px rgba(148,210,189,0.25)}
+.route-goal-drawer__action--primary{background:rgba(148,210,189,0.2);border-color:rgba(148,210,189,0.6);color:rgba(255,255,255,0.95)}
+.route-goal-drawer__action--primary:hover,.route-goal-drawer__action--primary:focus-visible{background:rgba(148,210,189,0.3);border-color:rgba(148,210,189,0.75);color:#fff}
 .route-goal-drawer__panel{position:relative;border-radius:20px;padding:18px;background:linear-gradient(150deg,rgba(13,27,42,0.95),rgba(8,18,34,0.88));border:1px solid rgba(119,141,169,0.4);box-shadow:0 28px 52px rgba(0,0,0,0.55),0 0 36px rgba(42,157,143,0.4);display:grid;gap:14px;max-height:320px;overflow:auto}
 .route-goal-drawer__panel::before{content:"";position:absolute;inset:0;border-radius:inherit;background:radial-gradient(circle at top right,rgba(148,210,189,0.28),rgba(148,210,189,0)65%);pointer-events:none}
 .route-goal-drawer__panel[hidden]{display:none}
@@ -403,13 +412,7 @@ gba(119,141,169,0.45)}
 .route-goal-option__icon{display:grid;place-items:center;width:42px;height:42px;border-radius:14px;background:rgba(119,141,169,0.2);color:var(--accent,#778da9);font-size:1.1rem}
 .route-goal-option__label{font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.92)}
 .route-goal-option--active{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 32px rgba(148,210,189,0.2);transform:translateY(-1px)}
-.route-goal-drawer__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px}
-.route-goal-drawer__bulk{display:flex;flex-wrap:wrap;gap:8px}
-.route-goal-drawer__bulk-btn{min-height:36px;padding:6px 14px;font-size:.78rem;letter-spacing:.06em;text-transform:uppercase;background:rgba(0,0,0,0.3);border:1px solid rgba(119,141,169,0.4);color:var(--text,#f0f4f8);border-radius:999px;transition:background .2s ease,border-color .2s ease,color .2s ease}
-.route-goal-drawer__bulk-btn:hover,.route-goal-drawer__bulk-btn:focus-visible{background:rgba(0,0,0,0.45);border-color:rgba(148,210,189,0.55);color:var(--text,#f0f4f8);outline:none}
-.route-goal-drawer__close{background:rgba(0,0,0,0.35);border-color:rgba(119,141,169,0.4);color:var(--text,#f0f4f8)}
-.route-goal-drawer__close:hover{background:rgba(0,0,0,0.45)}
-.route-goal-drawer--open .route-goal-drawer__toggle{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}
+.route-goal-drawer--open .route-goal-drawer__surface{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}
 .route-context__resources{display:grid;gap:10px}
 .route-context__resource-add{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
 .route-context__resource-add select,.route-context__resource-add input{background:rgba(13,27,42,0.6);border:1px solid rgba(119,141,169,0.35);border-radius:10px;color:var(--text,#f0f4f8);padding:8px 12px;font-size:.95rem;min-width:160px;transition:border-color .2s ease,box-shadow .2s ease}

--- a/index.html
+++ b/index.html
@@ -14111,26 +14111,24 @@
     }
 
     function formatGoalSummary(goals){
-      if(!Array.isArray(goals) || !goals.length){
-        return kidMode ? 'Tap to pick tonight’s goals' : 'Tap to pick tonight’s goals';
+      const selection = Array.isArray(goals) ? goals.filter(Boolean) : [];
+      if(!selection.length){
+        return kidMode ? 'No goals selected yet' : 'No goals selected yet';
       }
-      const labels = goals.slice(0, 3).map(goal => capitalize(goal));
-      const remainder = goals.length - labels.length;
-      const suffix = remainder > 0 ? ` +${remainder}` : '';
-      return `${labels.join(', ')}${suffix}`;
+      if(selection.length === 1){
+        return kidMode ? '1 goal selected' : '1 focus selected';
+      }
+      return kidMode
+        ? `${selection.length} goals selected`
+        : `${selection.length} focuses selected`;
     }
 
     function renderGoalSummaryMarkup(goals){
-      if(!Array.isArray(goals) || !goals.length){
-        const label = kidMode ? 'Tap to pick tonight’s goals' : 'Tap to pick tonight’s goals';
-        return `<span class="route-goal-summary__placeholder">${escapeHTML(label)}</span>`;
-      }
-      const chips = goals.slice(0, 3).map(goal => `<span class="route-goal-summary__chip">${escapeHTML(capitalize(goal))}</span>`);
-      const remainder = goals.length - chips.length;
-      if(remainder > 0){
-        chips.push(`<span class="route-goal-summary__chip route-goal-summary__chip--more">+${remainder}</span>`);
-      }
-      return chips.join('');
+      const summaryLabel = formatGoalSummary(goals);
+      const empty = !Array.isArray(goals) || !goals.length;
+      const classes = ['route-goal-summary__count'];
+      if(empty) classes.push('route-goal-summary__count--empty');
+      return `<span class="${classes.join(' ')}">${escapeHTML(summaryLabel)}</span>`;
     }
 
     function renderGoalDrawer(tags, selectedGoals){
@@ -14151,22 +14149,30 @@
       }).join('');
       const selectAllLabel = kidMode ? 'Select all goals' : 'Select all goals';
       const clearAllLabel = kidMode ? 'Clear goals' : 'Deselect all goals';
+      const manageLabel = kidMode ? 'Browse goals' : 'Manage goals';
+      const summaryHint = kidMode ? 'Focus areas update recommendations instantly.' : 'Adjusting goals tunes every recommendation.';
       return `
         <div class="${classes.join(' ')}" data-goal-picker>
-          <button type="button" class="route-goal-drawer__toggle" data-goal-toggle aria-expanded="${routeGoalDrawerOpen ? 'true' : 'false'}" aria-label="${escapeHTML(`${toggleLabel}: ${summary}`)}" title="${escapeHTML(summary)}">
-            <span class="route-goal-drawer__title">${escapeHTML(toggleLabel)}</span>
-            <div class="route-goal-drawer__summary" data-goal-summary data-goal-summary-text="${escapeHTML(summary)}">${summaryMarkup}</div>
-          </button>
+          <div class="route-goal-drawer__surface">
+            <div class="route-goal-drawer__header">
+              <div class="route-goal-drawer__title-block">
+                <span class="route-goal-drawer__title">${escapeHTML(toggleLabel)}</span>
+                <div class="route-goal-drawer__summary" data-goal-summary data-goal-summary-text="${escapeHTML(summary)}" title="${escapeHTML(summaryHint)}">${summaryMarkup}</div>
+              </div>
+              <button type="button" class="route-goal-drawer__manage" data-goal-toggle aria-expanded="${routeGoalDrawerOpen ? 'true' : 'false'}" aria-label="${escapeHTML(`${toggleLabel}: ${summary}`)}">
+                <span>${escapeHTML(manageLabel)}</span>
+                <i class="fa-solid fa-chevron-${routeGoalDrawerOpen ? 'up' : 'down'}" data-goal-toggle-icon></i>
+              </button>
+            </div>
+            <div class="route-goal-drawer__actions">
+              <button type="button" class="chip route-goal-drawer__action" data-goal-bulk="select-all">${escapeHTML(selectAllLabel)}</button>
+              <button type="button" class="chip route-goal-drawer__action" data-goal-bulk="clear">${escapeHTML(clearAllLabel)}</button>
+              <button type="button" class="chip route-goal-drawer__action route-goal-drawer__action--primary" data-goal-close>${escapeHTML(kidMode ? 'Done picking' : 'Lock selections')}</button>
+            </div>
+          </div>
           <div class="route-goal-drawer__panel"${panelHiddenAttr}>
             <div class="route-goal-drawer__list">
               ${options}
-            </div>
-            <div class="route-goal-drawer__footer">
-              <div class="route-goal-drawer__bulk">
-                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="select-all">${escapeHTML(selectAllLabel)}</button>
-                <button type="button" class="chip route-goal-drawer__bulk-btn" data-goal-bulk="clear">${escapeHTML(clearAllLabel)}</button>
-              </div>
-              <button type="button" class="chip route-goal-drawer__close" data-goal-close>${escapeHTML(kidMode ? 'Done picking' : 'Lock selections')}</button>
             </div>
           </div>
         </div>
@@ -14596,6 +14602,7 @@
       const goalPicker = card.querySelector('[data-goal-picker]');
       if(goalPicker){
         const toggle = goalPicker.querySelector('[data-goal-toggle]');
+        const toggleIcon = goalPicker.querySelector('[data-goal-toggle-icon]');
         const panel = goalPicker.querySelector('.route-goal-drawer__panel');
         const applyDrawerState = () => {
           goalPicker.classList.toggle('route-goal-drawer--open', routeGoalDrawerOpen);
@@ -14608,6 +14615,10 @@
           }
           if(toggle){
             toggle.setAttribute('aria-expanded', routeGoalDrawerOpen ? 'true' : 'false');
+          }
+          if(toggleIcon){
+            toggleIcon.classList.toggle('fa-chevron-up', routeGoalDrawerOpen);
+            toggleIcon.classList.toggle('fa-chevron-down', !routeGoalDrawerOpen);
           }
         };
         if(toggle){


### PR DESCRIPTION
## Summary
- Surface Tonight’s Goals management controls prominently with a refreshed layout and count-based summary
- Style the goal picker card and quick action chips to match the premium route dashboard aesthetic while keeping the drawer interactions intact
- Keep the manage toggle responsive with an animated chevron indicator and accessible status messaging

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de83967eb4833192652a5f3ae430d4