### PR TITLE
Integrate medium pal soul guide into shortage catalog

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -151,3 +151,14 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Gather a second independent map citation with explicit Daedream and Nox coordinate clusters (interactive map export or community atlas) to reinforce the hunt step beyond the Small Settlement anchor.
 2. Secure a dungeon-focused citation for Tombat/Felbat Small Pal Soul drops so the route can branch into late-game instanced loops for variety.
 3. Monitor production `resourceGuideGaps`; if Small Pal Soul remains listed post-deploy, inspect bundle ingestion and ensure the new catalog entry flags `shortage_menu: true` in downstream manifests.
+
+### 2025-11-12 Medium Pal Soul shortage sync
+
+* Promoted `resource-medium-pal-soul` into the shortage catalog so adaptive menus now surface Helzephyr raids, Sakurajima Sootseer clears, and Crusher balancing when Medium Pal Souls fall short.
+* Regenerated `data/guides.bundle.json` metadata so the embedded `guideCatalog` mirrors the new entry and updates the published guide count.
+
+**Continuation notes:**
+
+1. Add a secondary Helzephyr coordinate citation (interactive atlas or official map) so future updates can display exact patrol loops alongside the bridge landmark.
+2. Document medium-soul chest hotspots beyond Duneshelter once reliable coordinates or screenshots land; wire them into the catalog entry for parity with the route JSON.
+3. Audit downstream clients once bundles rebuild to ensure the new catalog record clears Medium Pal Soul from `resourceGuideGaps` and respects existing shortage sort order.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8640,9 +8640,51 @@
               "id": "nox",
               "slug": "nox",
               "name": "Nox"
-            }
+        }
+      ]
+    },
+    {
+      "id": "resource-medium-pal-soul-harmonization",
+      "title": "Medium Pal Soul Harmonization",
+      "source_heading": "Medium Pal Soul Harmonization",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player needs Medium Pal Souls to sustain Statue of Power upgrades or upscale Small Pal Soul production.",
+      "keywords": [
+        "medium pal soul",
+        "statue of power",
+        "crusher",
+        "helzephyr",
+        "sootseer"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Sweep the **Helzephyr ridges north of Bridge of the Twin Knights** after dusk to harvest rare Medium Pal Soul drops alongside Venom Glands.",
+          "citations": [
+            "palwiki-helzephyr-raw"
           ]
         },
+        {
+          "order": 2,
+          "instruction": "Raid **Sakurajima Sootseer camps at night**\u2014each kill guarantees Medium Pal Souls plus Bones and Crude Oil for statue stockpiles.",
+          "citations": [
+            "palwiki-sootseer"
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Teleport to **Duneshelter (357,347)**, loot desert chests, and run the **Crusher** so spare Small or Large souls convert into Medium Pal Souls between hunts.",
+          "citations": [
+            "palwiki-duneshelter-raw",
+            "palwiki-medium-pal-soul-raw",
+            "palfandom-medium-pal-soul-raw",
+            "palwiki-crusher-pal-soul-conversion"
+          ]
+        }
+      ]
+    },
         {
           "order": 2,
           "instruction": "Feed **Medium Pal Souls into the Crusher** before dawn so every medium converts into two small souls for statue offerings.",

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -23861,7 +23861,7 @@
           "step_id": "resource-small-pal-soul:002",
           "type": "craft",
           "summary": "Convert medium souls at the Crusher",
-          "detail": "Load the Crusher with Medium Pal Souls before dawn—each crush outputs two Small Pal Souls, letting you stretch sanctuary hauls or dungeon clears into twice the offerings needed for statue upgrades.",
+          "detail": "Load the Crusher with Medium Pal Souls before dawn\u2014each crush outputs two Small Pal Souls, letting you stretch sanctuary hauls or dungeon clears into twice the offerings needed for statue upgrades.",
           "targets": [
             {
               "kind": "item",
@@ -24397,7 +24397,7 @@
   },
   "guideCatalog": {
     "path": "data/guide_catalog.json",
-    "guide_count": 197,
+    "guide_count": 198,
     "fields": [
       "id",
       "title",
@@ -30309,6 +30309,48 @@
               "instruction": "Assign Dumud to a ranch to produce oil passively.",
               "citations": [
                 "9e983e\u2020L1-L26"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-medium-pal-soul-harmonization",
+          "title": "Medium Pal Soul Harmonization",
+          "source_heading": "Medium Pal Soul Harmonization",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player needs Medium Pal Souls to sustain Statue of Power upgrades or upscale Small Pal Soul production.",
+          "keywords": [
+            "medium pal soul",
+            "statue of power",
+            "crusher",
+            "helzephyr",
+            "sootseer"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Sweep the **Helzephyr ridges north of Bridge of the Twin Knights** after dusk to harvest rare Medium Pal Soul drops alongside Venom Glands.",
+              "citations": [
+                "palwiki-helzephyr-raw"
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Raid **Sakurajima Sootseer camps at night**\u2014each kill guarantees Medium Pal Souls plus Bones and Crude Oil for statue stockpiles.",
+              "citations": [
+                "palwiki-sootseer"
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Teleport to **Duneshelter (357,347)**, loot desert chests, and run the **Crusher** so spare Small or Large souls convert into Medium Pal Souls between hunts.",
+              "citations": [
+                "palwiki-duneshelter-raw",
+                "palwiki-medium-pal-soul-raw",
+                "palfandom-medium-pal-soul-raw",
+                "palwiki-crusher-pal-soul-conversion"
               ]
             }
           ]

--- a/guides.md
+++ b/guides.md
@@ -1173,7 +1173,7 @@ citations preserved where they existed in the source material).
 {
   "guide_catalog": {
     "path": "data/guide_catalog.json",
-    "guide_count": 201,
+    "guide_count": 202,
     "fields": [
       "id",
       "title",


### PR DESCRIPTION
## Summary
- add the medium pal soul harmonization guide to the catalog so it appears in shortage menus
- regenerate the bundled guide catalog metadata and counts to include the new entry
- log the catalog sync and follow-up research tasks in agent.md

## Testing
- not run (documentation and data only)


------
https://chatgpt.com/codex/tasks/task_e_68e01d266c4083319f7991ae6a8e9aa6