### PR TITLE
Wire Venom Gland resource guide into catalog and registry

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -77,7 +77,7 @@ Key confirmations from the review:
 
 ### Backlog (Confirm Against `routeGuideData.resourceGuideGaps` Before Starting)
 
-* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **Broncherry Meat**, **Cotton Candy**, **High Quality Pal Oil**, **Venom Gland**, **Small Pal Soul**, **Medium Pal Soul follow-ups (Crusher automation variants)**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
+* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **Broncherry Meat**, **Cotton Candy**, **High Quality Pal Oil**, **Small Pal Soul**, **Medium Pal Soul follow-ups (Crusher automation variants)**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
 * Secondary targets once two independent citations are secured: **Milk auxiliary spawns**, **Seed restock timers (Tomato/Lettuce/Berry)**, **Elite alpha respawn timers for gemstone loops**, **Automation throughput benchmarks for Assembly Line/Power Grid resources**.
 
 Update this backlog whenever a guide ships or when a data source becomes available, and archive stale TODOs with reasoning if a resource becomes obsolete or its shortages are resolved by upstream patches.
@@ -88,3 +88,10 @@ Update this backlog whenever a guide ships or when a data source becomes availab
 * **Selective re‑generation** – When a patch only affects a subset of routes (e.g. a recipe change for a single saddle), regenerate only that route and its dependent subroutes instead of rebuilding the entire file.  This minimises the risk of introducing unrelated errors.
 
 By adhering to these guidelines, the Palmate agent will produce reliable, comprehensive guides that help players enjoy Palworld while keeping pace with the game’s rapid evolution.
+
+### 2025-10-31 Venom Gland coverage sync
+
+* Added the `resource-venom-gland-supply-network` catalog entry with shortage flag, merchant/dungeon/alpha context, and wired citations so the shortages UI can surface the route immediately.
+* Verified `index.html` relies entirely on parsed guide data for `resourceGuideGaps`; no hard-coded Venom Gland references required updates after the new route synced into `guides.md` and `data/guides.bundle.json`.
+* Expanded the Source Registry with `palwiki-killamari`, `palwiki-menasting`, and `palfandom-venom-gland` to clear unresolved citations for the new route JSON blocks.
+* Next agent touchpoint: confirm the shortages drawer surfaces the Venom Gland guide once bundles regenerate in production, then continue with the remaining backlog targets above (Caprity Meat, Galeclaw Poultry, etc.).

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8203,5 +8203,118 @@
         }
       ]
     }
