### PR TITLE
Add Gold Coin Treasury Circuit resource route

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -99,6 +99,8 @@ This document describes the responsibilities, workflows and quality assurance st
 
 *Progress 2025-10-21:* Delivered Chikipi Poultry Harvest Loop (`resource-chikipi-poultry`) covering Windswept Hills capture sweeps, Meat Cleaver butchery, and pantry/ranch balancing, synchronized `data/guides.bundle.json`, and logged new source transcripts for the cleaver and Chikipi drops.【palwiki-chikipi†L9-L76】【palwiki-meat-cleaver†L20-L41】
   * Next steps: source sanctuary-specific citations so Woolipop/Cotton Candy automation can ship, identify reliable field locations for Galeclaw poultry and Caprity meat (two independent sources per spawn), and expand the pantry chain with preservation infrastructure once storage references surface.
+*Progress 2025-10-22:* Built Gold Coin Treasury Circuit (`resource-gold-coin`) to chain Mau night hunts, Vixy/Mau ranch automation, and Small Settlement merchant sell loops; synchronized `guides.md` and `data/guides.bundle.json`, registered new wiki citations for Mau and Gold Coin economy coverage, and extracted fresh raw transcripts into `sources/`.【palwiki-mau-raw†L11-L115】【palwiki-gold-coin-raw†L3-L28】【palwiki-gold-coin†L28-L44】【palwiki-wandering-merchant-raw†L1-L119】
+  * Next steps: secure independent coverage for treasure chest coin routes and PIDF incident timers, gather spawn citations for Galeclaw poultry and Caprity meat to unlock their meat guides, and trace merchant restock cadence so the currency loop can feed higher-tier refinery routes.
 
 ## Performance Notes
 

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -14489,6 +14489,385 @@
       ]
     },
     {
+      "route_id": "resource-gold-coin",
+      "title": "Gold Coin Treasury Circuit",
+      "category": "resources",
+      "tags": [
+        "resource-farm",
+        "gold-coin",
+        "currency",
+        "economy"
+      ],
+      "progression_role": "support",
+      "recommended_level": {
+        "min": 12,
+        "max": 30
+      },
+      "modes": {
+        "normal": true,
+        "hardcore": true,
+        "solo": true,
+        "coop": true
+      },
+      "prerequisites": {
+        "routes": [
+          "starter-base-capture"
+        ],
+        "tech": [
+          "ranch"
+        ],
+        "items": [],
+        "pals": []
+      },
+      "objectives": [
+        "Hunt Windswept Hills camps for Mau captures and coin drops",
+        "Assign Mau and Vixy to ranch slots for passive coin income",
+        "Sell surplus loot to settlement merchants and sweep chests between payouts"
+      ],
+      "estimated_time_minutes": {
+        "solo": 38,
+        "coop": 26
+      },
+      "estimated_xp_gain": {
+        "min": 220,
+        "max": 340
+      },
+      "risk_profile": "medium",
+      "failure_penalties": {
+        "normal": "Getting downed by faction patrols drops coin hauls and consumables needed for later merchant buys.",
+        "hardcore": "Hardcore wipes while escorting merchants can delete Mau/Vixy producers and stall your entire economy for hours."
+      },
+      "adaptive_guidance": {
+        "underleveled": "Stage near the Small Settlement statue and focus on Vixy captures before pushing into night camps for Mau coins.\u3010palwiki-small-settlement\u2020L1-L9\u3011\u3010palwiki-vixy\u2020L118-L176\u3011",
+        "overleveled": "Chain dungeon clears with settlement sell runs so every patrol and chest becomes coin yield, not wasted time.\u3010palwiki-mau-raw\u2020L109-L114\u3011\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011",
+        "resource_shortages": [
+          {
+            "item_id": "gold-coin",
+            "solution": "Rotate Mau and Vixy through the ranch before departing so Gold Digger and Dig Here! keep banking coins between raids.\u3010palwiki-mau-raw\u2020L11-L115\u3011\u3010palwiki-vixy\u2020L118-L176\u3011"
+          }
+        ],
+        "time_limited": "Sell high-value drops at the Small Settlement merchant each pass, then sprint back to base before raids hit.\u3010palwiki-wandering-merchant-raw\u2020L24-L119\u3011",
+        "dynamic_rules": [
+          {
+            "signal": "mode:coop",
+            "condition": "mode.coop === true",
+            "adjustment": "Assign one player to escort merchants while the partner clears patrols and ferries loot to storage.",
+            "priority": 1,
+            "mode_scope": [
+              "coop"
+            ],
+            "related_steps": [
+              "resource-gold-coin:003",
+              "resource-gold-coin:004"
+            ]
+          }
+        ]
+      },
+      "checkpoints": [
+        {
+          "id": "resource-gold-coin:checkpoint-captures",
+          "label": "Mau Captured and Routed",
+          "includes": [
+            "resource-gold-coin:001"
+          ]
+        },
+        {
+          "id": "resource-gold-coin:checkpoint-ranch",
+          "label": "Ranch Automation Paying Out",
+          "includes": [
+            "resource-gold-coin:002"
+          ]
+        },
+        {
+          "id": "resource-gold-coin:checkpoint-ledger",
+          "label": "Merchant Sales Loop",
+          "includes": [
+            "resource-gold-coin:003",
+            "resource-gold-coin:004"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "step_id": "resource-gold-coin:001",
+          "type": "capture",
+          "summary": "Sweep Windswept Hills nights for Mau",
+          "detail": "Teleport to the Small Settlement (75,-479), clear nearby faction camps, and dive Windswept Hills dungeons at night to capture at least two Mau for coin production and drops.\u3010palwiki-small-settlement\u2020L1-L9\u3011\u3010palwiki-mau-raw\u2020L11-L115\u3011",
+          "targets": [
+            {
+              "kind": "pal",
+              "id": "mau",
+              "qty": 2
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "windswept-hills",
+              "coords": [
+                75,
+                -479
+              ],
+              "time": "night",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Use higher-tier spheres and disengage if multiple patrol waves stack to avoid losing coin drops.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "mega-sphere"
+            ],
+            "pals": [
+              "rushoar"
+            ],
+            "consumables": [
+              "paldium-fragment"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 140,
+            "max": 210
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "gold-coin",
+                "qty": 200
+              }
+            ],
+            "pals": [
+              "mau"
+            ],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-small-settlement",
+            "palwiki-mau-raw"
+          ]
+        },
+        {
+          "step_id": "resource-gold-coin:002",
+          "type": "assign",
+          "summary": "Automate Mau and Vixy at the ranch",
+          "detail": "Assign Mau and Vixy to ranch slots so Gold Digger and Dig Here! continuously dig coins, spheres, and arrows between field runs.\u3010palwiki-mau-raw\u2020L11-L115\u3011\u3010palwiki-vixy\u2020L118-L176\u3011\u3010palwiki-gold-coin-raw\u2020L20-L27\u3011",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "gold-coin",
+              "qty": 120
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "base",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {},
+          "recommended_loadout": {
+            "gear": [],
+            "pals": [
+              "mau",
+              "vixy"
+            ],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 50,
+            "max": 80
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "gold-coin",
+                "qty": 120
+              }
+            ],
+            "pals": [
+              "mau",
+              "vixy"
+            ],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-mau-raw",
+            "palwiki-vixy",
+            "palwiki-gold-coin-raw"
+          ]
+        },
+        {
+          "step_id": "resource-gold-coin:003",
+          "type": "trade",
+          "summary": "Sell loot to settlement merchants",
+          "detail": "Haul crafted goods, spare bones, and excess pals to the Small Settlement merchants to convert inventory into gold coins before the next hunt.\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011\u3010palwiki-gold-coin\u2020L28-L44\u3011\u3010palwiki-wandering-merchant-raw\u2020L1-L119\u3011",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "gold-coin",
+              "qty": 300
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "windswept-hills",
+              "coords": [
+                75,
+                -479
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "coop": {
+              "role_splits": [
+                {
+                  "role": "quartermaster",
+                  "tasks": "Handle trades and track merchant inventory"
+                },
+                {
+                  "role": "runner",
+                  "tasks": "Escort goods and restock ranch pals"
+                }
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "inventory-pouch"
+            ],
+            "pals": [
+              "mau"
+            ],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 40,
+            "max": 60
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "gold-coin",
+                "qty": 300
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-gold-coin-raw",
+            "palwiki-gold-coin",
+            "palwiki-wandering-merchant-raw"
+          ]
+        },
+        {
+          "step_id": "resource-gold-coin:004",
+          "type": "combat",
+          "summary": "Clear patrols and open chests along the circuit",
+          "detail": "Sweep the crossroads between merchant stops, eliminate Syndicate patrols, and crack open treasure chests to top off coins between ranch payouts.\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011\u3010palwiki-wandering-merchant-raw\u2020L12-L18\u3011",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "gold-coin",
+              "qty": 80
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "windswept-hills",
+              "coords": [
+                60,
+                -440
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Break line of sight after each incident to avoid overlapping patrol aggro before regrouping.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "metal-spear"
+            ],
+            "pals": [
+              "anubis"
+            ],
+            "consumables": [
+              "medical-supplies"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 60,
+            "max": 90
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "gold-coin",
+                "qty": 80
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-gold-coin-raw",
+            "palwiki-wandering-merchant-raw"
+          ]
+        }
+      ],
+      "completion_criteria": [
+        {
+          "type": "have-item",
+          "item_id": "gold-coin",
+          "qty": 500
+        }
+      ],
+      "yields": {
+        "levels_estimate": "+0 to +1",
+        "key_unlocks": [
+          "merchant-funding"
+        ]
+      },
+      "metrics": {
+        "progress_segments": 4,
+        "boss_targets": 0,
+        "quest_nodes": 0
+      },
+      "next_routes": [
+        {
+          "route_id": "resource-refined-ingot",
+          "reason": "Refined ingot upgrades demand heavy merchant spending, so a coin surplus keeps furnaces online."
+        },
+        {
+          "route_id": "resource-milk",
+          "reason": "Milk and bakery chains buy daily from settlement merchants; bank coins to keep dairies stocked."
+        }
+      ]
+    },
+    {
       "route_id": "resource-ore",
       "title": "Ore Mining Grid",
       "category": "resources",
@@ -28644,6 +29023,24 @@
           "url": "https://palworld.wiki.gg/wiki/Vixy",
           "access_date": "2025-10-18",
           "notes": "Shows Dig Here! produces items at the ranch and that Vixy drops Bone and Leather at 100% rates.\u3010palwiki-vixy\u2020L9-L49\u3011"
+        },
+        "palwiki-mau-raw": {
+          "title": "Mau – Palworld Wiki",
+          "url": "https://palworld.wiki.gg/wiki/Mau",
+          "access_date": "2025-10-21",
+          "notes": "Confirms Mau’s Gold Digger partner skill digs coins, lists coin drop amounts, and notes it spawns in Windswept Hills dungeons or faction camps.\u3010palwiki-mau-raw\u2020L11-L115\u3011"
+        },
+        "palwiki-gold-coin-raw": {
+          "title": "Gold Coin – Palworld Wiki",
+          "url": "https://palworld.wiki.gg/wiki/Gold_Coin",
+          "access_date": "2025-10-21",
+          "notes": "States Gold Coins are traded currency and can be earned by selling items or pals, defeating human mobs, opening chests, or ranching Mau, Mau Cryst, and Vixy.\u3010palwiki-gold-coin-raw\u2020L3-L28\u3011"
+        },
+        "palwiki-gold-coin": {
+          "title": "Gold Coin – Palworld Wiki (Fandom)",
+          "url": "https://palworld.fandom.com/wiki/Gold_Coin",
+          "access_date": "2025-10-21",
+          "notes": "Lists merchant sales, Syndicate drops, and ranch producers (Mau, Mau Cryst, Vixy) for Gold Coins.\u3010palwiki-gold-coin\u2020L28-L44\u3011"
         },
         "palwiki-nail": {
           "title": "Nail \u2013 Palworld Wiki",

--- a/guides.md
+++ b/guides.md
@@ -21518,6 +21518,392 @@ help players understand why a route is suggested.
 }
 ```
 
+### Route: Gold Coin Treasury Circuit
+
+Gold Coin Treasury Circuit chains Mau night raids, Vixy ranch digs, and settlement sell runs so your economy keeps pace with merchant schematics and tech unlocks.【palwiki-mau-raw†L11-L115】【palwiki-vixy†L118-L176】【palwiki-gold-coin-raw†L20-L28】【palwiki-wandering-merchant-raw†L1-L119】
+
+```json
+{
+  "route_id": "resource-gold-coin",
+  "title": "Gold Coin Treasury Circuit",
+  "category": "resources",
+  "tags": [
+    "resource-farm",
+    "gold-coin",
+    "currency",
+    "economy"
+  ],
+  "progression_role": "support",
+  "recommended_level": {
+    "min": 12,
+    "max": 30
+  },
+  "modes": {
+    "normal": true,
+    "hardcore": true,
+    "solo": true,
+    "coop": true
+  },
+  "prerequisites": {
+    "routes": [
+      "starter-base-capture"
+    ],
+    "tech": [
+      "ranch"
+    ],
+    "items": [],
+    "pals": []
+  },
+  "objectives": [
+    "Hunt Windswept Hills camps for Mau captures and coin drops",
+    "Assign Mau and Vixy to ranch slots for passive coin income",
+    "Sell surplus loot to settlement merchants and sweep chests between payouts"
+  ],
+  "estimated_time_minutes": {
+    "solo": 38,
+    "coop": 26
+  },
+  "estimated_xp_gain": {
+    "min": 220,
+    "max": 340
+  },
+  "risk_profile": "medium",
+  "failure_penalties": {
+    "normal": "Getting downed by faction patrols drops coin hauls and consumables needed for later merchant buys.",
+    "hardcore": "Hardcore wipes while escorting merchants can delete Mau/Vixy producers and stall your entire economy for hours."
+  },
+  "adaptive_guidance": {
+    "underleveled": "Stage near the Small Settlement statue and focus on Vixy captures before pushing into night camps for Mau coins.【palwiki-small-settlement†L1-L9】【palwiki-vixy†L118-L176】",
+    "overleveled": "Chain dungeon clears with settlement sell runs so every patrol and chest becomes coin yield, not wasted time.【palwiki-mau-raw†L109-L114】【palwiki-gold-coin-raw†L20-L28】",
+    "resource_shortages": [
+      {
+        "item_id": "gold-coin",
+        "solution": "Rotate Mau and Vixy through the ranch before departing so Gold Digger and Dig Here! keep banking coins between raids.【palwiki-mau-raw†L11-L115】【palwiki-vixy†L118-L176】"
+      }
+    ],
+    "time_limited": "Sell high-value drops at the Small Settlement merchant each pass, then sprint back to base before raids hit.【palwiki-wandering-merchant-raw†L24-L119】",
+    "dynamic_rules": [
+      {
+        "signal": "mode:coop",
+        "condition": "mode.coop === true",
+        "adjustment": "Assign one player to escort merchants while the partner clears patrols and ferries loot to storage.",
+        "priority": 1,
+        "mode_scope": [
+          "coop"
+        ],
+        "related_steps": [
+          "resource-gold-coin:003",
+          "resource-gold-coin:004"
+        ]
+      }
+    ]
+  },
+  "checkpoints": [
+    {
+      "id": "resource-gold-coin:checkpoint-captures",
+      "label": "Mau Captured and Routed",
+      "includes": [
+        "resource-gold-coin:001"
+      ]
+    },
+    {
+      "id": "resource-gold-coin:checkpoint-ranch",
+      "label": "Ranch Automation Paying Out",
+      "includes": [
+        "resource-gold-coin:002"
+      ]
+    },
+    {
+      "id": "resource-gold-coin:checkpoint-ledger",
+      "label": "Merchant Sales Loop",
+      "includes": [
+        "resource-gold-coin:003",
+        "resource-gold-coin:004"
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "step_id": "resource-gold-coin:001",
+      "type": "capture",
+      "summary": "Sweep Windswept Hills nights for Mau",
+      "detail": "Teleport to the Small Settlement (75,-479), clear nearby faction camps, and dive Windswept Hills dungeons at night to capture at least two Mau for coin production and drops.【palwiki-small-settlement†L1-L9】【palwiki-mau-raw†L11-L115】",
+      "targets": [
+        {
+          "kind": "pal",
+          "id": "mau",
+          "qty": 2
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "windswept-hills",
+          "coords": [
+            75,
+            -479
+          ],
+          "time": "night",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Use higher-tier spheres and disengage if multiple patrol waves stack to avoid losing coin drops.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "mega-sphere"
+        ],
+        "pals": [
+          "rushoar"
+        ],
+        "consumables": [
+          "paldium-fragment"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 140,
+        "max": 210
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "gold-coin",
+            "qty": 200
+          }
+        ],
+        "pals": [
+          "mau"
+        ],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-small-settlement",
+        "palwiki-mau-raw"
+      ]
+    },
+    {
+      "step_id": "resource-gold-coin:002",
+      "type": "assign",
+      "summary": "Automate Mau and Vixy at the ranch",
+      "detail": "Assign Mau and Vixy to ranch slots so Gold Digger and Dig Here! continuously dig coins, spheres, and arrows between field runs.【palwiki-mau-raw†L11-L115】【palwiki-vixy†L118-L176】【palwiki-gold-coin-raw†L20-L27】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "gold-coin",
+          "qty": 120
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "base",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {},
+      "recommended_loadout": {
+        "gear": [],
+        "pals": [
+          "mau",
+          "vixy"
+        ],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 50,
+        "max": 80
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "gold-coin",
+            "qty": 120
+          }
+        ],
+        "pals": [
+          "mau",
+          "vixy"
+        ],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-mau-raw",
+        "palwiki-vixy",
+        "palwiki-gold-coin-raw"
+      ]
+    },
+    {
+      "step_id": "resource-gold-coin:003",
+      "type": "trade",
+      "summary": "Sell loot to settlement merchants",
+      "detail": "Haul crafted goods, spare bones, and excess pals to the Small Settlement merchants to convert inventory into gold coins before the next hunt.【palwiki-gold-coin-raw†L20-L28】【palwiki-gold-coin†L28-L44】【palwiki-wandering-merchant-raw†L1-L119】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "gold-coin",
+          "qty": 300
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "windswept-hills",
+          "coords": [
+            75,
+            -479
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "coop": {
+          "role_splits": [
+            {
+              "role": "quartermaster",
+              "tasks": "Handle trades and track merchant inventory"
+            },
+            {
+              "role": "runner",
+              "tasks": "Escort goods and restock ranch pals"
+            }
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "inventory-pouch"
+        ],
+        "pals": [
+          "mau"
+        ],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 40,
+        "max": 60
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "gold-coin",
+            "qty": 300
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-gold-coin-raw",
+        "palwiki-gold-coin",
+        "palwiki-wandering-merchant-raw"
+      ]
+    },
+    {
+      "step_id": "resource-gold-coin:004",
+      "type": "combat",
+      "summary": "Clear patrols and open chests along the circuit",
+      "detail": "Sweep the crossroads between merchant stops, eliminate Syndicate patrols, and crack open treasure chests to top off coins between ranch payouts.【palwiki-gold-coin-raw†L20-L28】【palwiki-wandering-merchant-raw†L12-L18】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "gold-coin",
+          "qty": 80
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "windswept-hills",
+          "coords": [
+            60,
+            -440
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Break line of sight after each incident to avoid overlapping patrol aggro before regrouping.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "metal-spear"
+        ],
+        "pals": [
+          "anubis"
+        ],
+        "consumables": [
+          "medical-supplies"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 60,
+        "max": 90
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "gold-coin",
+            "qty": 80
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-gold-coin-raw",
+        "palwiki-wandering-merchant-raw"
+      ]
+    }
+  ],
+  "completion_criteria": [
+    {
+      "type": "have-item",
+      "item_id": "gold-coin",
+      "qty": 500
+    }
+  ],
+  "yields": {
+    "levels_estimate": "+0 to +1",
+    "key_unlocks": [
+      "merchant-funding"
+    ]
+  },
+  "metrics": {
+    "progress_segments": 4,
+    "boss_targets": 0,
+    "quest_nodes": 0
+  },
+  "next_routes": [
+    {
+      "route_id": "resource-refined-ingot",
+      "reason": "Refined ingot upgrades demand heavy merchant spending, so a coin surplus keeps furnaces online."
+    },
+    {
+      "route_id": "resource-milk",
+      "reason": "Milk and bakery chains buy daily from settlement merchants; bank coins to keep dairies stocked."
+    }
+  ]
+}
+```
+
 ## Source Registry
 
 The source registry maps the short citation keys used throughout this file
@@ -22180,6 +22566,24 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/wiki/Vixy",
       "access_date": "2025-10-18",
       "notes": "Shows Dig Here! produces items at the ranch and that Vixy drops Bone and Leather at 100% rates.【palwiki-vixy†L9-L49】"
+    },
+    "palwiki-mau-raw": {
+      "title": "Mau – Palworld Wiki",
+      "url": "https://palworld.wiki.gg/wiki/Mau",
+      "access_date": "2025-10-21",
+      "notes": "Confirms Mau’s Gold Digger partner skill digs coins, lists coin drop amounts, and notes it spawns in Windswept Hills dungeons or faction camps.【palwiki-mau-raw†L11-L115】"
+    },
+    "palwiki-gold-coin-raw": {
+      "title": "Gold Coin – Palworld Wiki",
+      "url": "https://palworld.wiki.gg/wiki/Gold_Coin",
+      "access_date": "2025-10-21",
+      "notes": "States Gold Coins are traded currency and can be earned by selling items or pals, defeating human mobs, opening chests, or ranching Mau, Mau Cryst, and Vixy.【palwiki-gold-coin-raw†L3-L28】"
+    },
+    "palwiki-gold-coin": {
+      "title": "Gold Coin – Palworld Wiki (Fandom)",
+      "url": "https://palworld.fandom.com/wiki/Gold_Coin",
+      "access_date": "2025-10-21",
+      "notes": "Lists merchant sales, Syndicate drops, and ranch producers (Mau, Mau Cryst, Vixy) for Gold Coins.【palwiki-gold-coin†L28-L44】"
     },
     "palwiki-nail": {
       "title": "Nail \u2013 Palworld Wiki",

--- a/sources/palwiki-gold-coin-raw.txt
+++ b/sources/palwiki-gold-coin-raw.txt
@@ -1,0 +1,43 @@
+{{stub}}
+{{Item
+| description   = Currency traded on Palpagos Island. Can be exchanged for items or Pals with merchants.
+| type          = Material
+| rarity        = Common
+
+| weight        = 0
+| durability    = 
+
+| buy           = 1
+| sell          = 1
+
+| technology    = 
+| required_level = 
+| cost          = 
+| made_at       =
+| workload        =
+}}
+
+{{I|{{PAGENAME}}}} is a [[Material]] which is used as currency to trade with various characters, such as the [[Wandering Merchant]], [[Pal Merchant]], and [[Black Marketeer]]. Gold Coins can be obtained by selling [[Item]]s and [[Pal]]s to these merchants, by killing human mobs, or found in [[Treasure Chest]]s, or produced at a {{i|Ranch}} by {{i|Mau}}, {{i|Mau Cryst}}, or {{i|Vixy}}.
+
+==Acquisition==
+* [[Farming]]:
+**{{I|Vixy}}
+**{{I|Mau}}
+**{{I|Mau Cryst}}
+*Possible drop from [[Treasure Chest|Treasure Chests]].
+*Dropped by:
+{{Drops}}
+
+== History ==
+* [[0.2.0.6]]
+** Icon got updated.
+* [[0.1.2.0]]
+** Introduced.
+
+== Gallery ==
+<gallery>
+File:Gold Coin icon old.png|Old icon
+</gallery>
+
+{{Navbox Materials}}
+[[Category:Materials]]

--- a/sources/palwiki-gold-coin.txt
+++ b/sources/palwiki-gold-coin.txt
@@ -1,0 +1,53 @@
+{{Stub}}
+{{Infobox Item
+|name = Gold Coin
+|image = Gold_Coin_icon.png 
+|effects = Currency traded on Palpagos Island. Can be exchanged for items or Pals with merchants.
+|type = [[Material]]
+|source = [[Treasure Chest]]<br/>
+Trading<br/>
+<div class="mw-collapsible mw-collapsed">
+Pal drops
+<div class="mw-collapsible-content">
+{{p|Direhowl}}<br/>
+{{p|Vanwyrm}}<br/>
+{{p|Mau}}<br/>
+{{p|Mimog}}<br/>
+</div>
+Ranch
+<div class="mw-collapsible-content">
+{{p|Mau}}<br/>
+{{p|Mau Cryst}}<br/>
+{{p|Vixy}}<br/>
+</div>
+</div>
+|weight = 0
+|rarity = Common}}
+'''Gold Coin''' is a [[material]] in {{PW}}.
+
+==Acquisition==
+
+* Opening chests 
+* Selling items to [[Wandering Merchant|merchants]]. 
+* [https://palworld.fandom.com/wiki/Rayne_Syndicate Syndicate Thugs] can drop them. 
+=== Pal drops ===
+The following [[pals]] can drop this item:
+*{{p|Direhowl}}
+*{{p|Vanwyrm}}
+*{{p|Mau}}
+*{{p|Mimog}}
+
+=== Ranch === 
+The following [[pals]] can give this item when assigned to a [[ranch]]:
+*{{p|Mau}}
+*{{p|Mau Cryst}}
+*{{p|Vixy}}
+
+=== Production ===
+* {{p|Gold Coin Assembly Line}}
+
+==Gallery==
+<gallery>
+File:Gold Coin icon Old.png|Old icon
+</gallery>{{Navbox Materials}}
+[[Category:Materials]]

--- a/sources/palwiki-mau-raw.txt
+++ b/sources/palwiki-mau-raw.txt
@@ -1,0 +1,138 @@
+{{Pal Prev/Next | prevPal =  Killamari Primo | prevNo = 023b | nextPal =  Mau Cryst | nextNo = 024b}}
+{{Pal
+
+|name                   =Mau
+|no                     =024
+|title                  =Noble Glimmer
+
+|ele1                   =Dark
+|ele2                   =
+
+|partnerskill           =Gold Digger
+|partnerskill_desc      =Sometimes digs up [[Gold Coin]] when assigned to a [[Ranch]].
+|partnerskill_icon      =Farming
+
+| hp                     = 70
+| attack                 = 60
+| attack_melee           = 70
+| defense                = 70
+| support                = 100
+
+| slow_walk_speed        = 52
+| walk_speed             = 105
+| run_speed              = 475
+| ride_sprint_speed      = 550
+| transport_speed        = 317
+| stamina                = 100
+| work_speed             = 100
+
+| price                  = 1000
+| receive_damage_rate    = 1
+| receive_damage_rate_a  = 0.48
+| capture_rate_correct   = 1
+| capture_rate_correct_a = 0.7
+| breeding_rank          = 1480
+
+| passiveskill1          =
+| passiveskill2          = 
+| passiveskill3          = 
+| passiveskill4          = 
+
+| activeskill1           = Sand Blast
+| activeskill7           = Dark Ball
+| activeskill15          = Shadow Burst
+| activeskill22          = Sand Tornado
+| activeskill30          = Spirit Flame
+| activeskill40          = Nightmare Ball
+| activeskill50          = Dark Laser
+
+|kindling               =
+|watering               =
+|planting               =
+|generating_electricity =
+|handiwork              =
+|gathering              =
+|lumbering              =
+|mining                 =
+|medicine_production    =
+|cooling                =
+|transport              =
+|farming                =1
+
+| food                  = 1
+| nocturnal             = Yes
+
+|drop1=Gold Coin 
+|drop1_min=100
+|drop1_max=200
+|drop1_chance=50
+|drop2                  = 
+|drop2_min              = 
+|drop2_max              = 
+|drop2_chance           = 
+|drop3                  = 
+|drop3_min              = 
+|drop3_max              = 
+|drop3_chance           = 
+|drop4                  = 
+|drop4_min              = 
+|drop4_max              = 
+|drop4_chance           = 
+|drop5                  = 
+|drop5_min              = 
+|drop5_max              = 
+|drop5_chance           = 
+
+|alphadrop1=Ancient Civilization Parts 
+|alphadrop1_min=1
+|alphadrop1_max=2
+|alphadrop1_chance=100
+|alphadrop2=Gold Coin 
+|alphadrop2_min=100
+|alphadrop2_max=200
+|alphadrop2_chance=50
+|alphadrop4=Precious Claw
+|alphadrop4_min=1
+|alphadrop4_max=2
+|alphadrop4_chance=100
+|alphadrop5=Ring of Dark Resistance
+|alphadrop5_min=1
+|alphadrop5_max=1
+|alphadrop5_chance=5
+
+}}{{paldeck|Its hard tail does not deteriorate even when cut off. Some believed these severed tails to be good luck but, for the innumerable Mau who where poached as a result, they where anything but.}}
+'''Mau''' (Japanese: '''ニャオテト''' ''Nyaotet'') is a {{i|Dark}} [[Elements|element]] [[Pals|Pal]]. It has an {{i|Ice}} [[Elements|element]] [[Breeding|variation]], [[Mau Cryst]].
+
+== Appearance ==
+Mau is a small cat-like Pal with ebony fur and gold markings across its body. It has a gold ornament at the tip of its tail, and it has a gold collar around its neck. It has two gold bands around each of its ears and legs.
+
+== Behavior and habitat ==
+It can be found within dungeons in the [[Windswept Hills]] or captured in the camps of a [[Enemies|faction]].
+
+
+== Utility ==
+Mau digs up [[Gold Coins]] while assigned to a [[Ranch]].
+
+== History ==
+* [[0.2.4.0]]
+** Increased the Alpha Received Damage Rate from 0.4 to 0.48.
+* [[0.1.2.0]]
+** Introduced.
+
+== Variant(s) ==
+* [[Mau Cryst]]
+
+== Trivia ==
+* This Pal was named by the community during a [[Name This Pal]] event.
+* Mau’s name and Egyptian theme are inspired by the Egyptian Mau cat breed. In the game files, Mau is called “Bastet.” Its tail tip, shaped like a sistrum, reinforces this connection, as the Egyptian cat deity often holds one.
+* The Japanese name might be from ニャオ “Nyao” (the sound a cat) and “Bastet.”
+* This Pal is #041 in Paldeck on PocketPair [https://x.com/Palworld_EN/status/1720410507713085442 X].
+
+== Media ==
+{{#ev:youtube|n4XaI8_1EEo|410|inline|Paldeck No.041 MAU - Palworld Gameplay Pocketpair||autoplay=false}}
+<gallery widths="150">
+File:Mau2.png|A Mau sleeping
+</gallery>
+
+{{Navbox Pals}}
+[[Category:Pals]]


### PR DESCRIPTION
## Summary
- add the Gold Coin Treasury Circuit resource guide covering Mau hunts, ranch automation, and merchant sell loops
- sync data/guides.bundle.json and register new Mau/Gold Coin sources in the source registry
- document the progress and follow-up work for gold coin coverage in agent.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5a29a5e4833197aa8f57a1619cd4