### PR TITLE
Add Mozzarina Meat Packing Loop resource route

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -112,6 +112,9 @@ This document describes the responsibilities, workflows and quality assurance st
 *Progress 2025-10-26:* Authored High Quality Cloth Loom Circuit (`resource-high-quality-cloth`) covering the Sealed Realm of the Pristine Sibelyx clear, ranch automation, and 10-wool weaving batches; synchronized `guides.md`, `data/guides.bundle.json`, and `data/guide_catalog.json`, and registered new Palworld wiki citations for the cloth recipe, Sibelyx drops, and sealed realm coordinates.
   * Next steps: capture supplemental merchant pricing or alternative cloth sources (e.g., Sibelyx Ignis if added in future patches), gather second-source confirmation for Sealed Realm level requirements, and expand tailoring coverage to Cotton Candy supply loops once reliable Woolipop field spawn citations are accessible.
 
+*Progress 2025-10-27:* Built Mozzarina Meat Packing Loop (`resource-mozzarina-meat`), wiring capture, cleaver, and cooler workflows into `guides.md`, `data/guides.bundle.json`, and `data/guide_catalog.json`, and added new raw citations for Mozzarina drops and Cooler Box tech alongside refreshed source registry notes.
+  * Next steps: secure reliable Caprity/Galeclaw spawn citations (SegmentNext/GameSkinny/Gamespot requests currently return 404/403) so additional meat routes can ship, gather a second independent reference for Cooler Box merchant alternatives, and continue mapping remaining protein shortages (Caprity Meat, Galeclaw Poultry, Broncherry Meat) once location sources are accessible.
+
 ## Performance Notes
 
 * **Chunking** – When creating or updating `guides.md`, generate large JSON blocks in manageable chunks to avoid exceeding context limits.  Use the container tools to build the file incrementally.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -7918,6 +7918,75 @@
           ]
         }
       ]