+    ,
+    {
+      "id": "resource-venom-gland-supply-network",
+      "title": "Venom Gland Supply Network",
+      "source_heading": "Venom Gland Supply Network",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player reports running out of Venom Glands for Strange Juice, poison ammo, or antidote stock.",
+      "keywords": [
+        "venom gland",
+        "poison",
+        "helzephyr",
+        "killamari",
+        "menasting"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Fast travel to the **Small Settlement (78,-477)** and **Sea Breeze Archipelago merchant (-190,-600)** to buy every Venom Gland for 100 Gold before the daily reset.",
+          "citations": [
+            "palwiki-wandering-merchant-raw\u2020L31-L34",
+            "palwiki-wandering-merchant-raw\u2020L176-L181"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "small-settlement",
+              "name": "Small Settlement",
+              "region": "Windswept Hills"
+            },
+            {
+              "type": "location",
+              "id": "sea-breeze-archipelago-merchant",
+              "name": "Sea Breeze Archipelago Merchant",
+              "region": "Sea Breeze Archipelago"
+            },
+            {
+              "type": "item",
+              "id": "venom_gland",
+              "slug": "venom-gland",
+              "name": "Venom Gland"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Clear level 15-20 Windswept Hills dungeons at night, focusing on **Killamari** packs for repeat Venom Gland drops and extra jelly.",
+          "citations": [
+            "palwiki-killamari\u2020L240-L240",
+            "palfandom-venom-gland\u2020L11-L34"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "windswept-hills",
+              "name": "Windswept Hills",
+              "region": "Windswept Hills"
+            },
+            {
+              "type": "pal",
+              "id": "killamari",
+              "slug": "killamari",
+              "name": "Killamari"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Hunt **Helzephyr** along the Bridge of the Twin Knights cliffs each night cycle to bank Medium Pal Souls and Venom Glands together.",
+          "citations": [
+            "palwiki-helzephyr-raw\u2020L247-L247",
+            "palfandom-venom-gland\u2020L11-L34"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "bridge-of-the-twin-knights",
+              "name": "Bridge of the Twin Knights",
+              "region": "Windswept Hills"
+            },
+            {
+              "type": "pal",
+              "id": "helzephyr",
+              "slug": "helzephyr",
+              "name": "Helzephyr"
+            }
+          ]
+        },
+        {
+          "order": 4,
+          "instruction": "Rotate into the **Desiccated Mineshaft (493,79)** to defeat the Menasting alpha for guaranteed late-game Venom Glands and Precious Plumes.",
+          "citations": [
+            "palwiki-menasting\u2020L245-L245",
+            "palfandom-venom-gland\u2020L16-L34"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "desiccated-mineshaft",
+              "name": "Desiccated Mineshaft",
+              "region": "Dessicated Desert"
+            },
+            {
+              "type": "pal",
+              "id": "menasting",
+              "slug": "menasting",
+              "name": "Menasting"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/guides.md
+++ b/guides.md
@@ -24873,6 +24873,18 @@ updating guides, refresh these entries with new dates and pages.
       "access_date": "2025-10-24",
       "notes": "Lists Helzephyr Medium Pal Soul drop chances and describes its nocturnal patrols north of the Bridge of the Twin Knights and Islandhopper Coast waypoints.【palwiki-helzephyr-raw†L65-L116】"
     },
+    "palwiki-killamari": {
+      "title": "Killamari \u2013 Palworld Wiki",
+      "url": "https://palworld.wiki.gg/wiki/Killamari",
+      "access_date": "2025-10-31",
+      "notes": "Confirms Killamari spawn in Windswept Hills night dungeons and drop Venom Glands alongside Jelly.【palwiki-killamari†L240-L240】"
+    },
+    "palwiki-menasting": {
+      "title": "Menasting \u2013 Palworld Wiki",
+      "url": "https://palworld.wiki.gg/wiki/Menasting",
+      "access_date": "2025-10-31",
+      "notes": "Documents the Desiccated Mineshaft alpha at (493,79) and its guaranteed Venom Gland and Precious Plume drops.【palwiki-menasting†L245-L245】"
+    },
     "palwiki-medium-pal-soul-raw": {
       "title": "Medium Pal Soul \u2013 Palworld Wiki (raw)",
       "url": "https://palworld.wiki.gg/index.php?title=Medium_Pal_Soul&action=raw",
@@ -24920,6 +24932,12 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.fandom.com/wiki/Medium_Pal_Soul?action=raw",
       "access_date": "2025-10-24",
       "notes": "Confirms guaranteed Sootseer drops, Helzephyr sources, and Desiccated Desert treasure chest spawns for Medium Pal Souls.【palfandom-medium-pal-soul-raw†L12-L38】"
+    },
+    "palfandom-venom-gland": {
+      "title": "Venom Gland \u2013 Palworld Wiki (Fandom)",
+      "url": "https://palworld.fandom.com/wiki/Venom_Gland",
+      "access_date": "2025-10-31",
+      "notes": "Lists Venom Gland drops from Killamari, Helzephyr, and Menasting plus merchant sales, highlighting multi-source farming loops.【palfandom-venom-gland†L11-L34】"
     },
     "palfandom-precious-dragon-stone": {
       "title": "Precious Dragon Stone \u2013 Palworld Wiki (Fandom)",


### PR DESCRIPTION
## Summary
- add the Venom Gland Supply Network catalog entry with shortage menu flag and multi-source farming steps
- register the Killamari, Menasting, and Venom Gland source citations in the guides markdown
- log the Venom Gland coverage progress and backlog update in agent.md

## Testing
- node -e "JSON.parse(require('fs').readFileSync('data/guide_catalog.json','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68dfe5a4c93883318b1c9194bb30c3e2