### PR TITLE
Add cotton candy Woolipop ranch route

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -127,3 +127,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Locate a second independent map citation with explicit Galeclaw spawn coordinates (e.g., interactive map exports) to strengthen location guidance beyond the Fandom listing.
 2. Audit late-game cooking routes (Cake, Luxury Meals) to ensure they reference Galeclaw poultry in their prerequisites now that the supply loop exists.
 3. Prototype a sanctuary/alpha follow-up once reliable Caprity citations land so higher-tier poultry inputs (Caprity Meat) can chain directly from this route.
+
+### 2025-11-07 Cotton Candy ranch automation
+
+* Added the `resource-cotton-candy` route with breeding-focused steps, checkpoints, and adaptive guidance so shortages now surface a Woolipop ranch loop.
+* Synced `data/guides.bundle.json` and `data/guide_catalog.json` to expose the new resource in the client shortage menu, including merchant/breeding metadata.
+* Captured new rendered citations (`palwiki-breeding-render`, `palwiki-woolipop-breeding`) and registered them in the source registry alongside existing cotton candy/woolipop entries.
+
+**Continuation notes:**
+
+1. Source a field citation for wild Woolipop spawn coordinates (e.g., interactive map export) so the route can offer an alternate capture path for players without cake.
+2. Confirm whether any merchants sell Cotton Candy directly and, if so, add a `trade` branch plus catalog link for rapid restocks.
+3. After production deploy, verify the shortages UI removes Cotton Candy from `resourceGuideGaps`; if not, regenerate the production bundles and investigate parser expectations.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8354,91 +8354,91 @@
               "id": "high_quality_pal_oil",
               "slug": "high-quality-pal-oil",
               "name": "High Quality Pal Oil"