+    },
+    {
+      "id": "resource-mozzarina-meat-packing-loop",
+      "title": "Mozzarina Meat Packing Loop",
+      "source_heading": "Mozzarina Meat Packing Loop",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "trigger": "Player asks how to farm Mozzarina Meat or automate Mozzarina butchery",
+      "keywords": [
+        "mozzarina meat",
+        "butcher",
+        "cooler box"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Glide to the **Sealed Realm of the Swordmaster** pasture (\u2212117, \u2212490) and capture Mozzarina pairs at day or night using Dark pals to stagger the herd.",
+          "citations": [
+            "segmentnext-mozzarina\u2020L3-L8",
+            "segmentnext-mozzarina\u2020L21-L24",
+            "palwiki-sealed-realms\u2020L57-L61"
+          ],
+          "links": [
+            {
+              "type": "pal",
+              "id": "mozzarina",
+              "slug": "mozzarina",
+              "name": "Mozzarina"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Unlock the **Meat Cleaver** at level 12 and the **Cooler Box** at level 13 to carve Mozzarina and chill prime cuts before they spoil.",
+          "citations": [
+            "palwiki-meat-cleaver\u2020L20-L39",
+            "palwiki-cooler-box-raw\u2020L1-L24"
+          ],
+          "links": [
+            {
+              "type": "tech",
+              "id": "meat-cleaver",
+              "slug": "meat-cleaver",
+              "name": "Meat Cleaver"
+            },
+            {
+              "type": "tech",
+              "id": "cooler-box",
+              "slug": "cooler-box",
+              "name": "Cooler Box"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Cull surplus Mozzarina with the cleaver\u2014each butchered Pal yields 2\u20133 Mozzarina Meat at a guaranteed rate for high-value meals.",
+          "citations": [
+            "palwiki-mozzarina-raw\u2020L65-L93"
+          ],
+          "links": [
+            {
+              "type": "item",
+              "id": "mozzarina_meat",
+              "slug": "mozzarina-meat",
+              "name": "Mozzarina Meat"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -15183,6 +15183,337 @@
       ]
     },
     {
+      "route_id": "resource-mozzarina-meat",
+      "title": "Mozzarina Meat Packing Loop",
+      "category": "resources",
+      "tags": [
+        "resource-farm",
+        "mozzarina-meat",
+        "cooking",
+        "mid-game"
+      ],
+      "progression_role": "support",
+      "recommended_level": {
+        "min": 20,
+        "max": 34
+      },
+      "modes": {
+        "normal": true,
+        "hardcore": true,
+        "solo": true,
+        "coop": true
+      },
+      "prerequisites": {
+        "routes": [
+          "starter-base-capture",
+          "resource-milk"
+        ],
+        "tech": [
+          "meat-cleaver",
+          "cooler-box"
+        ],
+        "items": [],
+        "pals": []
+      },
+      "objectives": [
+        "Reinforce the Mozzarina pasture north of the Swordmaster sealed realm",
+        "Unlock the Meat Cleaver and Cooler Box to process and chill prime cuts",
+        "Cull surplus Mozzarina for guaranteed meat while preserving dairy producers"
+      ],
+      "estimated_time_minutes": {
+        "solo": 36,
+        "coop": 26
+      },
+      "estimated_xp_gain": {
+        "min": 320,
+        "max": 520
+      },
+      "risk_profile": "medium",
+      "failure_penalties": {
+        "normal": "Wiping in Bamboo Groves despawns the herd and wastes cleaver cooldowns until respawns reset.",
+        "hardcore": "Hardcore deaths strand captured Mozzarina and delete crafted cleavers, so retreat if patrols swarm."
+      },
+      "adaptive_guidance": {
+        "underleveled": "Sweep the grove at dawn, use Dark pals to stagger the herd, and pick off sleepy Mozzarina in small pulls.",
+        "overleveled": "Rotate hunts day and night\u2014herds respawn in pairs so you can chain captures into a cull cycle.",
+        "resource_shortages": [
+          {
+            "item_id": "mozzarina-meat",
+            "solution": "Cull two Mozzarina per loop with the cleaver; each yields 2\u20133 meat at a 100% rate so chill the cuts immediately."
+          }
+        ],
+        "time_limited": "Butcher two captives, stash the meat in a Cooler Box, then let ranchers refill stocks between raids.",
+        "dynamic_rules": [
+          {
+            "signal": "mode:coop",
+            "condition": "mode.coop === true",
+            "adjustment": "Assign a wrangler to kite patrols while the butcher chains cleaver swings and rotates chilled storage.",
+            "priority": 1,
+            "mode_scope": [
+              "coop"
+            ],
+            "related_steps": [
+              "resource-mozzarina-meat:001",
+              "resource-mozzarina-meat:002"
+            ]
+          }
+        ]
+      },
+      "checkpoints": [
+        {
+          "id": "resource-mozzarina-meat:checkpoint-herd",
+          "label": "Mozzarina Herd Secured",
+          "includes": [
+            "resource-mozzarina-meat:001"
+          ]
+        },
+        {
+          "id": "resource-mozzarina-meat:checkpoint-cleaver",
+          "label": "Cleaver & Cooler Online",
+          "includes": [
+            "resource-mozzarina-meat:002"
+          ]
+        },
+        {
+          "id": "resource-mozzarina-meat:checkpoint-pantry",
+          "label": "Meat Pantry Stocked",
+          "includes": [
+            "resource-mozzarina-meat:003"
+          ]
+        }
+      ],
+      "supporting_routes": {
+        "recommended": [
+          "resource-milk"
+        ],
+        "optional": [
+          "resource-ice-organ"
+        ]
+      },
+      "failure_recovery": {
+        "normal": "Fast travel to Ravine Entrance, rest five minutes, then recapture the herd once patrols rotate away.",
+        "hardcore": "Extract captured Mozzarina immediately and restock ice organs before another butchering run to avoid compounding losses."
+      },
+      "steps": [
+        {
+          "step_id": "resource-mozzarina-meat:001",
+          "type": "capture",
+          "summary": "Reinforce the Swordmaster pasture",
+          "detail": "Glide to the Sealed Realm of the Swordmaster (\u2212117, \u2212490) and sweep the southern Bamboo Groves. Mozzarina spawn in peaceful pairs all day, so use Dark pals to stagger them and throw Mega Spheres before Syndicate patrols rotate in.",
+          "targets": [
+            {
+              "kind": "pal",
+              "id": "mozzarina",
+              "qty": 4
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "bamboo-groves",
+              "coords": [
+                -117,
+                -490
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Tag one Mozzarina at a time and drag it toward Ravine Entrance before culling so backup patrols don't collapse on you.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "mega-pal-sphere",
+              "grappling-gun"
+            ],
+            "pals": [
+              "blazehowl"
+            ],
+            "consumables": [
+              "smoked-meat"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 200,
+            "max": 320
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "milk",
+                "qty": 2
+              }
+            ],
+            "pals": [
+              "mozzarina"
+            ],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "segmentnext-mozzarina",
+            "palwiki-sealed-realms"
+          ]
+        },
+        {
+          "step_id": "resource-mozzarina-meat:002",
+          "type": "craft",
+          "summary": "Unlock cleaver and chill storage",
+          "detail": "Spend 2 tech points at level 12 to unlock the Meat Cleaver, craft it at the Primitive Workbench (5 Ingots, 20 Wood, 5 Stone), then unlock the Cooler Box at level 13 so chilled storage keeps cuts fresh when tended by a Cooling Pal.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "mozzarina-meat",
+              "qty": 6
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "windswept-hills",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Capture an extra Mozzarina before butchering so a cleaver misclick doesn't exhaust your dairy line.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "meat-cleaver",
+              "cooler-box"
+            ],
+            "pals": [
+              "penking"
+            ],
+            "consumables": [
+              "ice-organ"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 60,
+            "max": 80
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "mozzarina-meat",
+                "qty": 6
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "condition": "player lacks ice-organ >= 5",
+              "action": "include_subroute",
+              "subroute_ref": "resource-ice-organ"
+            }
+          ],
+          "citations": [
+            "palwiki-meat-cleaver",
+            "palwiki-cooler-box-raw"
+          ]
+        },
+        {
+          "step_id": "resource-mozzarina-meat:003",
+          "type": "base",
+          "summary": "Balance dairy and butcher rotations",
+          "detail": "Keep two Mozzarina assigned to the ranch for milk while cycling the extras through the cleaver. Each cull yields 2\u20133 Mozzarina Meat at 100%, so stage Cooler Box slots or cook high-SAN meals as needed.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "mozzarina-meat",
+              "qty": 12
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "windswept-hills",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {},
+          "recommended_loadout": {
+            "gear": [
+              "cooler-box",
+              "campfire"
+            ],
+            "pals": [
+              "penking"
+            ],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 40,
+            "max": 60
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "mozzarina-meat",
+                "qty": 12
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-mozzarina-raw",
+            "segmentnext-mozzarina"
+          ]
+        }
+      ],
+      "completion_criteria": [
+        {
+          "type": "have-item",
+          "item_id": "mozzarina-meat",
+          "qty": 12
+        }
+      ],
+      "yields": {
+        "levels_estimate": "+0 to +1",
+        "key_unlocks": [
+          "prime-protein"
+        ]
+      },
+      "metrics": {
+        "progress_segments": 3,
+        "boss_targets": 0,
+        "quest_nodes": 0
+      },
+      "next_routes": [
+        {
+          "route_id": "resource-cake",
+          "reason": "Cakes and other luxury meals scale with Mozzarina dairy and meat reserves."
+        },
+        {
+          "route_id": "resource-ice-organ",
+          "reason": "Cooler Boxes demand a steady Ice Organ supply to keep meat preserved."
+        }
+      ]
+    },
+    {
       "route_id": "resource-ore",
       "title": "Ore Mining Grid",
       "category": "resources",
@@ -30076,6 +30407,18 @@
           "url": "https://palworld.wiki.gg/wiki/Mau",
           "access_date": "2025-10-21",
           "notes": "Confirms Mau\u2019s Gold Digger partner skill digs coins, lists coin drop amounts, and notes it spawns in Windswept Hills dungeons or faction camps.\u3010palwiki-mau-raw\u2020L11-L115\u3011"
+        },
+        "palwiki-mozzarina-raw": {
+          "title": "Mozzarina \u2013 Palworld Wiki (raw)",
+          "url": "https://palworld.wiki.gg/index.php?title=Mozzarina&action=raw",
+          "access_date": "2025-10-27",
+          "notes": "Shows Mozzarina Meat dropping in 2\u20133 piece bundles at 100% alongside guaranteed milk for both normal and alpha variants.\u3010palwiki-mozzarina-raw\u2020L65-L105\u3011"
+        },
+        "palwiki-cooler-box-raw": {
+          "title": "Cooler Box \u2013 Palworld Wiki (raw)",
+          "url": "https://palworld.wiki.gg/index.php?title=Cooler_Box&action=raw",
+          "access_date": "2025-10-27",
+          "notes": "Explains the Cooler Box unlock at technology level 13, its 20 Ingot/20 Stone/5 Ice Organ recipe, and that Cooling pals prevent stored food from spoiling.\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011"
         },
         "palwiki-gold-coin-raw": {
           "title": "Gold Coin \u2013 Palworld Wiki",

--- a/guides.md
+++ b/guides.md
@@ -22973,6 +22973,344 @@ Lamball Butchery Circuit corrals Windswept Hills Lamball, unlocks the Meat Cleav
 }
 ```
 
+### Route: Mozzarina Meat Packing Loop
+
+Mozzarina Meat Packing Loop pivots the Swordmaster pasture captures into a cleaver-and-cooler chain that harvests 2–3 Mozzarina Meat per cull while leaving ranchers on dairy duty.【segmentnext-mozzarina†L3-L8】【palwiki-mozzarina-raw†L65-L93】
+
+```json
+{
+  "route_id": "resource-mozzarina-meat",
+  "title": "Mozzarina Meat Packing Loop",
+  "category": "resources",
+  "tags": [
+    "resource-farm",
+    "mozzarina-meat",
+    "cooking",
+    "mid-game"
+  ],
+  "progression_role": "support",
+  "recommended_level": {
+    "min": 20,
+    "max": 34
+  },
+  "modes": {
+    "normal": true,
+    "hardcore": true,
+    "solo": true,
+    "coop": true
+  },
+  "prerequisites": {
+    "routes": [
+      "starter-base-capture",
+      "resource-milk"
+    ],
+    "tech": [
+      "meat-cleaver",
+      "cooler-box"
+    ],
+    "items": [],
+    "pals": []
+  },
+  "objectives": [
+    "Reinforce the Mozzarina pasture north of the Swordmaster sealed realm",
+    "Unlock the Meat Cleaver and Cooler Box to process and chill prime cuts",
+    "Cull surplus Mozzarina for guaranteed meat while preserving dairy producers"
+  ],
+  "estimated_time_minutes": {
+    "solo": 36,
+    "coop": 26
+  },
+  "estimated_xp_gain": {
+    "min": 320,
+    "max": 520
+  },
+  "risk_profile": "medium",
+  "failure_penalties": {
+    "normal": "Wiping in Bamboo Groves despawns the herd and wastes cleaver cooldowns until respawns reset.",
+    "hardcore": "Hardcore deaths strand captured Mozzarina and delete crafted cleavers, so retreat if patrols swarm."
+  },
+  "adaptive_guidance": {
+    "underleveled": "Sweep the grove at dawn, use Dark pals to stagger the herd, and pick off sleepy Mozzarina in small pulls.【segmentnext-mozzarina†L4-L7】【segmentnext-mozzarina†L21-L24】",
+    "overleveled": "Rotate hunts day and night—herds respawn in pairs so you can chain captures into a cull cycle.【segmentnext-mozzarina†L4-L8】",
+    "resource_shortages": [
+      {
+        "item_id": "mozzarina-meat",
+        "solution": "Cull two Mozzarina per loop with the cleaver; each yields 2–3 meat at a 100% rate so chill the cuts immediately.【palwiki-mozzarina-raw†L65-L93】【palwiki-cooler-box-raw†L1-L27】"
+      }
+    ],
+    "time_limited": "Butcher two captives, stash the meat in a Cooler Box, then let ranchers refill stocks between raids.【palwiki-cooler-box-raw†L1-L24】【palwiki-mozzarina-raw†L65-L93】",
+    "dynamic_rules": [
+      {
+        "signal": "mode:coop",
+        "condition": "mode.coop === true",
+        "adjustment": "Assign a wrangler to kite patrols while the butcher chains cleaver swings and rotates chilled storage.",
+        "priority": 1,
+        "mode_scope": [
+          "coop"
+        ],
+        "related_steps": [
+          "resource-mozzarina-meat:001",
+          "resource-mozzarina-meat:002"
+        ]
+      }
+    ]
+  },
+  "checkpoints": [
+    {
+      "id": "resource-mozzarina-meat:checkpoint-herd",
+      "label": "Mozzarina Herd Secured",
+      "includes": [
+        "resource-mozzarina-meat:001"
+      ]
+    },
+    {
+      "id": "resource-mozzarina-meat:checkpoint-cleaver",
+      "label": "Cleaver & Cooler Online",
+      "includes": [
+        "resource-mozzarina-meat:002"
+      ]
+    },
+    {
+      "id": "resource-mozzarina-meat:checkpoint-pantry",
+      "label": "Meat Pantry Stocked",
+      "includes": [
+        "resource-mozzarina-meat:003"
+      ]
+    }
+  ],
+  "supporting_routes": {
+    "recommended": [
+      "resource-milk"
+    ],
+    "optional": [
+      "resource-ice-organ"
+    ]
+  },
+  "failure_recovery": {
+    "normal": "Fast travel to Ravine Entrance, rest five minutes, then recapture the herd once patrols rotate away.【segmentnext-mozzarina†L4-L8】",
+    "hardcore": "Extract captured Mozzarina immediately and restock ice organs before another butchering run to avoid compounding losses.【segmentnext-mozzarina†L7-L8】【palwiki-cooler-box-raw†L17-L24】"
+  },
+  "steps": [
+    {
+      "step_id": "resource-mozzarina-meat:001",
+      "type": "capture",
+      "summary": "Reinforce the Swordmaster pasture",
+      "detail": "Glide to the Sealed Realm of the Swordmaster (−117, −490) and sweep the southern Bamboo Groves. Mozzarina spawn in peaceful pairs all day, so use Dark pals to stagger them and throw Mega Spheres before Syndicate patrols rotate in.【segmentnext-mozzarina†L3-L8】【segmentnext-mozzarina†L21-L24】【124c92†L57-L61】",
+      "targets": [
+        {
+          "kind": "pal",
+          "id": "mozzarina",
+          "qty": 4
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "bamboo-groves",
+          "coords": [
+            -117,
+            -490
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Tag one Mozzarina at a time and drag it toward Ravine Entrance before culling so backup patrols don't collapse on you.【segmentnext-mozzarina†L4-L8】",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "mega-pal-sphere",
+          "grappling-gun"
+        ],
+        "pals": [
+          "blazehowl"
+        ],
+        "consumables": [
+          "smoked-meat"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 200,
+        "max": 320
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "milk",
+            "qty": 2
+          }
+        ],
+        "pals": [
+          "mozzarina"
+        ],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "segmentnext-mozzarina",
+        "palwiki-sealed-realms"
+      ]
+    },
+    {
+      "step_id": "resource-mozzarina-meat:002",
+      "type": "craft",
+      "summary": "Unlock cleaver and chill storage",
+      "detail": "Spend 2 tech points at level 12 to unlock the Meat Cleaver, craft it at the Primitive Workbench (5 Ingots, 20 Wood, 5 Stone), then unlock the Cooler Box at level 13 so chilled storage keeps cuts fresh when tended by a Cooling Pal.【palwiki-meat-cleaver†L20-L39】【palwiki-cooler-box-raw†L1-L24】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "mozzarina-meat",
+          "qty": 6
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "windswept-hills",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Capture an extra Mozzarina before butchering so a cleaver misclick doesn't exhaust your dairy line.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "meat-cleaver",
+          "cooler-box"
+        ],
+        "pals": [
+          "penking"
+        ],
+        "consumables": [
+          "ice-organ"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 60,
+        "max": 80
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "mozzarina-meat",
+            "qty": 6
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "condition": "player lacks ice-organ >= 5",
+          "action": "include_subroute",
+          "subroute_ref": "resource-ice-organ"
+        }
+      ],
+      "citations": [
+        "palwiki-meat-cleaver",
+        "palwiki-cooler-box-raw"
+      ]
+    },
+    {
+      "step_id": "resource-mozzarina-meat:003",
+      "type": "base",
+      "summary": "Balance dairy and butcher rotations",
+      "detail": "Keep two Mozzarina assigned to the ranch for milk while cycling the extras through the cleaver. Each cull yields 2–3 Mozzarina Meat at 100%, so stage Cooler Box slots or cook high-SAN meals as needed.【palwiki-mozzarina-raw†L65-L121】【segmentnext-mozzarina†L28-L30】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "mozzarina-meat",
+          "qty": 12
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "windswept-hills",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {},
+      "recommended_loadout": {
+        "gear": [
+          "cooler-box",
+          "campfire"
+        ],
+        "pals": [
+          "penking"
+        ],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 40,
+        "max": 60
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "mozzarina-meat",
+            "qty": 12
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-mozzarina-raw",
+        "segmentnext-mozzarina"
+      ]
+    }
+  ],
+  "completion_criteria": [
+    {
+      "type": "have-item",
+      "item_id": "mozzarina-meat",
+      "qty": 12
+    }
+  ],
+  "yields": {
+    "levels_estimate": "+0 to +1",
+    "key_unlocks": [
+      "prime-protein"
+    ]
+  },
+  "metrics": {
+    "progress_segments": 3,
+    "boss_targets": 0,
+    "quest_nodes": 0
+  },
+  "next_routes": [
+    {
+      "route_id": "resource-cake",
+      "reason": "Cakes and other luxury meals scale with Mozzarina dairy and meat reserves."
+    },
+    {
+      "route_id": "resource-ice-organ",
+      "reason": "Cooler Boxes demand a steady Ice Organ supply to keep meat preserved."
+    }
+  ]
+}
+```
+
 ## Source Registry
 
 The source registry maps the short citation keys used throughout this file
@@ -23324,6 +23662,12 @@ updating guides, refresh these entries with new dates and pages.
       "access_date": "2025-10-11",
       "notes": "Documents Milk Maker\u2019s ranch production and that Mozzarina drop milk at 100% in both normal and alpha variants.\u3010a877d4\u2020L10-L35\u3011"
     },
+    "palwiki-mozzarina-raw": {
+      "title": "Mozzarina \u2013 Palworld Wiki (raw)",
+      "url": "https://palworld.wiki.gg/index.php?title=Mozzarina&action=raw",
+      "access_date": "2025-10-27",
+      "notes": "Shows Mozzarina Meat dropping in 2\u20133 piece bundles at 100% alongside guaranteed milk for both normal and alpha variants.\u3010palwiki-mozzarina-raw\u2020L65-L105\u3011"
+    },
     "palwiki-gumoss": {
       "title": "Gumoss \u2013 Palworld Wiki (Fandom)",
       "url": "https://palworld.fandom.com/wiki/Gumoss",
@@ -23335,6 +23679,12 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/wiki/Ranch",
       "access_date": "2025-10-11",
       "notes": "Shows Ranch unlock requirements (level 5, two tech points) and build costs of 50 Wood, 20 Stone, and 30 Fiber.\u30101a1614\u2020L1-L16\u3011"
+    },
+    "palwiki-cooler-box-raw": {
+      "title": "Cooler Box \u2013 Palworld Wiki (raw)",
+      "url": "https://palworld.wiki.gg/index.php?title=Cooler_Box&action=raw",
+      "access_date": "2025-10-27",
+      "notes": "Explains the Cooler Box unlock at technology level 13, its 20 Ingot/20 Stone/5 Ice Organ recipe, and that Cooling pals prevent stored food from spoiling.\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011"
     },
     "palwiki-sealed-realms": {
       "title": "Sealed Realms \u2013 Palworld Wiki",

--- a/sources/palwiki-cooler-box-raw.txt
+++ b/sources/palwiki-cooler-box-raw.txt
@@ -1,0 +1,46 @@
+{{Stub}}
+{{Structure
+| description    = Small food vault. Assign an Ice Pal to help prevent food stored inside from spoiling.
+| category       = Storage
+| hit_points     = 2,000
+| capacity       = 10
+| supporting     = No
+
+| workload       = 50
+| mat1           = Ingot
+| qty1           = 20
+| mat2           = Stone
+| qty2           = 20
+| mat3           = Ice Organ
+| qty3           = 5
+
+| tech_name      = Cooler Box
+| required_level = 13
+| cost      = 2
+}}
+
+'''Cooler Box''' is a [[structure]].
+
+==Acquisition==
+It's a tier 13 [[technology]] item and requires 2 point to unlock.
+
+==Crafting==
+{{Recipe
+|mat1=Ingot
+|mat1qty=20
+|mat2=Stone
+|mat2qty=20
+|mat3=Ice Organ
+|mat3qty=5
+|output1=Cooler Box
+|output1qty=1
+}}
+
+==Usage==
+Used to store up to 10 Items. When maintained by a Pal with the {{i|Cooling}} Work Suitability, keeps food products fresh from decaying.
+
+==History==
+*[[0.1.2.0]]
+**Introduced.
+
+[[Category:Structures]]

--- a/sources/palwiki-mozzarina-raw.txt
+++ b/sources/palwiki-mozzarina-raw.txt
@@ -1,0 +1,142 @@
+{{Pal Prev/Next | prevPal =  Flopie | prevNo = 028 | nextPal =  Bristla | nextNo = 030}}
+{{Pal
+
+|name                   ={{PAGENAME}}
+|no                     =029
+|title                  =Grade A Beef
+
+|ele1                   =Neutral
+|ele2                   =
+
+|partnerskill           =Milk Maker
+|partnerskill_desc      =Sometimes produces [[Milk]] when assigned to a [[Ranch]].
+|partnerskill_icon      =Farming
+
+| hp                     = 90
+| attack                 = 50
+| attack_melee           = 100
+| defense                = 80
+| support                = 100
+
+| slow_walk_speed        = 55
+| walk_speed             = 55
+| run_speed              = 580
+| ride_sprint_speed      = 700
+| transport_speed        = 317
+| stamina                = 100
+| work_speed             = 100
+
+| price                  = 2620
+| receive_damage_rate    = 1
+| receive_damage_rate_a  = 0.24
+| capture_rate_correct   = 1
+| capture_rate_correct_a = 0.7
+| breeding_rank          = 910
+
+| passiveskill1          =
+| passiveskill2          = 
+| passiveskill3          = 
+| passiveskill4          = 
+
+| activeskill1           = Power Shot
+| activeskill7           = Sand Blast
+| activeskill15          = Air Cannon
+| activeskill22          = Stone Blast
+| activeskill30          = Stone Cannon
+| activeskill40          = Power Bomb
+| activeskill50          = Pal Blast
+
+|kindling               =
+|watering               =
+|planting               =
+|generating_electricity =
+|handiwork              =
+|gathering              =
+|lumbering              =
+|mining                 =
+|medicine_production    =
+|cooling                =
+|transport              =
+|farming                =1
+
+| food                  = 3
+| nocturnal             = No
+
+|drop1=Mozzarina Meat 
+|drop1_min=2
+|drop1_max=3
+|drop1_chance=100
+|drop2=Milk
+|drop2_min=1
+|drop2_max=1
+|drop2_chance=100
+|drop3                  = 
+|drop3_min              = 
+|drop3_max              = 
+|drop3_chance           = 
+|drop4                  = 
+|drop4_min              = 
+|drop4_max              = 
+|drop4_chance           = 
+|drop5                  = 
+|drop5_min              = 
+|drop5_max              = 
+|drop5_chance           = 
+
+|alphadrop1=Ancient Civilization Parts 
+|alphadrop1_min=1
+|alphadrop1_max=2
+|alphadrop1_chance=100
+|alphadrop2=Mozzarina Meat
+|alphadrop2_min=2
+|alphadrop2_max=3
+|alphadrop2_chance=100
+|alphadrop3=Milk
+|alphadrop3_min=1
+|alphadrop3_max=1
+|alphadrop3_chance=100
+|alphadrop4=Precious Pelt
+|alphadrop4_min=1
+|alphadrop4_max=2
+|alphadrop4_chance=100
+|alphadrop5=Ring of Resistance +1
+|alphadrop5_min=1
+|alphadrop5_max=1
+|alphadrop5_chance=3
+
+}}{{paldeck|Milk pours from this Pal like water from an open faucet, regardless of its gender. It's truly a mystery of life, although this mystery may be better left unsolved.}}
+'''Mozzarina''' (Japanese: '''ミルカルビ''' ''Milkalbi'') is a {{i|Neutral}} [[Elements|element]] [[Pals|Pal]].
+
+==Appearance==
+Mozzarina is a black-and-white cow-like Pal, whose torso and head are two round balls, with four stumpy legs as well as a pair of pink udders barely visible underneath. Its face has two closed eyes, two slightly curved tan horns, and a curved smile with two visible fangs.
+
+==Behavior and habitat==
+It wont attack unless attacked.
+[[File:Mozzarina_Day_Habitat.webp|thumb|Daytime Mozzarina Spawns]]
+[[File:Mozzarina_Night_Habitat.webp|thumb|Nightime Mozzarina Spawns]]
+
+== Utility ==
+Mozzarina's [[Partner Skill]], Milk Maker, causes it to produce [[Milk]] when assigned to a [[Ranch]].
+
+Mozzarina's mediocre combat capabilities are almost always ignored in favor of its sole work suitability, [[Farming]]. While assigned to a ranch, Mozzarina will produce Milk, which can be used at a [[Campfire]] to make [[Hot Milk]] or at a [[Cooking Pot]] to produce a variety of high-SAN foods such as [[Pancake|Pancakes]].
+
+==History==
+* [[0.2.4.0]]
+** Increased the Alpha Received Damage Rate from 0.2 to 0.24.
+* [[0.1.2.0]]
+** Introduced.
+
+==Trivia==
+* Their name may come from the word ''mozzarella''.
+* Its Japanese name may come from ''milk'' and ''kalbi'' (Korean grilled ribs).
+* Mozzarina does not have a gender ratio of 1-to-1 Male to Female.  Mozzarina has a 20% chance to spawn as a male and an 80% chance to spawn as a female; this is in contrast with most other Pals, which have an equal chance to spawn with either gender. Other Pals with uneven gender ratios include [[Beegarde]], [[Elizabee]], [[Dazzi]], [[Lovander]], [[Kingpaca]], [[Kingpaca Cryst]], [[Warsect]], [[Lyleen]], and [[Lyleen Noct]].
+
+==Media==
+<gallery widths="150">
+File:Mozzarina old.png|Mozzarina's old model.
+File:Mozzarina Sleeping.png|Mozzarina sleeping
+File:MozzarinaGettingAttackedScreenshotFromRandomRamVid.webp
+</gallery>
+
+{{Navbox Pals}}
+[[Category:Pals]]

--- a/sources/segmentnext-mozzarina.txt
+++ b/sources/segmentnext-mozzarina.txt
@@ -1,0 +1,30 @@
+Trying to get some Milk to make a cake? Well, the Neutral-type pal , Mozzarina can help you out with that in Palworld . This Pal has the Milk Maker Partner Skill, which means you can assign them to your Ranch to produce an infinite amount of Milk.
+This Pal serves as a good option for this task especially because it can be found in the early game and isn’t very hard to find either. Read on to learn about Mozzarina’s location, its breeding combinations, and stats in Palworld.
+Where to find Mozzarina in Palworld?
+Mozzarinas are peaceful cow-like Pals that are often found in green areas, feeding on any vegetation they see – especially in the southern parts of the Bamboo Groves. Specifically, you can find many of them roaming across the green pastures just north of the Sealed Realm of the Swordmaster.
+This Sealed Realm serves as a Fast Travel Point in itself, but another one closest to it is the Ravine Entrance FTP, which you can consider as the eastern border of the spawn area.
+In the north and west, the Mozzarina spawn location spans the Sealed Realm of the Thunder Dragon FTP and the Ascetic Falls FTP respectively.
+Finding a Mozzarina in Palworld isn’t a very difficult task because of two main reasons. You not only have a small spawn area that you need to search, but the Pals also spawn in groups of 2 and 3, which makes them even easier to spot and farm. Also, Mozzarina spawns in both the day and night , meaning that you can just pop up at its location to catch it anytime you want.
+You can also purchase a Mozzarina from a Pal Merchant for around 2620 Gold.
+Lastly, you can hatch Mozzarina from a Common Egg in Palworld. Common Eggs, along with other types of eggs, are easily spottable during your journey in the Palpagos Islands.
+How to breed Mozzarina in Palworld
+Catching a Mozzarina in the wild is easy enough compared to many other Pals in the game, but breeding one would be the easiest way you can come by one. To breed a Mozzarina, you may try the following combinations of Pals:
+Nitewing with Foxparks
+Cinnamoth with Fuack
+Tanzee with Surfent
+Melpaca with Eikthyrdeer
+Melpaca with Caprity
+Penking with Killamari
+Best breeding combos for Mozzarina in Palworld
+Apart from being a perfect base worker, Mozzarina can be bred with other pals to produce many offspring creatures. You can try many breeding combos with this pal, and some of the best are below:
+Mozzarina weaknesses and stats
+Mozzarina is a cute pal with passive nature. However, to avoid any possible trouble while catching it, make sure to bring your best Dark-type pals to encounter this cow-like creature. By doing so, you can exploit Mozzarina’s weakness to Dark-type enemies. (as it is a neutral type itself)
+The Pal may initially try to flee if you approach it, but will not hesitate to attack once you land a hit on it. Unlike other Pals though, you don’t have to attack a Mozzarina to catch it – just throw a Pal Sphere when you find it.
+If you find a Mozzarina sleeping at night time, you can take advantage of this and make a surprise attack followed by throwing a Pal Sphere at it.
+If the level of Mozzarina exceeds 15, then make sure to use Mega Spheres as their catch chances are reduced with standard ones.
+The base stats you will notice after capturing Mozzarina are quite promising, especially in the early stages of the game.
+Mozzarina Skills
+The standard Mozzarina comes equipped with many useful Active Skills that help it greatly in combat. These include skills like Sand Blast, Stone Blast, Air Cannon, Power Shot, Power Bomb, and Stone Cannon.
+Though these are great Ground skills, combat isn’t really what a Mozzarina is made for. This Pal is mainly used as a Milk producer in your base since it’s the earliest one with this ability you can get in the game.
+With its Partner Skill , Milk Maker, you can simply assign this Pal to your Ranch and let it produce the good stuff. You can then use the Milk in several recipes like Cakes, which are an essential resource when it comes to breeding and hatching eggs.
+If you manage to kill a Mozzarina, then it has a chance to drop Milk and Mozzarina Meat, which is a useful resource as well. If it’s the Alpha boss variant, the drops will include the above two as well as Ancient Civilization Parts, Ring of Resistance +1, and Precious Pelt. However, we don’t recommend killing them in Palworld as farming milk is a much better option.


### PR DESCRIPTION
## Summary
- add the Mozzarina Meat Packing Loop resource route with capture, cleaver, and cooler guidance
- sync guides bundle and catalog with the new route and register Mozzarina/Cooler Box source transcripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd03d003483318287d6ba97d3515c