-        }
-      ]
-    },
-    {
-      "id": "resource-galeclaw-poultry-skyridge",
-      "title": "Galeclaw Poultry Skyridge Circuit",
-      "source_heading": "Galeclaw Poultry Skyridge Circuit",
-      "category": "Resources",
-      "category_group": "Resources & Crafting",
-      "shortage_menu": true,
-      "trigger": "Player needs Galeclaw Poultry for mid-game cooking buffs and basic Chikipi runs are too slow.",
-      "keywords": [
-        "galeclaw poultry",
-        "meat cleaver",
-        "small settlement",
-        "cooler box"
-      ],
-      "steps": [
-        {
-          "order": 1,
-          "instruction": "Fast travel to the **Small Settlement (75,-479)** and sweep the western ridge to capture Galeclaw flights.",
-          "citations": [
-            "palwiki-small-settlement\u2020L3-L15",
-            "palfandom-windswept-hills-raw\u2020L24-L40"
-          ],
-          "links": [
-            {
-              "type": "location",
-              "id": "small-settlement",
-              "name": "Small Settlement",
-              "region": "Windswept Hills"
-            },
-            {
-              "type": "pal",
-              "id": "galeclaw",
-              "slug": "galeclaw",
-              "name": "Galeclaw"
             }
           ]
         },
         {
-          "order": 2,
-          "instruction": "Craft the **Meat Cleaver** and butcher captured Galeclaw—each yields one Galeclaw Poultry at 100%.",
-          "citations": [
-            "palwiki-meat-cleaver\u2020L20-L39",
-            "palwiki-galeclaw-raw\u2020L6-L33"
+          "id": "resource-galeclaw-poultry-skyridge",
+          "title": "Galeclaw Poultry Skyridge Circuit",
+          "source_heading": "Galeclaw Poultry Skyridge Circuit",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player needs Galeclaw Poultry for mid-game cooking buffs and basic Chikipi runs are too slow.",
+          "keywords": [
+            "galeclaw poultry",
+            "meat cleaver",
+            "small settlement",
+            "cooler box"
           ],
-          "links": [
+          "steps": [
             {
-              "type": "item",
-              "id": "meat-cleaver",
-              "slug": "meat-cleaver",
-              "name": "Meat Cleaver"
+              "order": 1,
+              "instruction": "Fast travel to the **Small Settlement (75,-479)** and sweep the western ridge to capture Galeclaw flights.",
+              "citations": [
+                "palwiki-small-settlement\u2020L3-L15",
+                "palfandom-windswept-hills-raw\u2020L24-L40"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "small-settlement",
+                  "name": "Small Settlement",
+                  "region": "Windswept Hills"
+                },
+                {
+                  "type": "pal",
+                  "id": "galeclaw",
+                  "slug": "galeclaw",
+                  "name": "Galeclaw"
+                }
+              ]
             },
             {
-              "type": "item",
-              "id": "galeclaw_poultry",
-              "slug": "galeclaw-poultry",
-              "name": "Galeclaw Poultry"
+              "order": 2,
+              "instruction": "Craft the **Meat Cleaver** and butcher captured Galeclaw\u2014each yields one Galeclaw Poultry at 100%.",
+              "citations": [
+                "palwiki-meat-cleaver\u2020L20-L39",
+                "palwiki-galeclaw-raw\u2020L6-L33"
+              ],
+              "links": [
+                {
+                  "type": "item",
+                  "id": "meat-cleaver",
+                  "slug": "meat-cleaver",
+                  "name": "Meat Cleaver"
+                },
+                {
+                  "type": "item",
+                  "id": "galeclaw_poultry",
+                  "slug": "galeclaw-poultry",
+                  "name": "Galeclaw Poultry"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Unlock a **Cooler Box** and assign a Cooling Pal so butchered poultry stays fresh between hunts.",
+              "citations": [
+                "palwiki-cooler-box-raw\u2020L1-L24",
+                "palwiki-galeclaw-raw\u2020L6-L33"
+              ],
+              "links": [
+                {
+                  "type": "structure",
+                  "id": "cooler-box",
+                  "name": "Cooler Box"
+                },
+                {
+                  "type": "pal",
+                  "id": "penking",
+                  "slug": "penking",
+                  "name": "Penking"
+                }
+              ]
             }
           ]
         },
-        {
-          "order": 3,
-          "instruction": "Unlock a **Cooler Box** and assign a Cooling Pal so butchered poultry stays fresh between hunts.",
-          "citations": [
-            "palwiki-cooler-box-raw\u2020L1-L24",
-            "palwiki-galeclaw-raw\u2020L6-L33"
-          ],
-          "links": [
-            {
-              "type": "structure",
-              "id": "cooler-box",
-              "name": "Cooler Box"
-            },
-            {
-              "type": "pal",
-              "id": "penking",
-              "slug": "penking",
-              "name": "Penking"
-            }
-          ]
-        }
-      ]
-    },
         {
           "order": 2,
           "instruction": "Capture **Elphidran** at **No. 1 Wildlife Sanctuary (90,-735)** for guaranteed 2\u20133 oil drops per capture.",
@@ -8505,6 +8505,93 @@
               "id": "high_quality_pal_oil",
               "slug": "high-quality-pal-oil",
               "name": "High Quality Pal Oil"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "resource-cotton-candy-woolipop",
+      "title": "Cotton Candy Woolipop Confection Loop",
+      "source_heading": "Cotton Candy Woolipop Confection Loop",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player needs Cotton Candy for desserts or trade stock and lacks a reliable ranch supply.",
+      "keywords": [
+        "cotton candy",
+        "woolipop",
+        "breeding",
+        "cake"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "**Bake cake and unlock the Breeding Farm** so you can load at least one cake and assign a male and female parent before hatching begins.",
+          "citations": [
+            "palwiki-breeding-render\u2020L1-L3",
+            "palwiki-cotton-candy\u2020L4-L24"
+          ],
+          "links": [
+            {
+              "type": "structure",
+              "id": "breeding-farm",
+              "name": "Breeding Farm"
+            },
+            {
+              "type": "item",
+              "id": "cake",
+              "slug": "cake",
+              "name": "Cake"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "**Breed Lamball + Mozzarina** at the farm to hatch Woolipop eggs without leaving Windswept Hills.",
+          "citations": [
+            "palwiki-woolipop-breeding\u2020L2-L9"
+          ],
+          "links": [
+            {
+              "type": "pal",
+              "id": "lamball",
+              "slug": "lamball",
+              "name": "Lamball"
+            },
+            {
+              "type": "pal",
+              "id": "mozzarina",
+              "slug": "mozzarina",
+              "name": "Mozzarina"
+            },
+            {
+              "type": "pal",
+              "id": "woolipop",
+              "slug": "woolipop",
+              "name": "Woolipop"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "**Assign Woolipop to a Ranch** to harvest 1\u20132 Cotton Candy per cycle and bank the sweets since they never expire.",
+          "citations": [
+            "palwiki-woolipop\u2020L12-L120",
+            "palwiki-cotton-candy\u2020L4-L24"
+          ],
+          "links": [
+            {
+              "type": "pal",
+              "id": "woolipop",
+              "slug": "woolipop",
+              "name": "Woolipop"
+            },
+            {
+              "type": "item",
+              "id": "cotton_candy",
+              "slug": "cotton-candy",
+              "name": "Cotton Candy"
             }
           ]
         }

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -14531,7 +14531,7 @@
         "resource_shortages": [
           {
             "item_id": "galeclaw_poultry",
-            "solution": "Cull two captured Galeclaw per loop—each yields one Galeclaw Poultry at 100%—then let the rest respawn for the next hunt.\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011"
+            "solution": "Cull two captured Galeclaw per loop\u2014each yields one Galeclaw Poultry at 100%\u2014then let the rest respawn for the next hunt.\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011"
           }
         ],
         "time_limited": "Fast travel to the Small Settlement, drop two flights, butcher them, and stash the cuts in a Cooler Box before logging off.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011",
@@ -14652,7 +14652,7 @@
           "step_id": "resource-galeclaw-poultry:002",
           "type": "craft",
           "summary": "Butcher Galeclaw for guaranteed poultry",
-          "detail": "Equip the Meat Cleaver (crafted at the Primitive Workbench for 5 Ingots, 20 Wood, 5 Stone) and butcher captured Galeclaw—each yields one Galeclaw Poultry at a 100% rate, so stagger culls to keep flyers in reserve.\u3010palwiki-meat-cleaver\u2020L20-L39\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011",
+          "detail": "Equip the Meat Cleaver (crafted at the Primitive Workbench for 5 Ingots, 20 Wood, 5 Stone) and butcher captured Galeclaw\u2014each yields one Galeclaw Poultry at a 100% rate, so stagger culls to keep flyers in reserve.\u3010palwiki-meat-cleaver\u2020L20-L39\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011",
           "targets": [
             {
               "kind": "item",
@@ -14673,7 +14673,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Back up captures with spare spheres before butchering so a misclick doesn’t erase your only flyers.",
+              "tactics": "Back up captures with spare spheres before butchering so a misclick doesn\u2019t erase your only flyers.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -23337,6 +23337,327 @@
         {
           "route_id": "resource-poison-arrow",
           "reason": "Large Pal Souls support poison ammo upgrades once hair and glands are stocked."
+        }
+      ]
+    },
+    {
+      "route_id": "resource-cotton-candy",
+      "title": "Cotton Candy Woolipop Confection Loop",
+      "category": "resources",
+      "tags": [
+        "resource-farm",
+        "cotton-candy",
+        "dessert",
+        "support"
+      ],
+      "progression_role": "support",
+      "recommended_level": {
+        "min": 14,
+        "max": 32
+      },
+      "modes": {
+        "normal": true,
+        "hardcore": true,
+        "solo": true,
+        "coop": true
+      },
+      "prerequisites": {
+        "routes": [
+          "resource-cake",
+          "resource-lamball-mutton",
+          "resource-milk"
+        ],
+        "tech": [
+          "breeding-farm",
+          "ranch"
+        ],
+        "items": [
+          "cake"
+        ],
+        "pals": []
+      },
+      "objectives": [
+        "Stage breeding farm cake reserves and parent pals",
+        "Hatch Woolipop eggs from Lamball + Mozzarina pairs",
+        "Assign Woolipop to the ranch and warehouse surplus cotton candy"
+      ],
+      "estimated_time_minutes": {
+        "solo": 38,
+        "coop": 26
+      },
+      "estimated_xp_gain": {
+        "min": 180,
+        "max": 300
+      },
+      "risk_profile": "low",
+      "failure_penalties": {
+        "normal": "Losing the cake to idle parents stalls breeding until another batch is baked.",
+        "hardcore": "If raids kill Woolipop or parents you lose both cotton candy output and your breeding seed pair."
+      },
+      "adaptive_guidance": {
+        "underleveled": "Run the Lamball Mutton and Milk routes to capture Lamball and Mozzarina parents, then feed one cake into the Breeding Farm to produce a first Woolipop without hunting high-level zones.",
+        "overleveled": "Breed multiple Woolipop pairs so their guaranteed cotton candy and High Quality Pal Oil drops keep late-game confectionery and polymer lines humming.",
+        "resource_shortages": [
+          {
+            "item_id": "cotton_candy",
+            "solution": "Assign each Woolipop to the ranch\u2014Candy Pop guarantees 1\u20132 cotton candy per cycle and stock never spoils, so fill a chest before logging off."
+          }
+        ],
+        "time_limited": "Queue cakes ahead of time and let Woolipop work the ranch overnight\u2014the candy never expires, making it ideal for weekend prep.",
+        "dynamic_rules": [
+          {
+            "signal": "mode:coop",
+            "condition": "mode.coop === true",
+            "adjustment": "Have one player babysit incubators while the other rotates ranch assignments and restocks cake so eggs and candy flow in parallel.",
+            "priority": 2,
+            "mode_scope": [
+              "coop"
+            ],
+            "related_steps": [
+              "resource-cotton-candy:001",
+              "resource-cotton-candy:002",
+              "resource-cotton-candy:003"
+            ]
+          }
+        ]
+      },
+      "checkpoints": [
+        {
+          "id": "resource-cotton-candy:checkpoint-cake",
+          "label": "Breeding Farm Stocked",
+          "includes": [
+            "resource-cotton-candy:001"
+          ]
+        },
+        {
+          "id": "resource-cotton-candy:checkpoint-incubator",
+          "label": "Woolipop Hatchery Online",
+          "includes": [
+            "resource-cotton-candy:002"
+          ]
+        },
+        {
+          "id": "resource-cotton-candy:checkpoint-ranch",
+          "label": "Candy Ranch Output Stable",
+          "includes": [
+            "resource-cotton-candy:003"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "step_id": "resource-cotton-candy:001",
+          "type": "prepare",
+          "summary": "Stage cake and Breeding Farm staffing",
+          "detail": "Unlock the Breeding Farm, drop at least one cake into its chest, and assign a male and female parent so the queue can begin as soon as you deliver Lamball and Mozzarina.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "cake",
+              "qty": 2
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "base",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "adjustment": "Stock an extra cake and keep parents in the Palbox until raids end to avoid losing breeding bait.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [],
+            "pals": [],
+            "consumables": [
+              "cake"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 40,
+            "max": 60
+          },
+          "outputs": {
+            "items": [],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-cake"
+            }
+          ],
+          "citations": [
+            "palwiki-breeding-render\u2020L1-L3"
+          ]
+        },
+        {
+          "step_id": "resource-cotton-candy:002",
+          "type": "base",
+          "summary": "Pair Lamball and Mozzarina to hatch Woolipop",
+          "detail": "Pull a Lamball and Mozzarina from storage, assign them to the Breeding Farm with cake, and incubate the resulting Woolipop eggs; the combo is guaranteed and keeps you in early-game zones.",
+          "targets": [
+            {
+              "kind": "pal",
+              "id": "woolipop",
+              "qty": 2
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "base",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "coop": {
+              "role_splits": [
+                {
+                  "role": "breeder",
+                  "tasks": "Cycles parents and cake"
+                },
+                {
+                  "role": "runner",
+                  "tasks": "Monitors incubators and shuttles hatchlings to the ranch"
+                }
+              ],
+              "loot_rules": "Alternate ownership of hatched Woolipop so both players unlock the ranch drop."
+            }
+          },
+          "recommended_loadout": {
+            "gear": [],
+            "pals": [
+              "lamball",
+              "mozzarina"
+            ],
+            "consumables": [
+              "cake"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 80,
+            "max": 120
+          },
+          "outputs": {
+            "items": [],
+            "pals": [
+              "woolipop"
+            ],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-lamball-mutton"
+            },
+            {
+              "subroute_ref": "resource-milk"
+            }
+          ],
+          "citations": [
+            "palwiki-woolipop-breeding\u2020L2-L9",
+            "palwiki-breeding-render\u2020L1-L3"
+          ]
+        },
+        {
+          "step_id": "resource-cotton-candy:003",
+          "type": "assign",
+          "summary": "Staff Woolipop on the Ranch for cotton candy",
+          "detail": "Drop Woolipop onto the ranch: Candy Pop guarantees 1\u20132 cotton candy plus High Quality Pal Oil per cycle, and the sweets never spoil, so funnel output into chests for long-term buffs.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "cotton_candy",
+              "qty": 12
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "base",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Pen Woolipop behind walls or capture a Pal Merchant so raids cannot snipe your candy source.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [],
+            "pals": [
+              "woolipop"
+            ],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 60,
+            "max": 90
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "cotton_candy",
+                "qty": 12
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-high-quality-pal-oil"
+            }
+          ],
+          "citations": [
+            "palwiki-woolipop\u2020L12-L100",
+            "palwiki-cotton-candy\u2020L4-L24"
+          ]
+        }
+      ],
+      "completion_criteria": [
+        {
+          "type": "have-item",
+          "item_id": "cotton_candy",
+          "qty": 15
+        }
+      ],
+      "yields": {
+        "levels_estimate": "+0 to +1",
+        "key_unlocks": [
+          "cotton-candy-stockpile"
+        ]
+      },
+      "metrics": {
+        "progress_segments": 3,
+        "boss_targets": 0,
+        "quest_nodes": 0
+      },
+      "next_routes": [
+        {
+          "route_id": "resource-high-quality-pal-oil",
+          "reason": "Woolipop ranching doubles as a High Quality Pal Oil drip once your candy reserve is stable."
         }
       ]
     }

--- a/guides.md
+++ b/guides.md
@@ -24437,6 +24437,334 @@ High Quality Pal Oil Sanctuary Circuit stitches settlement merchant restocks wit
 }
 ```
 
+### Route: Cotton Candy Woolipop Confection Loop
+
+Cotton Candy Woolipop Confection Loop uses breeding-farm automation to hatch a steady Woolipop line, then stations the flock on your ranch so cotton candy stockpiles never expire between dessert batches.【palwiki-breeding-render†L1-L3】【palwiki-woolipop†L12-L120】【palwiki-cotton-candy†L4-L24】
+
+```json
+{
+  "route_id": "resource-cotton-candy",
+  "title": "Cotton Candy Woolipop Confection Loop",
+  "category": "resources",
+  "tags": [
+    "resource-farm",
+    "cotton-candy",
+    "dessert",
+    "support"
+  ],
+  "progression_role": "support",
+  "recommended_level": {
+    "min": 14,
+    "max": 32
+  },
+  "modes": {
+    "normal": true,
+    "hardcore": true,
+    "solo": true,
+    "coop": true
+  },
+  "prerequisites": {
+    "routes": [
+      "resource-cake",
+      "resource-lamball-mutton",
+      "resource-milk"
+    ],
+    "tech": [
+      "breeding-farm",
+      "ranch"
+    ],
+    "items": [
+      "cake"
+    ],
+    "pals": []
+  },
+  "objectives": [
+    "Stage breeding farm cake reserves and parent pals",
+    "Hatch Woolipop eggs from Lamball + Mozzarina pairs",
+    "Assign Woolipop to the ranch and warehouse surplus cotton candy"
+  ],
+  "estimated_time_minutes": {
+    "solo": 38,
+    "coop": 26
+  },
+  "estimated_xp_gain": {
+    "min": 180,
+    "max": 300
+  },
+  "risk_profile": "low",
+  "failure_penalties": {
+    "normal": "Losing the cake to idle parents stalls breeding until another batch is baked.",
+    "hardcore": "If raids kill Woolipop or parents you lose both cotton candy output and your breeding seed pair."
+  },
+  "adaptive_guidance": {
+    "underleveled": "Run the Lamball Mutton and Milk routes to capture Lamball and Mozzarina parents, then feed one cake into the Breeding Farm to produce a first Woolipop without hunting high-level zones.【palwiki-breeding-render†L1-L3】【palwiki-woolipop-breeding†L2-L9】",
+    "overleveled": "Breed multiple Woolipop pairs so their guaranteed cotton candy and High Quality Pal Oil drops keep late-game confectionery and polymer lines humming.【palwiki-woolipop†L66-L100】",
+    "resource_shortages": [
+      {
+        "item_id": "cotton_candy",
+        "solution": "Assign each Woolipop to the ranch—Candy Pop guarantees 1–2 cotton candy per cycle and stock never spoils, so fill a chest before logging off.【palwiki-woolipop†L12-L120】【palwiki-cotton-candy†L4-L24】"
+      }
+    ],
+    "time_limited": "Queue cakes ahead of time and let Woolipop work the ranch overnight—the candy never expires, making it ideal for weekend prep.【palwiki-cotton-candy†L4-L24】",
+    "dynamic_rules": [
+      {
+        "signal": "mode:coop",
+        "condition": "mode.coop === true",
+        "adjustment": "Have one player babysit incubators while the other rotates ranch assignments and restocks cake so eggs and candy flow in parallel.",
+        "priority": 2,
+        "mode_scope": [
+          "coop"
+        ],
+        "related_steps": [
+          "resource-cotton-candy:001",
+          "resource-cotton-candy:002",
+          "resource-cotton-candy:003"
+        ]
+      }
+    ]
+  },
+  "checkpoints": [
+    {
+      "id": "resource-cotton-candy:checkpoint-cake",
+      "label": "Breeding Farm Stocked",
+      "includes": [
+        "resource-cotton-candy:001"
+      ]
+    },
+    {
+      "id": "resource-cotton-candy:checkpoint-incubator",
+      "label": "Woolipop Hatchery Online",
+      "includes": [
+        "resource-cotton-candy:002"
+      ]
+    },
+    {
+      "id": "resource-cotton-candy:checkpoint-ranch",
+      "label": "Candy Ranch Output Stable",
+      "includes": [
+        "resource-cotton-candy:003"
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "step_id": "resource-cotton-candy:001",
+      "type": "prepare",
+      "summary": "Stage cake and Breeding Farm staffing",
+      "detail": "Unlock the Breeding Farm, drop at least one cake into its chest, and assign a male and female parent so the queue can begin as soon as you deliver Lamball and Mozzarina.【palwiki-breeding-render†L1-L3】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "cake",
+          "qty": 2
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "base",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "adjustment": "Stock an extra cake and keep parents in the Palbox until raids end to avoid losing breeding bait.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [],
+        "pals": [],
+        "consumables": [
+          "cake"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 40,
+        "max": 60
+      },
+      "outputs": {
+        "items": [],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-cake"
+        }
+      ],
+      "citations": [
+        "palwiki-breeding-render†L1-L3"
+      ]
+    },
+    {
+      "step_id": "resource-cotton-candy:002",
+      "type": "base",
+      "summary": "Pair Lamball and Mozzarina to hatch Woolipop",
+      "detail": "Pull a Lamball and Mozzarina from storage, assign them to the Breeding Farm with cake, and incubate the resulting Woolipop eggs; the combo is guaranteed and keeps you in early-game zones.【palwiki-woolipop-breeding†L2-L9】【palwiki-breeding-render†L1-L3】",
+      "targets": [
+        {
+          "kind": "pal",
+          "id": "woolipop",
+          "qty": 2
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "base",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "coop": {
+          "role_splits": [
+            {
+              "role": "breeder",
+              "tasks": "Cycles parents and cake"
+            },
+            {
+              "role": "runner",
+              "tasks": "Monitors incubators and shuttles hatchlings to the ranch"
+            }
+          ],
+          "loot_rules": "Alternate ownership of hatched Woolipop so both players unlock the ranch drop."
+        }
+      },
+      "recommended_loadout": {
+        "gear": [],
+        "pals": [
+          "lamball",
+          "mozzarina"
+        ],
+        "consumables": [
+          "cake"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 80,
+        "max": 120
+      },
+      "outputs": {
+        "items": [],
+        "pals": [
+          "woolipop"
+        ],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-lamball-mutton"
+        },
+        {
+          "subroute_ref": "resource-milk"
+        }
+      ],
+      "citations": [
+        "palwiki-woolipop-breeding†L2-L9",
+        "palwiki-breeding-render†L1-L3"
+      ]
+    },
+    {
+      "step_id": "resource-cotton-candy:003",
+      "type": "assign",
+      "summary": "Staff Woolipop on the Ranch for cotton candy",
+      "detail": "Drop Woolipop onto the ranch: Candy Pop guarantees 1–2 cotton candy plus High Quality Pal Oil per cycle, and the sweets never spoil, so funnel output into chests for long-term buffs.【palwiki-woolipop†L12-L100】【palwiki-cotton-candy†L4-L24】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "cotton_candy",
+          "qty": 12
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "base",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Pen Woolipop behind walls or capture a Pal Merchant so raids cannot snipe your candy source.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [],
+        "pals": [
+          "woolipop"
+        ],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 60,
+        "max": 90
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "cotton_candy",
+            "qty": 12
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-high-quality-pal-oil"
+        }
+      ],
+      "citations": [
+        "palwiki-woolipop†L12-L100",
+        "palwiki-cotton-candy†L4-L24"
+      ]
+    }
+  ],
+  "completion_criteria": [
+    {
+      "type": "have-item",
+      "item_id": "cotton_candy",
+      "qty": 15
+    }
+  ],
+  "yields": {
+    "levels_estimate": "+0 to +1",
+    "key_unlocks": [
+      "cotton-candy-stockpile"
+    ]
+  },
+  "metrics": {
+    "progress_segments": 3,
+    "boss_targets": 0,
+    "quest_nodes": 0
+  },
+  "next_routes": [
+    {
+      "route_id": "resource-high-quality-pal-oil",
+      "reason": "Woolipop ranching doubles as a High Quality Pal Oil drip once your candy reserve is stable."
+    }
+  ]
+}
+```
+
 ## Source Registry
 
 The source registry maps the short citation keys used throughout this file
@@ -24847,6 +25175,18 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/index.php?title=Mozzarina&action=raw",
       "access_date": "2025-10-27",
       "notes": "Shows Mozzarina Meat dropping in 2\u20133 piece bundles at 100% alongside guaranteed milk for both normal and alpha variants.\u3010palwiki-mozzarina-raw\u2020L65-L105\u3011"
+    },
+    "palwiki-breeding-render": {
+      "title": "Breeding \u2013 Palworld Wiki (rendered)",
+      "url": "https://palworld.fandom.com/wiki/Breeding?action=render",
+      "access_date": "2025-11-07",
+      "notes": "Rendered page states the Breeding Farm needs a male and female Pal plus Cake to produce eggs.\u3010palwiki-breeding-render\u2020L1-L3\u3011"
+    },
+    "palwiki-woolipop-breeding": {
+      "title": "Woolipop \u2013 Palworld Wiki (breeding render)",
+      "url": "https://palworld.fandom.com/wiki/Woolipop?action=render",
+      "access_date": "2025-11-07",
+      "notes": "Lists breeding combinations including Lamball + Mozzarina yielding Woolipop eggs.\u3010palwiki-woolipop-breeding\u2020L2-L9\u3011"
     },
     "palwiki-gumoss": {
       "title": "Gumoss \u2013 Palworld Wiki (Fandom)",

--- a/sources/palwiki-breeding-render.txt
+++ b/sources/palwiki-breeding-render.txt
@@ -1,0 +1,3 @@
+Breeding overview — palworld.fandom.com (rendered HTML)
+To breed Pals together you will need a Breeding Farm. Once you place the Breeding Farm you must assign a male and female Pal. The Breeding Farm also needs to be supplied with Cake. After some time they will produce a Pal Egg which can then be incubated.
+Breeding eggs now have a slight chance to produce an Alpha Pal.

--- a/sources/palwiki-woolipop-breeding.txt
+++ b/sources/palwiki-woolipop-breeding.txt
@@ -1,0 +1,69 @@
+Woolipop breeding pairs — palworld.fandom.com (rendered HTML)
+Chikipi +  Reindrix
+Illuminant Slime +  Reindrix
+Teafant +  Melpaca
+Blue Slime +  Melpaca
+Mau +  Eikthyrdeer Terra
+Mau +  Dumud
+Lamball +  Mozzarina
+Lamball +  Lullu
+Cattiva +  Eikthyrdeer
+Cremis +  Eikthyrdeer
+Vixy +  Caprity
+Herbil +  Caprity
+Mau Cryst +  Lovander
+Lifmunk +  Loupmoon
+Lifmunk +  Yakumo
+Green Slime +  Loupmoon
+Green Slime +  Yakumo
+Hangyu Cryst +  Loupmoon
+Foxparks +  Fenglope
+Jellroy +  Fenglope
+Hoocrates +  Verdash
+Purple Slime +  Verdash
+Demon Eye +  Verdash
+Jelliette +  Verdash
+Depresso +  Robinquill Terra
+Enchanted Sword +  Robinquill Terra
+Eye of Cthulhu +  Robinquill Terra
+Jolthog +  Felbat
+Jolthog Cryst +  Robinquill
+Pengullet +  Galeclaw
+Pengullet +  Gorirat Terra
+Tocotoco +  Gorirat
+Cave Bat +  Gorirat
+Munchill +  Gorirat
+Fuack +  Vaelet
+Bristla +  Direhowl
+Rainbow Slime +  Direhowl
+Pengullet Lux +  Beegarde
+Pengullet Lux +  Turtacle Terra
+Ribbuny +  Beegarde
+Ribbuny +  Turtacle Terra
+Foxparks Cryst +  Beegarde
+Swee +  Cawgnito
+Finsider +  Cawgnito
+Fuack Ignis +  Gobfin
+Killamari +  Gobfin
+Flopie +  Gobfin Ignis
+Kelpsea Ignis +  Lunaris
+Kelpsea Ignis +  Turtacle
+Kelpsea +  Leezpunk
+Kelpsea +  Dazzi Noct
+Finsider Ignis +  Kikit
+Finsider Ignis +  Leezpunk
+Tanzee +  Rushoar
+Tanzee +  Kikit
+Killamari Primo +  Rushoar
+Killamari Primo +  Kikit
+Illuminant Bat +  Rushoar
+Illuminant Bat +  Kikit
+Smokie +  Rushoar
+Gumoss +  Leezpunk Ignis
+Daedream +  Maraith
+Daedream +  Wixen Noct
+Fuddler +  Wixen
+Fuddler +  Rooby
+Mimog +  Nox
+Gloopie +  Nox
+Woolipop +  Woolipop


### PR DESCRIPTION
## Summary
- add a Cotton Candy Woolipop Confection Loop route with breeding-focused steps and citations
- sync guides bundle, catalog entry, and new source registry records for the cotton candy shortage
- document the update and follow-on work in agent.md and store rendered breeding sources

## Testing
- python -m json.tool data/guides.bundle.json
- python -m json.tool data/guide_catalog.json

------
https://chatgpt.com/codex/tasks/task_e_68e00e3680488331b4ff973c0db42830