### PR TITLE
Add Broncherry Meat resource route

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -77,7 +77,7 @@ Key confirmations from the review:
 
 ### Backlog (Confirm Against `routeGuideData.resourceGuideGaps` Before Starting)
 
-* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **Broncherry Meat**, **Cotton Candy**, **High Quality Pal Oil**, **Small Pal Soul**, **Medium Pal Soul follow-ups (Crusher automation variants)**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
+* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **High Quality Pal Oil**, **Small Pal Soul**, **Medium Pal Soul follow-ups (Crusher automation variants)**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
 * Secondary targets once two independent citations are secured: **Milk auxiliary spawns**, **Seed restock timers (Tomato/Lettuce/Berry)**, **Elite alpha respawn timers for gemstone loops**, **Automation throughput benchmarks for Assembly Line/Power Grid resources**.
 
 Update this backlog whenever a guide ships or when a data source becomes available, and archive stale TODOs with reasoning if a resource becomes obsolete or its shortages are resolved by upstream patches.
@@ -162,3 +162,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Add a secondary Helzephyr coordinate citation (interactive atlas or official map) so future updates can display exact patrol loops alongside the bridge landmark.
 2. Document medium-soul chest hotspots beyond Duneshelter once reliable coordinates or screenshots land; wire them into the catalog entry for parity with the route JSON.
 3. Audit downstream clients once bundles rebuild to ensure the new catalog record clears Medium Pal Soul from `resourceGuideGaps` and respects existing shortage sort order.
+
+### 2025-11-13 Broncherry Meat caravan loop
+
+* Authored the `resource-broncherry-meat` route covering the (-222,-669) Alpha Broncherry loop and Meat Cleaver butchery so shortages can surface a guaranteed daily meat circuit.【palwiki-alpha-pals†L31-L104】【palwiki-broncherry-raw†L66-L103】【palwiki-meat-cleaver†L2-L38】
+* Synced the bundles and catalog entry so the shortage menu flags Broncherry Meat, including keywords and linkouts for Meat Cleaver crafting and Tomato Seed byproducts.
+* Registered `palwiki-broncherry-raw` in the source registry and refreshed `guides.bundle.json` metadata (`verified_at_utc` now 2025-11-13) to keep downstream clients in sync.
+
+**Continuation notes:**
+
+1. Secure a second independent citation for non-alpha Broncherry spawns (interactive map export or reputable guide) so future revisions can offer alternative hunt loops beyond the daily alpha kill.
+2. Capture quantitative butcher throughput (meat per hour, raid timers) once playtest data is available to tighten the estimated XP/output ranges in both the route JSON and shortage card.
+3. Audit downstream recipe routes (e.g., Rib Roast, hearty meals) to ensure they now reference the Broncherry Meat loop and surface dependencies appropriately once production bundles rebuild.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8598,6 +8598,86 @@
       ]
     },
     {
+      "id": "resource-broncherry-meat",
+      "title": "Broncherry Meat Caravan Loop",
+      "source_heading": "Broncherry Meat Caravan Loop",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player needs Broncherry Meat for high-tier meals and wants a dependable daily alpha route.",
+      "keywords": [
+        "broncherry meat",
+        "alpha pal",
+        "meat cleaver",
+        "tomato seeds"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "**Unlock the Meat Cleaver** at level 12 for 2 Tech Points, craft it at a Primitive Workbench, and equip it so the Butcher command appears for captured pals.",
+          "citations": [
+            "palwiki-meat-cleaver\u2020L2-L38"
+          ],
+          "links": [
+            {
+              "type": "item",
+              "id": "meat-cleaver",
+              "name": "Meat Cleaver"
+            },
+            {
+              "type": "structure",
+              "id": "primitive-workbench",
+              "name": "Primitive Workbench"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "**Clear or capture the level 23 Alpha Broncherry (-222,-669)** each in-game day to secure two guaranteed meat drops and a chance at Tomato Seeds.",
+          "citations": [
+            "palwiki-alpha-pals\u2020L31-L104",
+            "palwiki-broncherry-raw\u2020L66-L103"
+          ],
+          "links": [
+            {
+              "type": "pal",
+              "id": "broncherry",
+              "slug": "broncherry",
+              "name": "Broncherry"
+            },
+            {
+              "type": "location",
+              "id": "broncherry-alpha",
+              "name": "Broncherry Alpha Ridge",
+              "region": "Palpagos Overworld"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "**Butcher captured Broncherry at base** to double the meat haul and bank Tomato Seeds for plantations before the next daily respawn.",
+          "citations": [
+            "palwiki-broncherry-raw\u2020L66-L103",
+            "palwiki-meat-cleaver\u2020L2-L38"
+          ],
+          "links": [
+            {
+              "type": "item",
+              "id": "broncherry_meat",
+              "slug": "broncherry-meat",
+              "name": "Broncherry Meat"
+            },
+            {
+              "type": "item",
+              "id": "tomato_seeds",
+              "slug": "tomato-seeds",
+              "name": "Tomato Seeds"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "resource-small-pal-soul-night-loop",
       "title": "Small Pal Soul Night Hunts & Crusher Loop",
       "source_heading": "Small Pal Soul Night Hunts & Crusher Loop",

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schema_version": 2,
     "game_version": "v0.6.7 (build 1.079.736)",
-    "verified_at_utc": "2025-10-03T00:00:00Z",
-    "world_map_reference": "Palworld uses a two\u2011dimensional coordinate system where the X axis runs east\u2013west and the Y axis runs north\u2013south.  Coordinates may be positive or negative.  (0,0) lies near the initial spawn area on the main island.",
+    "verified_at_utc": "2025-11-13T00:00:00Z",
+    "world_map_reference": "Palworld uses a two‑dimensional coordinate system where the X axis runs east–west and the Y axis runs north–south.  Coordinates may be positive or negative.  (0,0) lies near the initial spawn area on the main island.",
     "difficulty_modes": [
       "normal",
       "hardcore"
@@ -280,12 +280,12 @@
       "capture_common_pal": {
         "min": 20,
         "max": 50,
-        "notes": "Capturing a new species yields a significant XP bonus compared with defeating it.  NameHero\u2019s leveling guide emphasises capturing Pals to gain XP\u3010116860197722081\u2020L96-L128\u3011."
+        "notes": "Capturing a new species yields a significant XP bonus compared with defeating it.  NameHero’s leveling guide emphasises capturing Pals to gain XP【116860197722081†L96-L128】."
       },
       "capture_rare_pal": {
         "min": 60,
         "max": 120,
-        "notes": "Rare or Alpha Pals award more XP (up to ~10\u00d7 for Alphas)."
+        "notes": "Rare or Alpha Pals award more XP (up to ~10× for Alphas)."
       },
       "defeat_pal": {
         "min": 10,
@@ -469,7 +469,7 @@
           "step_id": "starter-base-capture:001",
           "type": "gather",
           "summary": "Collect Wood and Stone",
-          "detail": "Harvest at least 20\u00a0Wood from trees and 15\u00a0Stone from boulders in the Windswept Hills.  Trees and stone nodes respawn quickly; use a primitive tool or your Pals to speed up collection.",
+          "detail": "Harvest at least 20 Wood from trees and 15 Stone from boulders in the Windswept Hills.  Trees and stone nodes respawn quickly; use a primitive tool or your Pals to speed up collection.",
           "targets": [
             {
               "kind": "item",
@@ -495,7 +495,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Avoid engaging hostile Pals while gathering; keep your HP above 50\u00a0% and carry extra berries.",
+              "tactics": "Avoid engaging hostile Pals while gathering; keep your HP above 50 % and carry extra berries.",
               "safety_buffer_items": [
                 {
                   "item_id": "wood",
@@ -551,7 +551,7 @@
           "step_id": "starter-base-capture:002",
           "type": "build",
           "summary": "Construct a Primitive Workbench",
-          "detail": "Open the construction menu and build a Primitive Workbench using 2\u00a0Wood\u3010907636800064548\u2020screenshot\u3011.  Place it near your gathering area.",
+          "detail": "Open the construction menu and build a Primitive Workbench using 2 Wood【907636800064548†screenshot】.  Place it near your gathering area.",
           "targets": [
             {
               "kind": "station",
@@ -597,7 +597,7 @@
           "step_id": "starter-base-capture:003",
           "type": "craft",
           "summary": "Craft Pal Spheres",
-          "detail": "Use the Primitive Workbench to craft at least five Pal\u00a0Spheres.  Each sphere requires Paldium Fragments (gathered from blue ore) and a small amount of Wood and Stone.  If you lack fragments, mine Paldium nodes along the river.",
+          "detail": "Use the Primitive Workbench to craft at least five Pal Spheres.  Each sphere requires Paldium Fragments (gathered from blue ore) and a small amount of Wood and Stone.  If you lack fragments, mine Paldium nodes along the river.",
           "targets": [
             {
               "kind": "item",
@@ -649,7 +649,7 @@
           "step_id": "starter-base-capture:004",
           "type": "capture",
           "summary": "Capture three early Pals",
-          "detail": "Throw Pal\u00a0Spheres at Lamball, Cattiva, Chikipi, Lifmunk or Foxparks in the Windswept Hills\u3010956200907149478\u2020L146-L169\u3011.  Approach from behind to improve your catch rate.  Capturing new species grants more XP than defeating them\u3010116860197722081\u2020L96-L128\u3011.",
+          "detail": "Throw Pal Spheres at Lamball, Cattiva, Chikipi, Lifmunk or Foxparks in the Windswept Hills【956200907149478†L146-L169】.  Approach from behind to improve your catch rate.  Capturing new species grants more XP than defeating them【116860197722081†L96-L128】.",
           "targets": [
             {
               "kind": "pal",
@@ -689,7 +689,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Avoid aggroing the nearby Mammorest boss while hunting\u3010956200907149478\u2020L146-L169\u3011.  Always keep a healing item ready.",
+              "tactics": "Avoid aggroing the nearby Mammorest boss while hunting【956200907149478†L146-L169】.  Always keep a healing item ready.",
               "safety_buffer_items": [
                 {
                   "item_id": "leather",
@@ -920,7 +920,7 @@
           {
             "signal": "resource_gap:leather_high",
             "condition": "resource_gaps contains leather >= 20",
-            "adjustment": "Run the Sea Breeze loop in :002 twice\u2014first clockwise around the Church, then along the Bridge of the Twin Knights\u2014to stock 20+ Leather in one outing.",
+            "adjustment": "Run the Sea Breeze loop in :002 twice—first clockwise around the Church, then along the Bridge of the Twin Knights—to stock 20+ Leather in one outing.",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -993,7 +993,7 @@
           "step_id": "resource-leather-early:001",
           "type": "travel",
           "summary": "Travel to leather hotspots",
-          "detail": "Head to the Sea\u00a0Breeze Archipelago Church or the Bridge of the Twin Knights.  These areas host large numbers of Foxparks, Rushoars and Fuacks, which all drop Leather\u3010840767909995613\u2020L78-L100\u3011\u3010840767909995613\u2020L106-L135\u3011.",
+          "detail": "Head to the Sea Breeze Archipelago Church or the Bridge of the Twin Knights.  These areas host large numbers of Foxparks, Rushoars and Fuacks, which all drop Leather【840767909995613†L78-L100】【840767909995613†L106-L135】.",
           "targets": [],
           "locations": [
             {
@@ -1041,8 +1041,8 @@
         {
           "step_id": "resource-leather-early:002",
           "type": "farm",
-          "summary": "Hunt leather\u2011dropping Pals",
-          "detail": "Defeat or capture Foxparks, Fuack, Rushoar, Melpaca, Vixy, Eikthyrdeer and Direhowl.  Each drop guarantees 1\u20133\u00a0Leather\u3010142053078936299\u2020L295-L311\u3011\u3010840767909995613\u2020L49-L103\u3011.  Use water Pals against fire types and electric Pals against water types.  Expect roughly 10\u201320\u00a0Leather/hour when solo and 20\u201330\u00a0Leather/hour in Co\u2011Op.",
+          "summary": "Hunt leather‑dropping Pals",
+          "detail": "Defeat or capture Foxparks, Fuack, Rushoar, Melpaca, Vixy, Eikthyrdeer and Direhowl.  Each drop guarantees 1–3 Leather【142053078936299†L295-L311】【840767909995613†L49-L103】.  Use water Pals against fire types and electric Pals against water types.  Expect roughly 10–20 Leather/hour when solo and 20–30 Leather/hour in Co‑Op.",
           "targets": [
             {
               "kind": "item",
@@ -1131,7 +1131,7 @@
           "step_id": "resource-leather-early:003",
           "type": "deliver",
           "summary": "Optionally buy Leather from merchants",
-          "detail": "If hunting is too risky, purchase Leather from a Wandering Merchant for approximately 150\u00a0gold each\u3010840767909995613\u2020L78-L100\u3011.",
+          "detail": "If hunting is too risky, purchase Leather from a Wandering Merchant for approximately 150 gold each【840767909995613†L78-L100】.",
           "targets": [
             {
               "kind": "item",
@@ -1251,7 +1251,7 @@
       },
       "risk_profile": "low",
       "failure_penalties": {
-        "normal": "Minimal\u2014only time spent",
+        "normal": "Minimal—only time spent",
         "hardcore": "Potential durability loss on tools"
       },
       "adaptive_guidance": {
@@ -1354,7 +1354,7 @@
           "step_id": "resource-paldium:001",
           "type": "gather",
           "summary": "Mine riverbed nodes",
-          "detail": "Follow the river south of the Windswept Hills fast travel statue.  Blue crystalline nodes respawn every few minutes and yield 2\u20134 fragments each\u3010palwiki-paldium\u2020L42-L71\u3011.",
+          "detail": "Follow the river south of the Windswept Hills fast travel statue.  Blue crystalline nodes respawn every few minutes and yield 2–4 fragments each【palwiki-paldium†L42-L71】.",
           "targets": [
             {
               "kind": "item",
@@ -1375,7 +1375,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Keep stamina above 50\u00a0% to dodge hostile Lamballs",
+              "tactics": "Keep stamina above 50 % to dodge hostile Lamballs",
               "safety_buffer_items": [
                 {
                   "item_id": "berry",
@@ -1429,7 +1429,7 @@
           "step_id": "resource-paldium:002",
           "type": "explore",
           "summary": "Hit cliffside outcrops",
-          "detail": "Circle the cliff ring northwest of the starting valley.  Surface fragments protrude from the ground and can be kicked for bonus drops, netting ~30 fragments per lap\u3010palwiki-paldium\u2020L86-L115\u3011.",
+          "detail": "Circle the cliff ring northwest of the starting valley.  Surface fragments protrude from the ground and can be kicked for bonus drops, netting ~30 fragments per lap【palwiki-paldium†L86-L115】.",
           "targets": [
             {
               "kind": "item",
@@ -1481,7 +1481,7 @@
           "step_id": "resource-paldium:003",
           "type": "craft",
           "summary": "Refine fragments from Ore",
-          "detail": "Back at base, smelt spare Ore into Ingots, then crush the leftovers to convert into extra fragments.  Each smelting cycle produces 2 fragments as a by-product when using the Primitive Furnace\u3010palwiki-paldium\u2020L118-L140\u3011.",
+          "detail": "Back at base, smelt spare Ore into Ingots, then crush the leftovers to convert into extra fragments.  Each smelting cycle produces 2 fragments as a by-product when using the Primitive Furnace【palwiki-paldium†L118-L140】.",
           "targets": [
             {
               "kind": "item",
@@ -1599,11 +1599,11 @@
       "risk_profile": "medium",
       "failure_penalties": {
         "normal": "Aggressive patrols near the shoreline can down you; respawning costs travel time.",
-        "hardcore": "Hardcore runs should avoid cliff combat\u2014fall damage while hauling fluids can be lethal."
+        "hardcore": "Hardcore runs should avoid cliff combat—fall damage while hauling fluids can be lethal."
       },
       "adaptive_guidance": {
-        "underleveled": "Capture only Pengullet during daylight and avoid the deeper coves where Syndicate scouts roam.\u3010palwiki-pengullet-fandom\u2020L1868-L1872\u3011",
-        "overleveled": "Chain Pengullet and Fuack loops without returning to base, filling storage with 30+ Pal Fluids per run.\u3010palwiki-pengullet\u2020L575-L619\u3011\u3010palwiki-fuack\u2020L1667-L1667\u3011",
+        "underleveled": "Capture only Pengullet during daylight and avoid the deeper coves where Syndicate scouts roam.【palwiki-pengullet-fandom†L1868-L1872】",
+        "overleveled": "Chain Pengullet and Fuack loops without returning to base, filling storage with 30+ Pal Fluids per run.【palwiki-pengullet†L575-L619】【palwiki-fuack†L1667-L1667】",
         "resource_shortages": [
           {
             "item_id": "pal-sphere",
@@ -1668,7 +1668,7 @@
           "step_id": "resource-pal-fluids:001",
           "type": "capture",
           "summary": "Sweep the Windswept shoreline for Pengullet",
-          "detail": "Follow the beach east of the Windswept Hills fast travel point. Pengullet congregate along the water, drop Pal Fluids on capture, and offer Watering utility for your base.\u3010palwiki-pengullet-fandom\u2020L1868-L1872\u3011\u3010palwiki-pengullet\u2020L575-L619\u3011",
+          "detail": "Follow the beach east of the Windswept Hills fast travel point. Pengullet congregate along the water, drop Pal Fluids on capture, and offer Watering utility for your base.【palwiki-pengullet-fandom†L1868-L1872】【palwiki-pengullet†L575-L619】",
           "targets": [
             {
               "kind": "item",
@@ -1735,7 +1735,7 @@
           "step_id": "resource-pal-fluids:002",
           "type": "capture",
           "summary": "Tag Fuack around inland ponds",
-          "detail": "Cut inland to the freshwater pools west of the plateau. Fuack roam around water sources, drop Pal Fluids alongside Leather, and bolster your Watering roster.\u3010palwiki-fuack\u2020L1853-L1859\u3011\u3010palwiki-fuack\u2020L1667-L1667\u3011",
+          "detail": "Cut inland to the freshwater pools west of the plateau. Fuack roam around water sources, drop Pal Fluids alongside Leather, and bolster your Watering roster.【palwiki-fuack†L1853-L1859】【palwiki-fuack†L1667-L1667】",
           "targets": [
             {
               "kind": "item",
@@ -1791,7 +1791,7 @@
           "step_id": "resource-pal-fluids:003",
           "type": "base",
           "summary": "Assign fluid workers or bottle extras",
-          "detail": "Back at base, station Pengullet or Fuack on Watering posts or cooking stations, then butcher surplus captures for additional Pal Fluids to feed polymer and medicine recipes.\u3010palwiki-pengullet\u2020L575-L619\u3011\u3010palwiki-fuack\u2020L1667-L1667\u3011",
+          "detail": "Back at base, station Pengullet or Fuack on Watering posts or cooking stations, then butcher surplus captures for additional Pal Fluids to feed polymer and medicine recipes.【palwiki-pengullet†L575-L619】【palwiki-fuack†L1667-L1667】",
           "targets": [
             {
               "kind": "item",
@@ -1908,12 +1908,12 @@
       },
       "risk_profile": "low",
       "failure_penalties": {
-        "normal": "Minimal\u2014Chikipi flee rather than fight, so only time is lost.",
+        "normal": "Minimal—Chikipi flee rather than fight, so only time is lost.",
         "hardcore": "Hardcore runs risk a stray patrol near the fields; keep distance if undergeared."
       },
       "adaptive_guidance": {
-        "underleveled": "Stay near the Palbox outskirts and capture one Chikipi at a time to avoid chain aggro.\u3010palwiki-chikipi\u2020L1850-L1857\u3011",
-        "overleveled": "Run the route twice per outing, filling both ranch slots and stockpiling 15+ Eggs for breeding queues.\u3010palwiki-chikipi\u2020L1667-L1693\u3011",
+        "underleveled": "Stay near the Palbox outskirts and capture one Chikipi at a time to avoid chain aggro.【palwiki-chikipi†L1850-L1857】",
+        "overleveled": "Run the route twice per outing, filling both ranch slots and stockpiling 15+ Eggs for breeding queues.【palwiki-chikipi†L1667-L1693】",
         "resource_shortages": [
           {
             "item_id": "pal-sphere",
@@ -1971,7 +1971,7 @@
         ]
       },
       "failure_recovery": {
-        "normal": "If a Chikipi faints, fast travel back to the Hills statue and repeat step :001\u2014respawns are fast.",
+        "normal": "If a Chikipi faints, fast travel back to the Hills statue and repeat step :001—respawns are fast.",
         "hardcore": "Avoid combat entirely; sprint away from patrols rather than risking a Hardcore wipe for a single egg."
       },
       "steps": [
@@ -1979,7 +1979,7 @@
           "step_id": "resource-egg:001",
           "type": "capture",
           "summary": "Gather Chikipi in Windswept Hills",
-          "detail": "Circle the grassy flats below the Palbox. Chikipi roam here constantly, lay eggs on the ground, and rarely fight back, so you can secure four layers quickly.\u3010palwiki-chikipi\u2020L1850-L1859\u3011",
+          "detail": "Circle the grassy flats below the Palbox. Chikipi roam here constantly, lay eggs on the ground, and rarely fight back, so you can secure four layers quickly.【palwiki-chikipi†L1850-L1859】",
           "targets": [
             {
               "kind": "pal",
@@ -2049,7 +2049,7 @@
           "step_id": "resource-egg:002",
           "type": "base",
           "summary": "Assign layers to the ranch",
-          "detail": "Place two captured Chikipi on the Ranch. Their Egg Layer partner skill produces eggs over time, so stagger assignments to keep timers rolling.\u3010palwiki-chikipi\u2020L1667-L1693\u3011",
+          "detail": "Place two captured Chikipi on the Ranch. Their Egg Layer partner skill produces eggs over time, so stagger assignments to keep timers rolling.【palwiki-chikipi†L1667-L1693】",
           "targets": [
             {
               "kind": "item",
@@ -2103,7 +2103,7 @@
           "step_id": "resource-egg:003",
           "type": "gather",
           "summary": "Scoop loose eggs while timers reset",
-          "detail": "Jog a perimeter lap through the same fields, collecting freshly laid eggs and watching for respawned Chikipi to top off your ranch roster.\u3010palwiki-chikipi\u2020L1850-L1859\u3011",
+          "detail": "Jog a perimeter lap through the same fields, collecting freshly laid eggs and watching for respawned Chikipi to top off your ranch roster.【palwiki-chikipi†L1850-L1859】",
           "targets": [
             {
               "kind": "item",
@@ -2223,15 +2223,15 @@
         "hardcore": "Drawing PIDF aggro at Duneshelter can snowball into squad wipes and merchant lockouts."
       },
       "adaptive_guidance": {
-        "underleveled": "Stick to the Small Settlement loop until you have spare seeds and tech unlocked before pushing into the desert merchants.\u3010palwiki-berry-seeds-raw\u2020L1-L18\u3011\u3010palwiki-small-settlement-raw\u2020L1-L11\u3011",
-        "overleveled": "Run the full Small Settlement to Duneshelter rotation to overstock seeds for multiple plantations.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-duneshelter-raw\u2020L1-L7\u3011",
+        "underleveled": "Stick to the Small Settlement loop until you have spare seeds and tech unlocked before pushing into the desert merchants.【palwiki-berry-seeds-raw†L1-L18】【palwiki-small-settlement-raw†L1-L11】",
+        "overleveled": "Run the full Small Settlement to Duneshelter rotation to overstock seeds for multiple plantations.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-duneshelter-raw†L1-L7】",
         "resource_shortages": [
           {
             "item_id": "berry-seeds",
-            "solution": "Alternate between harvesting local berry bushes and buying merchant stock each respawn to keep 30+ seeds banked.\u3010palwiki-berry-seeds-raw\u2020L1-L18\u3011\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-small-settlement-raw\u2020L1-L11\u3011"
+            "solution": "Alternate between harvesting local berry bushes and buying merchant stock each respawn to keep 30+ seeds banked.【palwiki-berry-seeds-raw†L1-L18】【palwiki-wandering-merchant-raw†L197-L252】【palwiki-small-settlement-raw†L1-L11】"
           }
         ],
-        "time_limited": "Sweep merchants for quick seed purchases, drop them into base storage, and let the plantation churn while you work on other goals.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-berry-plantation-raw\u2020L1-L34\u3011",
+        "time_limited": "Sweep merchants for quick seed purchases, drop them into base storage, and let the plantation churn while you work on other goals.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-berry-plantation-raw†L1-L34】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -2300,7 +2300,7 @@
           "step_id": "resource-berry-seeds:001",
           "type": "gather",
           "summary": "Harvest wild berry bushes",
-          "detail": "Fast travel to the Small Settlement (~75,-479) and loop the surrounding berry patches, interacting with Red Berry bushes for free seed drops while clearing low-level mobs for XP.\u3010palwiki-berry-seeds-raw\u2020L1-L18\u3011\u3010palwiki-small-settlement-raw\u2020L1-L11\u3011",
+          "detail": "Fast travel to the Small Settlement (~75,-479) and loop the surrounding berry patches, interacting with Red Berry bushes for free seed drops while clearing low-level mobs for XP.【palwiki-berry-seeds-raw†L1-L18】【palwiki-small-settlement-raw†L1-L11】",
           "targets": [
             {
               "kind": "item",
@@ -2350,7 +2350,7 @@
           "step_id": "resource-berry-seeds:002",
           "type": "trade",
           "summary": "Buy out settlement merchants",
-          "detail": "Rotate between the Small Settlement and Duneshelter merchants, buying Berry Seeds for 50 gold each whenever they restock so plantations never stall.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-small-settlement-raw\u2020L1-L11\u3011\u3010palwiki-duneshelter-raw\u2020L1-L7\u3011",
+          "detail": "Rotate between the Small Settlement and Duneshelter merchants, buying Berry Seeds for 50 gold each whenever they restock so plantations never stall.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-small-settlement-raw†L1-L11】【palwiki-duneshelter-raw†L1-L7】",
           "targets": [
             {
               "kind": "item",
@@ -2428,7 +2428,7 @@
           "step_id": "resource-berry-seeds:003",
           "type": "build",
           "summary": "Construct and staff a Berry Plantation",
-          "detail": "Spend 3 Berry Seeds, 20 Wood, and 20 Stone to place a Berry Plantation, then assign Planting, Watering, and Gathering pals so berries flow automatically.\u3010palwiki-berry-plantation-raw\u2020L1-L34\u3011",
+          "detail": "Spend 3 Berry Seeds, 20 Wood, and 20 Stone to place a Berry Plantation, then assign Planting, Watering, and Gathering pals so berries flow automatically.【palwiki-berry-plantation-raw†L1-L34】",
           "targets": [
             {
               "kind": "station",
@@ -2565,8 +2565,8 @@
         "hardcore": "Hardcore runs risk sacrificing early ranch workers; keep stamina high when kiting hostile patrols."
       },
       "adaptive_guidance": {
-        "underleveled": "Stick to the Windswept Hills meadows and capture docile Lamball pairs until you can safely travel to Sea Breeze.\u3010palwiki-lamball\u2020L620-L623\u3011\u3010goleap-region-levels\u2020L131-L147\u3011",
-        "overleveled": "Chain both regions in a single loop, hauling 25+ Wool before returning to base for tailoring queues.\u3010palwiki-lamball\u2020L620-L623\u3011",
+        "underleveled": "Stick to the Windswept Hills meadows and capture docile Lamball pairs until you can safely travel to Sea Breeze.【palwiki-lamball†L620-L623】【goleap-region-levels†L131-L147】",
+        "overleveled": "Chain both regions in a single loop, hauling 25+ Wool before returning to base for tailoring queues.【palwiki-lamball†L620-L623】",
         "resource_shortages": [
           {
             "item_id": "pal-sphere",
@@ -2578,7 +2578,7 @@
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Split duties\u2014one player lassos Lamball while the other clears respawn timers and escorts captives back to base.",
+            "adjustment": "Split duties—one player lassos Lamball while the other clears respawn timers and escorts captives back to base.",
             "priority": 3,
             "mode_scope": [
               "coop"
@@ -2647,7 +2647,7 @@
           "step_id": "resource-wool:001",
           "type": "capture",
           "summary": "Net Lamball herds in Windswept Hills",
-          "detail": "Teleport to the Windswept Hills statue and sweep the meadows south of the plateau. Lamball spawn here in friendly pairs and drop 1\u20133 Wool per capture, letting you recruit three ranch hands quickly.\u3010palwiki-lamball\u2020L575-L623\u3011\u3010goleap-region-levels\u2020L131-L147\u3011",
+          "detail": "Teleport to the Windswept Hills statue and sweep the meadows south of the plateau. Lamball spawn here in friendly pairs and drop 1–3 Wool per capture, letting you recruit three ranch hands quickly.【palwiki-lamball†L575-L623】【goleap-region-levels†L131-L147】",
           "targets": [
             {
               "kind": "pal",
@@ -2727,7 +2727,7 @@
           "step_id": "resource-wool:002",
           "type": "capture",
           "summary": "Rotate through Sea Breeze Archipelago pastures",
-          "detail": "Sail or glide to the Sea Breeze Archipelago and loop the coastal fields north of the Church. Lamball spawn here at similar levels, ensuring replacement workers and extra Wool for crafting stock.\u3010palwiki-lamball\u2020L620-L623\u3011",
+          "detail": "Sail or glide to the Sea Breeze Archipelago and loop the coastal fields north of the Church. Lamball spawn here at similar levels, ensuring replacement workers and extra Wool for crafting stock.【palwiki-lamball†L620-L623】",
           "targets": [
             {
               "kind": "item",
@@ -2781,7 +2781,7 @@
           "step_id": "resource-wool:003",
           "type": "base",
           "summary": "Staff the ranch and weave cloth",
-          "detail": "Back at base, assign two Lamball to the Ranch so they passively generate Wool, then queue Cloth recipes at the workbench for early armor upgrades.\u3010palwiki-lamball\u2020L433-L623\u3011",
+          "detail": "Back at base, assign two Lamball to the Ranch so they passively generate Wool, then queue Cloth recipes at the workbench for early armor upgrades.【palwiki-lamball†L433-L623】",
           "targets": [
             {
               "kind": "item",
@@ -2908,8 +2908,8 @@
         "hardcore": "Level 30 patrols around Mossanda Forest can one-shot undergeared players."
       },
       "adaptive_guidance": {
-        "underleveled": "Stay near Cinnamoth Forest (-74,-279) and net 6+ honey from level 18 Cinnamoth before approaching Mossanda Forest Pals.\u3010pcgamesn-honey\u2020L135-L144\u3011",
-        "overleveled": "Chain Cinnamoth and Mossanda loops without fast travel to restock 20+ honey in a single outing.\u3010pcgamesn-honey\u2020L135-L145\u3011",
+        "underleveled": "Stay near Cinnamoth Forest (-74,-279) and net 6+ honey from level 18 Cinnamoth before approaching Mossanda Forest Pals.【pcgamesn-honey†L135-L144】",
+        "overleveled": "Chain Cinnamoth and Mossanda loops without fast travel to restock 20+ honey in a single outing.【pcgamesn-honey†L135-L145】",
         "resource_shortages": [
           {
             "item_id": "pal-sphere",
@@ -2921,7 +2921,7 @@
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Split roles\u2014one player kites and weakens targets while the other nets captures and hauls honey.",
+            "adjustment": "Split roles—one player kites and weakens targets while the other nets captures and hauls honey.",
             "priority": 2,
             "mode_scope": [
               "coop"
@@ -2990,7 +2990,7 @@
           "step_id": "resource-honey:001",
           "type": "capture",
           "summary": "Capture Cinnamoth near Cinnamoth Forest",
-          "detail": "Teleport to Cinnamoth Forest (-74,-279) north of the Bridge of the Twin Knights. The level ~18 Cinnamoth here drop Honey when captured or defeated, letting you stock 6\u20138 units quickly.\u3010pcgamesn-honey\u2020L135-L144\u3011",
+          "detail": "Teleport to Cinnamoth Forest (-74,-279) north of the Bridge of the Twin Knights. The level ~18 Cinnamoth here drop Honey when captured or defeated, letting you stock 6–8 units quickly.【pcgamesn-honey†L135-L144】",
           "targets": [
             {
               "kind": "item",
@@ -3056,7 +3056,7 @@
           "step_id": "resource-honey:002",
           "type": "capture",
           "summary": "Hunt Beegarde in Mossanda Forest",
-          "detail": "Travel to Mossanda Forest (234,-118). Level 20\u201330 Beegarde spawn in groups and reliably drop Honey; capture two or three to staff your ranch and stock additional drops.\u3010pcgamesn-honey\u2020L135-L145\u3011",
+          "detail": "Travel to Mossanda Forest (234,-118). Level 20–30 Beegarde spawn in groups and reliably drop Honey; capture two or three to staff your ranch and stock additional drops.【pcgamesn-honey†L135-L145】",
           "targets": [
             {
               "kind": "pal",
@@ -3131,7 +3131,7 @@
           "step_id": "resource-honey:003",
           "type": "base",
           "summary": "Assign Beegarde to your ranch",
-          "detail": "Back at base, assign captured Beegarde to a Ranch. They will periodically produce Honey without further intervention, keeping your cake pipeline stocked.\u3010pcgamesn-honey\u2020L146-L148\u3011\u3010palwiki-honey\u2020L402-L433\u3011",
+          "detail": "Back at base, assign captured Beegarde to a Ranch. They will periodically produce Honey without further intervention, keeping your cake pipeline stocked.【pcgamesn-honey†L146-L148】【palwiki-honey†L402-L433】",
           "targets": [
             {
               "kind": "item",
@@ -3259,8 +3259,8 @@
         "hardcore": "Heat and high-level enemies in late-game regions can wipe an unprepared team, costing gear."
       },
       "adaptive_guidance": {
-        "underleveled": "Loop the Hillside Cavern entrance nodes and reset rather than diving deep until you reach level 25.\u3010pcgamesn-coal\u2020L135-L138\u3011",
-        "overleveled": "Add the Desiccated Desert ridge and Astral Mountain outcrops to clear 60+ Coal per circuit.\u3010pcgamesn-coal\u2020L135-L138\u3011",
+        "underleveled": "Loop the Hillside Cavern entrance nodes and reset rather than diving deep until you reach level 25.【pcgamesn-coal†L135-L138】",
+        "overleveled": "Add the Desiccated Desert ridge and Astral Mountain outcrops to clear 60+ Coal per circuit.【pcgamesn-coal†L135-L138】",
         "resource_shortages": [
           {
             "item_id": "metal-pickaxe",
@@ -3339,7 +3339,7 @@
           "step_id": "resource-coal:001",
           "type": "gather",
           "summary": "Mine Hillside Cavern nodes",
-          "detail": "Enter Hillside Cavern at 147,-397 northeast of Rayne Syndicate Tower. Clear the Coal, Sulfur, and Ore clusters with a Metal Pickaxe, exiting before weight caps you.\u3010pcgamesn-coal\u2020L135-L138\u3011",
+          "detail": "Enter Hillside Cavern at 147,-397 northeast of Rayne Syndicate Tower. Clear the Coal, Sulfur, and Ore clusters with a Metal Pickaxe, exiting before weight caps you.【pcgamesn-coal†L135-L138】",
           "targets": [
             {
               "kind": "item",
@@ -3399,7 +3399,7 @@
           "step_id": "resource-coal:002",
           "type": "gather",
           "summary": "Survey high-yield ridges",
-          "detail": "Once geared, push into the Desiccated Desert ridgeline (~340,-120) and Astral Mountain foothills (~40, 320) where Coal veins respawn quickly but enemies hit much harder.\u3010pcgamesn-coal\u2020L135-L138\u3011",
+          "detail": "Once geared, push into the Desiccated Desert ridgeline (~340,-120) and Astral Mountain foothills (~40, 320) where Coal veins respawn quickly but enemies hit much harder.【pcgamesn-coal†L135-L138】",
           "targets": [
             {
               "kind": "item",
@@ -3472,7 +3472,7 @@
           "step_id": "resource-coal:003",
           "type": "craft",
           "summary": "Process Coal for Refined Ingots",
-          "detail": "Back at base, feed Coal and Ore into the Improved Furnace to create Refined Ingots, or run Stone through the Crusher for extra Coal fragments.\u3010palwiki-coal\u2020L388-L430\u3011",
+          "detail": "Back at base, feed Coal and Ore into the Improved Furnace to create Refined Ingots, or run Stone through the Crusher for extra Coal fragments.【palwiki-coal†L388-L430】",
           "targets": [
             {
               "kind": "item",
@@ -3600,12 +3600,12 @@
         "hardcore": "Volcanic DoTs stack quickly; a wipe at Mount Obsidian risks permanent loss of high-tier tools and Pals."
       },
       "adaptive_guidance": {
-        "underleveled": "Loop the Mossanda Forest ravine deposits until you can survive lava enemies deeper in Mount Obsidian.\u3010pcgamesn-sulfur\u2020L11-L19\u3011",
-        "overleveled": "Base out of the Eternal Pyre entrance and rotate chest drops between runs to keep Sulfur flowing for munitions.\u3010pcgamesn-sulfur\u2020L15-L20\u3011",
+        "underleveled": "Loop the Mossanda Forest ravine deposits until you can survive lava enemies deeper in Mount Obsidian.【pcgamesn-sulfur†L11-L19】",
+        "overleveled": "Base out of the Eternal Pyre entrance and rotate chest drops between runs to keep Sulfur flowing for munitions.【pcgamesn-sulfur†L15-L20】",
         "resource_shortages": [
           {
             "item_id": "gunpowder",
-            "solution": "Run step :003 immediately after mining so Sulfur converts into ammunition stock instead of sitting unused.\u3010pcgamesn-sulfur\u2020L11-L15\u3011"
+            "solution": "Run step :003 immediately after mining so Sulfur converts into ammunition stock instead of sitting unused.【pcgamesn-sulfur†L11-L15】"
           }
         ],
         "time_limited": "Hit step :001 for a 10-minute top-up, then fast travel home before heat attrition sets in.",
@@ -3691,7 +3691,7 @@
           "step_id": "resource-sulfur:001",
           "type": "gather",
           "summary": "Mine the Mossanda lava ravine",
-          "detail": "Head northeast of the Mossanda Forest fast travel statue (234,-118) to a lava ravine with early Sulfur nodes; clear the small clusters quickly before heat and encumbrance stack up.\u3010pcgamesn-sulfur\u2020L13-L19\u3011",
+          "detail": "Head northeast of the Mossanda Forest fast travel statue (234,-118) to a lava ravine with early Sulfur nodes; clear the small clusters quickly before heat and encumbrance stack up.【pcgamesn-sulfur†L13-L19】",
           "targets": [
             {
               "kind": "item",
@@ -3741,7 +3741,7 @@
           "step_id": "resource-sulfur:002",
           "type": "gather",
           "summary": "Loop Mount Obsidian deposits",
-          "detail": "Fast travel to the Brothers of the Eternal Pyre Tower (-588,-518), stage a chest outside, then sweep the surrounding lava flows while a Cattiva hauls ore and Sulfur back between passes.\u3010pcgamesn-sulfur\u2020L15-L20\u3011\u3010pcgamesn-bosses\u2020L7-L9\u3011\u3010palwiki-sulfur\u2020L5-L8\u3011",
+          "detail": "Fast travel to the Brothers of the Eternal Pyre Tower (-588,-518), stage a chest outside, then sweep the surrounding lava flows while a Cattiva hauls ore and Sulfur back between passes.【pcgamesn-sulfur†L15-L20】【pcgamesn-bosses†L7-L9】【palwiki-sulfur†L5-L8】",
           "targets": [
             {
               "kind": "item",
@@ -3810,7 +3810,7 @@
           "step_id": "resource-sulfur:003",
           "type": "craft",
           "summary": "Refine Sulfur into Gunpowder",
-          "detail": "Back at base, combine Sulfur with Coal at the High Quality Workbench to craft Gunpowder so ammunition production keeps pace with weapon demand.\u3010pcgamesn-sulfur\u2020L11-L15\u3011\u3010palwiki-sulfur\u2020L5-L8\u3011",
+          "detail": "Back at base, combine Sulfur with Coal at the High Quality Workbench to craft Gunpowder so ammunition production keeps pace with weapon demand.【pcgamesn-sulfur†L11-L15】【palwiki-sulfur†L5-L8】",
           "targets": [
             {
               "kind": "item",
@@ -3940,12 +3940,12 @@
         "hardcore": "Falls or freezes near Astral Mountain wipe end-game kits; regroup with spare cold gear before returning."
       },
       "adaptive_guidance": {
-        "underleveled": "Unlock the PAL Research Tower statue first, then run short mining bursts before elites converge.\u3010pcgamesn-pure-quartz\u2020L15-L20\u3011\u3010pcgamesn-bosses\u2020L11-L13\u3011",
-        "overleveled": "Claim a ridge base inside Astral Mountain so mining Pals harvest Pure Quartz passively between manual runs.\u3010pcgamesn-pure-quartz\u2020L19-L23\u3011",
+        "underleveled": "Unlock the PAL Research Tower statue first, then run short mining bursts before elites converge.【pcgamesn-pure-quartz†L15-L20】【pcgamesn-bosses†L11-L13】",
+        "overleveled": "Claim a ridge base inside Astral Mountain so mining Pals harvest Pure Quartz passively between manual runs.【pcgamesn-pure-quartz†L19-L23】",
         "resource_shortages": [
           {
             "item_id": "circuit-board",
-            "solution": "Feed Pure Quartz into step :003 immediately so circuit production stays ahead of polymer demand.\u3010pcgamesn-pure-quartz\u2020L21-L23\u3011"
+            "solution": "Feed Pure Quartz into step :003 immediately so circuit production stays ahead of polymer demand.【pcgamesn-pure-quartz†L21-L23】"
           }
         ],
         "time_limited": "Fast travel in, grab two node clusters near the tower, then recall home before respawns escalate.",
@@ -4032,7 +4032,7 @@
           "step_id": "resource-pure-quartz:001",
           "type": "travel",
           "summary": "Unlock PAL Research Tower access",
-          "detail": "Climb to the PAL Research Tower statue at roughly (-149,445) so you can fast travel straight onto the snowy slopes leading into Astral Mountain\u2019s Pure Quartz zone.\u3010pcgamesn-bosses\u2020L11-L13\u3011\u3010pcgamesn-pure-quartz\u2020L15-L20\u3011",
+          "detail": "Climb to the PAL Research Tower statue at roughly (-149,445) so you can fast travel straight onto the snowy slopes leading into Astral Mountain’s Pure Quartz zone.【pcgamesn-bosses†L11-L13】【pcgamesn-pure-quartz†L15-L20】",
           "targets": [],
           "locations": [
             {
@@ -4074,7 +4074,7 @@
           "step_id": "resource-pure-quartz:002",
           "type": "gather",
           "summary": "Mine Astral Mountain ridges",
-          "detail": "From the tower, sweep the Astral Mountain ridges for dark grey nodes with silver veins\u2014these are Pure Quartz deposits that require durable pickaxes to break efficiently.\u3010pcgamesn-pure-quartz\u2020L15-L19\u3011\u3010palwiki-pure-quartz\u2020L1-L3\u3011",
+          "detail": "From the tower, sweep the Astral Mountain ridges for dark grey nodes with silver veins—these are Pure Quartz deposits that require durable pickaxes to break efficiently.【pcgamesn-pure-quartz†L15-L19】【palwiki-pure-quartz†L1-L3】",
           "targets": [
             {
               "kind": "item",
@@ -4139,7 +4139,7 @@
           "step_id": "resource-pure-quartz:003",
           "type": "base",
           "summary": "Anchor an Astral mining outpost",
-          "detail": "Claim a base spot that includes Pure Quartz nodes and assign mining and transport Pals so the deposits respawn into storage while you craft circuit boards on-site.\u3010pcgamesn-pure-quartz\u2020L17-L23\u3011",
+          "detail": "Claim a base spot that includes Pure Quartz nodes and assign mining and transport Pals so the deposits respawn into storage while you craft circuit boards on-site.【pcgamesn-pure-quartz†L17-L23】",
           "targets": [
             {
               "kind": "item",
@@ -4259,12 +4259,12 @@
         "hardcore": "Losing the assembly crew in raids delays late-game gear since polymer feeds every advanced recipe."
       },
       "adaptive_guidance": {
-        "underleveled": "Unlock the Production Assembly Line at tech level 33, then run small polymer batches until you stockpile better gear.\u3010efa13d\u2020L9-L13\u3011",
-        "overleveled": "Queue long polymer runs overnight with multiple handiwork Pals so weapons and circuit boards never bottleneck.\u3010efa13d\u2020L9-L16\u3011",
+        "underleveled": "Unlock the Production Assembly Line at tech level 33, then run small polymer batches until you stockpile better gear.【efa13d†L9-L13】",
+        "overleveled": "Queue long polymer runs overnight with multiple handiwork Pals so weapons and circuit boards never bottleneck.【efa13d†L9-L16】",
         "resource_shortages": [
           {
             "item_id": "high-quality-pal-oil",
-            "solution": "Assign Dumud to a Ranch and buy extra oil from merchants before starting long assembly queues.\u3010969e9d\u2020L1-L8\u3011"
+            "solution": "Assign Dumud to a Ranch and buy extra oil from merchants before starting long assembly queues.【969e9d†L1-L8】"
           }
         ],
         "time_limited": "Craft two quick batches in step :003, then shut down the line to avoid burning precious oil.",
@@ -4351,7 +4351,7 @@
           "step_id": "resource-polymer:001",
           "type": "build",
           "summary": "Unlock production assembly",
-          "detail": "Spend tech points at level 33 to unlock the Production Assembly Line and the Polymer recipe, then place the machine at base with power access.\u3010efa13d\u2020L9-L13\u3011",
+          "detail": "Spend tech points at level 33 to unlock the Production Assembly Line and the Polymer recipe, then place the machine at base with power access.【efa13d†L9-L13】",
           "targets": [
             {
               "kind": "tech",
@@ -4398,7 +4398,7 @@
           "step_id": "resource-polymer:002",
           "type": "farm",
           "summary": "Farm High Quality Pal Oil",
-          "detail": "Capture Dumud or other listed Pals and station them at a Ranch to generate High Quality Pal Oil, supplementing with merchant purchases as needed.\u3010969e9d\u2020L1-L8\u3011",
+          "detail": "Capture Dumud or other listed Pals and station them at a Ranch to generate High Quality Pal Oil, supplementing with merchant purchases as needed.【969e9d†L1-L8】",
           "targets": [
             {
               "kind": "item",
@@ -4464,7 +4464,7 @@
           "step_id": "resource-polymer:003",
           "type": "craft",
           "summary": "Run Polymer batches",
-          "detail": "Load the Production Assembly Line with 2 High Quality Pal Oil per craft and assign handiwork Pals to turn the stock into Polymer for weapons and circuit boards.\u3010efa13d\u2020L9-L16\u3011\u301099ff2c\u2020L5-L11\u3011",
+          "detail": "Load the Production Assembly Line with 2 High Quality Pal Oil per craft and assign handiwork Pals to turn the stock into Polymer for weapons and circuit boards.【efa13d†L9-L16】【99ff2c†L5-L11】",
           "targets": [
             {
               "kind": "item",
@@ -4586,12 +4586,12 @@
         "hardcore": "Letting raids hit without gunpowder can cost top-tier weapons and pals."
       },
       "adaptive_guidance": {
-        "underleveled": "Loop the Mossanda ravine deposits and Hillside Cavern entrance until you can survive level 30 patrols before pushing deeper.\u3010pcgamesn-sulfur\u2020L11-L19\u3011\u3010pcgamesn-coal\u2020L135-L138\u3011",
-        "overleveled": "Stage chests at the Eternal Pyre entrance and Astral ridges so mining pals ferry Sulfur and Coal while you queue gunpowder overnight.\u3010pcgamesn-sulfur\u2020L15-L20\u3011\u3010pcgamesn-coal\u2020L135-L138\u3011",
+        "underleveled": "Loop the Mossanda ravine deposits and Hillside Cavern entrance until you can survive level 30 patrols before pushing deeper.【pcgamesn-sulfur†L11-L19】【pcgamesn-coal†L135-L138】",
+        "overleveled": "Stage chests at the Eternal Pyre entrance and Astral ridges so mining pals ferry Sulfur and Coal while you queue gunpowder overnight.【pcgamesn-sulfur†L15-L20】【pcgamesn-coal†L135-L138】",
         "resource_shortages": [
           {
             "item_id": "charcoal",
-            "solution": "Feed furnaces with Wood stacks (2 per Charcoal) and keep a Kindling pal assigned so burners never stall.\u3010palwiki-charcoal\u2020L1-L7\u3011"
+            "solution": "Feed furnaces with Wood stacks (2 per Charcoal) and keep a Kindling pal assigned so burners never stall.【palwiki-charcoal†L1-L7】"
           }
         ],
         "time_limited": "Skip manual mining and craft from stored Sulfur and Charcoal for a quick 10-minute ammo top-up.",
@@ -4599,7 +4599,7 @@
           {
             "signal": "resource_gap:gunpowder_high",
             "condition": "resource_gaps contains gunpowder >= 60",
-            "adjustment": "Queue two batches in step :003 back-to-back and pause new weapon crafts until the deficit clears.\u3010palwiki-gunpowder\u2020L1-L1\u3011",
+            "adjustment": "Queue two batches in step :003 back-to-back and pause new weapon crafts until the deficit clears.【palwiki-gunpowder†L1-L1】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -4614,7 +4614,7 @@
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "One player runs the Sulfur loop while the other tends furnaces and workbench queues, swapping each cycle to manage stamina.\u3010pcgamesn-sulfur\u2020L13-L19\u3011\u3010pcgamesn-coal\u2020L135-L138\u3011",
+            "adjustment": "One player runs the Sulfur loop while the other tends furnaces and workbench queues, swapping each cycle to manage stamina.【pcgamesn-sulfur†L13-L19】【pcgamesn-coal†L135-L138】",
             "priority": 1,
             "mode_scope": [
               "coop"
@@ -4678,7 +4678,7 @@
           "step_id": "resource-gunpowder:001",
           "type": "gather",
           "summary": "Run Sulfur and Coal loops",
-          "detail": "Teleport to Mossanda Forest (234,-118) for Sulfur, then sweep Hillside Cavern at 147,-397 to refill Coal before recalling home; drop overflow in a chest outside the Eternal Pyre entrance.\u3010pcgamesn-sulfur\u2020L13-L19\u3011\u3010pcgamesn-coal\u2020L135-L138\u3011",
+          "detail": "Teleport to Mossanda Forest (234,-118) for Sulfur, then sweep Hillside Cavern at 147,-397 to refill Coal before recalling home; drop overflow in a chest outside the Eternal Pyre entrance.【pcgamesn-sulfur†L13-L19】【pcgamesn-coal†L135-L138】",
           "targets": [
             {
               "kind": "item",
@@ -4777,7 +4777,7 @@
           "step_id": "resource-gunpowder:002",
           "type": "craft",
           "summary": "Burn Wood into Charcoal",
-          "detail": "At base, load any furnace with Wood (2 per Charcoal) and assign a Kindling pal so the burn runs while you haul Sulfur in.\u3010palwiki-charcoal\u2020L1-L7\u3011",
+          "detail": "At base, load any furnace with Wood (2 per Charcoal) and assign a Kindling pal so the burn runs while you haul Sulfur in.【palwiki-charcoal†L1-L7】",
           "targets": [
             {
               "kind": "item",
@@ -4845,7 +4845,7 @@
           "step_id": "resource-gunpowder:003",
           "type": "craft",
           "summary": "Batch Gunpowder",
-          "detail": "Use the High Quality Workbench (or better) to combine 2 Charcoal with 1 Sulfur per craft, queuing 60 units so ammo benches never sit idle.\u3010palwiki-gunpowder\u2020L1-L1\u3011",
+          "detail": "Use the High Quality Workbench (or better) to combine 2 Charcoal with 1 Sulfur per craft, queuing 60 units so ammo benches never sit idle.【palwiki-gunpowder†L1-L1】",
           "targets": [
             {
               "kind": "item",
@@ -4977,7 +4977,7 @@
       "risk_profile": "medium",
       "failure_penalties": {
         "normal": "Knockouts drop your pouch and may cost gold if PIDF guards finish the fight.",
-        "hardcore": "Being executed by guards permanently ends the save\u2014retreat if health drops below 40%."
+        "hardcore": "Being executed by guards permanently ends the save—retreat if health drops below 40%."
       },
       "adaptive_guidance": {
         "underleveled": "If your weapons are below Iron tier, focus on trapping single merchants at night when patrols thin out before attempting the capture.",
@@ -4988,7 +4988,7 @@
             "solution": "Trigger resource-paldium from step :001 to restock fragments for higher-grade spheres."
           }
         ],
-        "time_limited": "Complete steps :001 and :002 only; mark the merchant\u2019s position and return later with time to handle the capture.",
+        "time_limited": "Complete steps :001 and :002 only; mark the merchant’s position and return later with time to handle the capture.",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -5060,7 +5060,7 @@
           "step_id": "capture-base-merchant:001",
           "type": "prepare",
           "summary": "Craft high-grade Pal Spheres",
-          "detail": "Use your best Pal Sphere recipe (Great or better) and craft at least six before leaving base. Human catch rates are far lower than standard Pals, so higher-grade spheres dramatically improve success odds\u3010529f5c\u2020L67-L80\u3011.",
+          "detail": "Use your best Pal Sphere recipe (Great or better) and craft at least six before leaving base. Human catch rates are far lower than standard Pals, so higher-grade spheres dramatically improve success odds【529f5c†L67-L80】.",
           "targets": [
             {
               "kind": "item",
@@ -5142,7 +5142,7 @@
           "step_id": "capture-base-merchant:002",
           "type": "travel",
           "summary": "Scout the Small Settlement",
-          "detail": "Ride or glide to the Small Settlement at approximately (75,\u00a0-479). The village hosts both a Pal Merchant and a Wandering Merchant\u2014confirm patrol routes and identify clear back alleys for the capture attempt\u3010165dd8\u2020L71-L90\u3011.",
+          "detail": "Ride or glide to the Small Settlement at approximately (75, -479). The village hosts both a Pal Merchant and a Wandering Merchant—confirm patrol routes and identify clear back alleys for the capture attempt【165dd8†L71-L90】.",
           "targets": [],
           "locations": [
             {
@@ -5200,7 +5200,7 @@
           "step_id": "capture-base-merchant:003",
           "type": "capture",
           "summary": "Weaken and capture the merchant",
-          "detail": "Aggro the merchant away from guards, chip them to low HP, then throw your high-grade Pal Spheres until the catch lands. All non-leader humans can be captured once weakened, but expect multiple throws because their catch rate is significantly lower than normal Pals\u3010529f5c\u2020L67-L90\u3011.",
+          "detail": "Aggro the merchant away from guards, chip them to low HP, then throw your high-grade Pal Spheres until the catch lands. All non-leader humans can be captured once weakened, but expect multiple throws because their catch rate is significantly lower than normal Pals【529f5c†L67-L90】.",
           "targets": [],
           "locations": [
             {
@@ -5215,7 +5215,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Use stun grenades or partner skills to avoid lethal retaliation\u2014you cannot afford PIDF executions."
+              "tactics": "Use stun grenades or partner skills to avoid lethal retaliation—you cannot afford PIDF executions."
             },
             "coop": {
               "role_splits": [
@@ -5263,7 +5263,7 @@
           "step_id": "capture-base-merchant:004",
           "type": "deliver",
           "summary": "Assign the merchant to your base",
-          "detail": "Place the captured merchant in your base party. Humans have only rank\u00a01 work suitability and cannot run farms or wield their weapons, but merchants stationed at your base permanently open their shop so you can buy and sell without hunting for a wandering spawn\u301094455f\u2020L13-L18\u3011\u3010529f5c\u2020L76-L90\u3011.",
+          "detail": "Place the captured merchant in your base party. Humans have only rank 1 work suitability and cannot run farms or wield their weapons, but merchants stationed at your base permanently open their shop so you can buy and sell without hunting for a wandering spawn【94455f†L13-L18】【529f5c†L76-L90】.",
           "targets": [],
           "locations": [
             {
@@ -5374,7 +5374,7 @@
         "resource_shortages": [
           {
             "item_id": "leather",
-            "solution": "Invoke resource-leather-early via step :003\u2019s branching."
+            "solution": "Invoke resource-leather-early via step :003’s branching."
           },
           {
             "item_id": "flame-organ",
@@ -5470,7 +5470,7 @@
           "step_id": "mount-foxparks-harness:001",
           "type": "capture",
           "summary": "Ensure you have a Foxparks",
-          "detail": "If you haven\u2019t already captured a Foxparks, travel to its spawn points around coordinates (189,\u00a0-478) or (144,\u00a0-583) in the Windswept Hills\u3010956200907149478\u2020L146-L169\u3011.  Use Water Pals to weaken it, then capture it with a Pal Sphere.",
+          "detail": "If you haven’t already captured a Foxparks, travel to its spawn points around coordinates (189, -478) or (144, -583) in the Windswept Hills【956200907149478†L146-L169】.  Use Water Pals to weaken it, then capture it with a Pal Sphere.",
           "targets": [
             {
               "kind": "pal",
@@ -5554,7 +5554,7 @@
           "step_id": "mount-foxparks-harness:002",
           "type": "unlock-tech",
           "summary": "Unlock the Foxparks Harness",
-          "detail": "Open the Technology menu at level\u00a06 and spend 1\u00a0tech point to unlock the Foxparks Harness\u3010353245298505537\u2020L150-L180\u3011.  This requires that you have already built a Pal Gear Workbench.",
+          "detail": "Open the Technology menu at level 6 and spend 1 tech point to unlock the Foxparks Harness【353245298505537†L150-L180】.  This requires that you have already built a Pal Gear Workbench.",
           "targets": [
             {
               "kind": "tech",
@@ -5590,7 +5590,7 @@
           "step_id": "mount-foxparks-harness:003",
           "type": "gather",
           "summary": "Collect materials",
-          "detail": "Gather 3\u00a0Leather, 5\u00a0Flame Organs and 5\u00a0Paldium Fragments.  Hunt Foxparks and Rushoars for Leather and Flame Organs, or branch to the leather farm route if you lack Leather.  Mine blue ore nodes for Paldium Fragments.",
+          "detail": "Gather 3 Leather, 5 Flame Organs and 5 Paldium Fragments.  Hunt Foxparks and Rushoars for Leather and Flame Organs, or branch to the leather farm route if you lack Leather.  Mine blue ore nodes for Paldium Fragments.",
           "targets": [
             {
               "kind": "item",
@@ -5697,7 +5697,7 @@
           "step_id": "mount-foxparks-harness:004",
           "type": "craft",
           "summary": "Craft the harness",
-          "detail": "At your Pal Gear Workbench, craft the Foxparks Harness using the collected materials\u3010353245298505537\u2020L150-L180\u3011.  The process takes about one minute.",
+          "detail": "At your Pal Gear Workbench, craft the Foxparks Harness using the collected materials【353245298505537†L150-L180】.  The process takes about one minute.",
           "targets": [
             {
               "kind": "item",
@@ -5745,7 +5745,7 @@
           "step_id": "mount-foxparks-harness:005",
           "type": "explore",
           "summary": "Equip the harness and use Foxparks",
-          "detail": "Equip the harness on Foxparks via the Pal menu.  Summon Foxparks, then hold the attack button to spray fire like a flamethrower\u3010513843636763139\u2020L117-L170\u3011.  This tool is excellent for clearing early dungeons and lighting furnaces.",
+          "detail": "Equip the harness on Foxparks via the Pal menu.  Summon Foxparks, then hold the attack button to spray fire like a flamethrower【513843636763139†L117-L170】.  This tool is excellent for clearing early dungeons and lighting furnaces.",
           "targets": [
             {
               "kind": "item",
@@ -5877,7 +5877,7 @@
           {
             "signal": "resource_gap:ingot",
             "condition": "resource_gaps contains ingot >= 10",
-            "adjustment": "Insert a furnace run before step :003\u2014queue 5 ore batches to cover the ingot deficit while other materials are gathered.",
+            "adjustment": "Insert a furnace run before step :003—queue 5 ore batches to cover the ingot deficit while other materials are gathered.",
             "priority": 1,
             "mode_scope": [
               "normal",
@@ -5964,7 +5964,7 @@
           "step_id": "mount-eikthyrdeer-saddle:001",
           "type": "capture",
           "summary": "Catch an Eikthyrdeer",
-          "detail": "Travel northwest of the starting area near the Rayne Syndicate Tower and locate an Eikthyrdeer\u3010963225160620124\u2020L140-L167\u3011.  Use Water or Fire Pals depending on the variant and capture it.",
+          "detail": "Travel northwest of the starting area near the Rayne Syndicate Tower and locate an Eikthyrdeer【963225160620124†L140-L167】.  Use Water or Fire Pals depending on the variant and capture it.",
           "targets": [
             {
               "kind": "pal",
@@ -5985,7 +5985,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Approach slowly and aim for a back attack; avoid the Tower\u2019s aggro range",
+              "tactics": "Approach slowly and aim for a back attack; avoid the Tower’s aggro range",
               "safety_buffer_items": [
                 {
                   "item_id": "pal-sphere",
@@ -6039,7 +6039,7 @@
           "step_id": "mount-eikthyrdeer-saddle:002",
           "type": "unlock-tech",
           "summary": "Unlock the saddle tech",
-          "detail": "At level\u00a012, spend 2\u00a0tech points to unlock the Eikthyrdeer Saddle\u3010963225160620124\u2020L160-L167\u3011.",
+          "detail": "At level 12, spend 2 tech points to unlock the Eikthyrdeer Saddle【963225160620124†L160-L167】.",
           "targets": [
             {
               "kind": "tech",
@@ -6075,7 +6075,7 @@
           "step_id": "mount-eikthyrdeer-saddle:003",
           "type": "gather",
           "summary": "Collect materials",
-          "detail": "Gather 5\u00a0Leather, 20\u00a0Fiber, 10\u00a0Ingots, 3\u00a0Horns and 15\u00a0Paldium Fragments\u3010963225160620124\u2020L160-L167\u3011.  Leather can be farmed using the leather subroute.  Fiber is harvested from bushes; Ingots require smelting ore.  Horns drop from Eikthyrdeer; if you only have one, defeat additional Eikthyrdeers.  Paldium comes from ore nodes.",
+          "detail": "Gather 5 Leather, 20 Fiber, 10 Ingots, 3 Horns and 15 Paldium Fragments【963225160620124†L160-L167】.  Leather can be farmed using the leather subroute.  Fiber is harvested from bushes; Ingots require smelting ore.  Horns drop from Eikthyrdeer; if you only have one, defeat additional Eikthyrdeers.  Paldium comes from ore nodes.",
           "targets": [
             {
               "kind": "item",
@@ -6125,7 +6125,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Gather a 20\u00a0% buffer (6\u00a0Leather, 24\u00a0Fiber) to account for mistakes",
+              "tactics": "Gather a 20 % buffer (6 Leather, 24 Fiber) to account for mistakes",
               "safety_buffer_items": [
                 {
                   "item_id": "leather",
@@ -6204,7 +6204,7 @@
           "step_id": "mount-eikthyrdeer-saddle:004",
           "type": "craft",
           "summary": "Craft the saddle",
-          "detail": "Use the Pal Gear Workbench to craft the Eikthyrdeer Saddle\u3010963225160620124\u2020L160-L167\u3011.  The process takes around 90\u00a0seconds.",
+          "detail": "Use the Pal Gear Workbench to craft the Eikthyrdeer Saddle【963225160620124†L160-L167】.  The process takes around 90 seconds.",
           "targets": [
             {
               "kind": "item",
@@ -6252,7 +6252,7 @@
           "step_id": "mount-eikthyrdeer-saddle:005",
           "type": "explore",
           "summary": "Equip and ride your mount",
-          "detail": "Equip the saddle on Eikthyrdeer via the Pal menu and summon it.  Press LB to call the Pal and X to mount.  Enjoy increased movement speed, a double jump and improved logging efficiency\u3010142053078936299\u2020L123-L142\u3011.",
+          "detail": "Equip the saddle on Eikthyrdeer via the Pal menu and summon it.  Press LB to call the Pal and X to mount.  Enjoy increased movement speed, a double jump and improved logging efficiency【142053078936299†L123-L142】.",
           "targets": [
             {
               "kind": "pal",
@@ -6371,7 +6371,7 @@
       },
       "adaptive_guidance": {
         "underleveled": "Hunt Direhowl during dawn when fewer spawn together, and bring a tanky Pal to soak hits.",
-        "overleveled": "Use tranquilizer bolts to speed up captures; Direhowl\u2019s HP melts under high-tier gear.",
+        "overleveled": "Use tranquilizer bolts to speed up captures; Direhowl’s HP melts under high-tier gear.",
         "resource_shortages": [
           {
             "item_id": "wood",
@@ -6466,7 +6466,7 @@
           "step_id": "mount-direhowl-harness:001",
           "type": "capture",
           "summary": "Catch a Direhowl",
-          "detail": "Travel to the Moonless Shore or Twilight Dunes at night and locate a Direhowl.  Use Light element skills to weaken it and capture it with Pal\u00a0Spheres.",
+          "detail": "Travel to the Moonless Shore or Twilight Dunes at night and locate a Direhowl.  Use Light element skills to weaken it and capture it with Pal Spheres.",
           "targets": [
             {
               "kind": "pal",
@@ -6550,7 +6550,7 @@
           "step_id": "mount-direhowl-harness:002",
           "type": "unlock-tech",
           "summary": "Unlock Direhowl Harness tech",
-          "detail": "At level\u00a09, spend 1\u00a0tech point to unlock the Direhowl Harness\u3010197143349627535\u2020L151-L156\u3011.",
+          "detail": "At level 9, spend 1 tech point to unlock the Direhowl Harness【197143349627535†L151-L156】.",
           "targets": [
             {
               "kind": "tech",
@@ -6586,7 +6586,7 @@
           "step_id": "mount-direhowl-harness:003",
           "type": "gather",
           "summary": "Collect materials",
-          "detail": "Gather 10\u00a0Leather, 20\u00a0Wood, 15\u00a0Fiber and 10\u00a0Paldium Fragments\u3010197143349627535\u2020L151-L156\u3011.  Use the leather farming route if necessary.  Wood and Fiber can be collected around the Windswept Hills; Paldium from blue ore nodes.",
+          "detail": "Gather 10 Leather, 20 Wood, 15 Fiber and 10 Paldium Fragments【197143349627535†L151-L156】.  Use the leather farming route if necessary.  Wood and Fiber can be collected around the Windswept Hills; Paldium from blue ore nodes.",
           "targets": [
             {
               "kind": "item",
@@ -6622,7 +6622,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Gather a 10\u00a0% buffer",
+              "tactics": "Gather a 10 % buffer",
               "safety_buffer_items": [
                 {
                   "item_id": "leather",
@@ -6697,7 +6697,7 @@
           "step_id": "mount-direhowl-harness:004",
           "type": "craft",
           "summary": "Craft the harness",
-          "detail": "Use the Pal Gear Workbench to craft the Direhowl Harness with the collected materials\u3010197143349627535\u2020L151-L156\u3011.",
+          "detail": "Use the Pal Gear Workbench to craft the Direhowl Harness with the collected materials【197143349627535†L151-L156】.",
           "targets": [
             {
               "kind": "item",
@@ -6842,7 +6842,7 @@
       "objectives": [
         "Capture a Nitewing",
         "Unlock the Nitewing Saddle tech",
-        "Gather materials: 20\u00a0Leather, 10\u00a0Cloth, 15\u00a0Ingots, 20\u00a0Fiber, 20\u00a0Paldium",
+        "Gather materials: 20 Leather, 10 Cloth, 15 Ingots, 20 Fiber, 20 Paldium",
         "Craft the saddle",
         "Ride a flying mount"
       ],
@@ -6860,7 +6860,7 @@
         "hardcore": "Death may delete character and Pals"
       },
       "adaptive_guidance": {
-        "underleveled": "Farm Leather and Cloth before travelling; Ice Wind Island\u2019s level 18 mobs overwhelm players below 14.",
+        "underleveled": "Farm Leather and Cloth before travelling; Ice Wind Island’s level 18 mobs overwhelm players below 14.",
         "overleveled": "Capture Nitewing using Ultra Spheres for a near-guaranteed catch, then finish crafting in one trip.",
         "resource_shortages": [
           {
@@ -6877,7 +6877,7 @@
           {
             "signal": "resource_gap:cloth",
             "condition": "resource_gaps contains cloth >= 10",
-            "adjustment": "Batch-craft Cloth before departure so step :003 doesn\u2019t require a return trip mid-route.",
+            "adjustment": "Batch-craft Cloth before departure so step :003 doesn’t require a return trip mid-route.",
             "priority": 1,
             "mode_scope": [
               "normal",
@@ -6959,14 +6959,14 @@
       },
       "failure_recovery": {
         "normal": "If you fall off cliffs during the capture, glide with a parachute or fast travel back to avoid corpse runs.",
-        "hardcore": "Carry heat and cold resist gear; abandon the attempt if armor durability falls below 30\u00a0%."
+        "hardcore": "Carry heat and cold resist gear; abandon the attempt if armor durability falls below 30 %."
       },
       "steps": [
         {
           "step_id": "mount-nitewing-saddle:001",
           "type": "capture",
           "summary": "Catch a Nitewing",
-          "detail": "Travel to Ice\u00a0Wind Island and find Nitewing.  The Alpha Nitewing spawns around the frozen cliffs (level\u00a018)\u3010825211382965329\u2020L294-L302\u3011.  Use Electric or Ice Pals to weaken it, then throw Pal Spheres to capture.",
+          "detail": "Travel to Ice Wind Island and find Nitewing.  The Alpha Nitewing spawns around the frozen cliffs (level 18)【825211382965329†L294-L302】.  Use Electric or Ice Pals to weaken it, then throw Pal Spheres to capture.",
           "targets": [
             {
               "kind": "pal",
@@ -6987,7 +6987,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Approach from behind to avoid Nitewing\u2019s dive attacks and bring healing supplies",
+              "tactics": "Approach from behind to avoid Nitewing’s dive attacks and bring healing supplies",
               "safety_buffer_items": [
                 {
                   "item_id": "pal-sphere",
@@ -7041,7 +7041,7 @@
           "step_id": "mount-nitewing-saddle:002",
           "type": "unlock-tech",
           "summary": "Unlock Nitewing Saddle tech",
-          "detail": "At level\u00a015, spend 2\u00a0tech points to unlock the Nitewing saddle\u3010524512399342633\u2020L151-L156\u3011.",
+          "detail": "At level 15, spend 2 tech points to unlock the Nitewing saddle【524512399342633†L151-L156】.",
           "targets": [
             {
               "kind": "tech",
@@ -7077,7 +7077,7 @@
           "step_id": "mount-nitewing-saddle:003",
           "type": "gather",
           "summary": "Collect materials",
-          "detail": "Gather 20\u00a0Leather, 10\u00a0Cloth, 15\u00a0Ingots, 20\u00a0Fiber and 20\u00a0Paldium Fragments.  Hunt leather\u2011dropping Pals or branch to the leather loop if needed.  Cloth is crafted from fiber at a Primitive Workbench.  Ingots require smelting ore.",
+          "detail": "Gather 20 Leather, 10 Cloth, 15 Ingots, 20 Fiber and 20 Paldium Fragments.  Hunt leather‑dropping Pals or branch to the leather loop if needed.  Cloth is crafted from fiber at a Primitive Workbench.  Ingots require smelting ore.",
           "targets": [
             {
               "kind": "item",
@@ -7118,7 +7118,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Collect a 20\u00a0% buffer of each material to account for failures",
+              "tactics": "Collect a 20 % buffer of each material to account for failures",
               "safety_buffer_items": [
                 {
                   "item_id": "leather",
@@ -7197,7 +7197,7 @@
           "step_id": "mount-nitewing-saddle:004",
           "type": "craft",
           "summary": "Craft the Nitewing Saddle",
-          "detail": "At your Pal Gear Workbench, craft the Nitewing Saddle using the collected materials\u3010524512399342633\u2020L151-L156\u3011.  The process takes about two minutes.",
+          "detail": "At your Pal Gear Workbench, craft the Nitewing Saddle using the collected materials【524512399342633†L151-L156】.  The process takes about two minutes.",
           "targets": [
             {
               "kind": "item",
@@ -7409,7 +7409,7 @@
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Split duties\u2014two players clear the tower while the others farm fiber and ingots\u2014so crafting can start immediately after the point is earned.",
+            "adjustment": "Split duties—two players clear the tower while the others farm fiber and ingots—so crafting can start immediately after the point is earned.",
             "priority": 3,
             "mode_scope": [
               "coop"
@@ -7505,7 +7505,7 @@
           "step_id": "tech-grappling-gun:002",
           "type": "unlock-tech",
           "summary": "Unlock Grappling Gun tech",
-          "detail": "Spend 1\u00a0Ancient Technology Point at level\u00a012 to unlock the Grappling Gun\u3010312162085103617\u2020L180-L205\u3011.",
+          "detail": "Spend 1 Ancient Technology Point at level 12 to unlock the Grappling Gun【312162085103617†L180-L205】.",
           "targets": [
             {
               "kind": "tech",
@@ -7541,7 +7541,7 @@
           "step_id": "tech-grappling-gun:003",
           "type": "gather",
           "summary": "Collect materials",
-          "detail": "Gather 10\u00a0Paldium Fragments, 10\u00a0Ingots, 30\u00a0Fiber and 1\u00a0Ancient Civilization Part\u3010312162085103617\u2020L180-L205\u3011.  Ancient Civilization Parts drop from tower bosses and dungeons.",
+          "detail": "Gather 10 Paldium Fragments, 10 Ingots, 30 Fiber and 1 Ancient Civilization Part【312162085103617†L180-L205】.  Ancient Civilization Parts drop from tower bosses and dungeons.",
           "targets": [
             {
               "kind": "item",
@@ -7577,7 +7577,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Gather a 10\u00a0% buffer of each resource",
+              "tactics": "Gather a 10 % buffer of each resource",
               "safety_buffer_items": [
                 {
                   "item_id": "paldium-fragment",
@@ -7649,7 +7649,7 @@
           "step_id": "tech-grappling-gun:004",
           "type": "craft",
           "summary": "Craft the Grappling Gun",
-          "detail": "At your Primitive Workbench or Weapon Workbench, craft the Grappling Gun using the collected materials\u3010312162085103617\u2020L180-L205\u3011.",
+          "detail": "At your Primitive Workbench or Weapon Workbench, craft the Grappling Gun using the collected materials【312162085103617†L180-L205】.",
           "targets": [
             {
               "kind": "item",
@@ -7785,7 +7785,7 @@
       },
       "objectives": [
         "Travel to the Rayne Syndicate Tower",
-        "Prepare with Ground\u2011type Pals and gear",
+        "Prepare with Ground‑type Pals and gear",
         "Defeat Zoe & Grizzbolt within the time limit",
         "Claim Ancient Technology Points"
       ],
@@ -7906,7 +7906,7 @@
           "step_id": "tower-rayne-syndicate:001",
           "type": "travel",
           "summary": "Reach the tower",
-          "detail": "Ride your mount to the Rayne Syndicate Tower at coordinates (112,\u00a0-434) in the Windswept Hills\u3010825211382965329\u2020L103-L118\u3011.",
+          "detail": "Ride your mount to the Rayne Syndicate Tower at coordinates (112, -434) in the Windswept Hills【825211382965329†L103-L118】.",
           "targets": [],
           "locations": [
             {
@@ -7945,7 +7945,7 @@
           "step_id": "tower-rayne-syndicate:002",
           "type": "prepare",
           "summary": "Prepare for battle",
-          "detail": "Equip Ground or Grass Pals such as Gumoss and Fuddler to counter Grizzbolt\u2019s Electric attacks\u3010825211382965329\u2020L103-L118\u3011.  Carry healing items and equip decent armor.  In Hardcore, craft an extra shield.",
+          "detail": "Equip Ground or Grass Pals such as Gumoss and Fuddler to counter Grizzbolt’s Electric attacks【825211382965329†L103-L118】.  Carry healing items and equip decent armor.  In Hardcore, craft an extra shield.",
           "targets": [],
           "locations": [],
           "mode_adjustments": {
@@ -7998,7 +7998,7 @@
           "step_id": "tower-rayne-syndicate:003",
           "type": "fight",
           "summary": "Defeat Zoe & Grizzbolt",
-          "detail": "Engage Zoe and her Pal Grizzbolt.  Deal at least 30K damage within ten minutes\u3010825211382965329\u2020L103-L118\u3011.  Use Ground or Water attacks, dodge electric beams and avoid the arena edges.",
+          "detail": "Engage Zoe and her Pal Grizzbolt.  Deal at least 30K damage within ten minutes【825211382965329†L103-L118】.  Use Ground or Water attacks, dodge electric beams and avoid the arena edges.",
           "targets": [
             {
               "kind": "boss",
@@ -8158,7 +8158,7 @@
         "pals": []
       },
       "objectives": [
-        "Prepare high\u2011level gear and Pals",
+        "Prepare high‑level gear and Pals",
         "Travel to Mount Obsidian",
         "Weaken Jetragon",
         "Capture it"
@@ -8270,14 +8270,14 @@
       },
       "failure_recovery": {
         "normal": "If you faint, retrieve your bag immediately; resupply on cooling consumables before retrying.",
-        "hardcore": "Abort if armor durability dips below 40\u00a0% or if multiple lava golems join the fight; survival takes priority."
+        "hardcore": "Abort if armor durability dips below 40 % or if multiple lava golems join the fight; survival takes priority."
       },
       "steps": [
         {
           "step_id": "capture-jetragon:001",
           "type": "prepare",
           "summary": "Prepare for battle",
-          "detail": "Craft heat\u2011resistant armor and weapons such as rocket launchers.  Recruit high\u2011level Ice or Dragon Pals.  Bring Ultra Pal Spheres and plenty of healing items.",
+          "detail": "Craft heat‑resistant armor and weapons such as rocket launchers.  Recruit high‑level Ice or Dragon Pals.  Bring Ultra Pal Spheres and plenty of healing items.",
           "targets": [],
           "locations": [],
           "mode_adjustments": {
@@ -8387,7 +8387,7 @@
           "locations": [],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Maintain maximum distance and use hit\u2011and\u2011run tactics",
+              "tactics": "Maintain maximum distance and use hit‑and‑run tactics",
               "safety_buffer_items": [
                 {
                   "item_id": "ancient-technology-point",
@@ -8438,7 +8438,7 @@
           "step_id": "capture-jetragon:004",
           "type": "capture",
           "summary": "Capture Jetragon",
-          "detail": "When Jetragon\u2019s health is low, throw Ultra Pal Spheres until you succeed.  It may take several attempts.  Once captured, Jetragon becomes a powerful flying mount with unmatched speed and combat abilities.",
+          "detail": "When Jetragon’s health is low, throw Ultra Pal Spheres until you succeed.  It may take several attempts.  Once captured, Jetragon becomes a powerful flying mount with unmatched speed and combat abilities.",
           "targets": [
             {
               "kind": "pal",
@@ -8497,7 +8497,7 @@
     },
     {
       "route_id": "purposeful-arc-early-foundation",
-      "title": "Purposeful Arc \u2014 Early Foundation",
+      "title": "Purposeful Arc — Early Foundation",
       "category": "campaign",
       "tags": [
         "purposeful",
@@ -8610,7 +8610,7 @@
       },
       "failure_recovery": {
         "normal": "Recraft Pal Spheres and repeat failed captures; regroup at your base to restock.",
-        "hardcore": "Abort the hunt if HP drops below 40%\u2014Hardcore saves should never risk a wipe over a mount."
+        "hardcore": "Abort the hunt if HP drops below 40%—Hardcore saves should never risk a wipe over a mount."
       },
       "steps": [
         {
@@ -8771,7 +8771,7 @@
     },
     {
       "route_id": "purposeful-arc-mid-expansion",
-      "title": "Purposeful Arc \u2014 Mid Expansion",
+      "title": "Purposeful Arc — Mid Expansion",
       "category": "campaign",
       "tags": [
         "purposeful",
@@ -8885,7 +8885,7 @@
       },
       "failure_recovery": {
         "normal": "Restock spheres and medicine after each major attempt; re-run leather or paldium farms if supplies run low.",
-        "hardcore": "Bail from tower fights when shields break\u2014preserving the save is more important than the Ancient Point."
+        "hardcore": "Bail from tower fights when shields break—preserving the save is more important than the Ancient Point."
       },
       "steps": [
         {
@@ -9076,7 +9076,7 @@
     },
     {
       "route_id": "purposeful-arc-legendary-push",
-      "title": "Purposeful Arc \u2014 Legendary Push",
+      "title": "Purposeful Arc — Legendary Push",
       "category": "campaign",
       "tags": [
         "purposeful",
@@ -12085,7 +12085,7 @@
           "step_id": "quest-main-story-early:013",
           "type": "fight",
           "summary": "Defeat Lily & Lyleen at Free Pal Alliance Tower",
-          "detail": "Travel to the snowy Free Pal Alliance tower and melt Lyleen with fire Pals while dodging Lily\u2019s ranged shots.",
+          "detail": "Travel to the snowy Free Pal Alliance tower and melt Lyleen with fire Pals while dodging Lily’s ranged shots.",
           "targets": [],
           "locations": [
             {
@@ -12137,7 +12137,7 @@
           "step_id": "quest-main-story-early:014",
           "type": "fight",
           "summary": "Overcome Axel & Orserk at Eternal Pyre Tower",
-          "detail": "Scale Mount Obsidian, exploit Orserk\u2019s weakness to ice and manage Axel\u2019s melee assaults to take the volcanic tower.",
+          "detail": "Scale Mount Obsidian, exploit Orserk’s weakness to ice and manage Axel’s melee assaults to take the volcanic tower.",
           "targets": [],
           "locations": [
             {
@@ -12189,7 +12189,7 @@
           "step_id": "quest-main-story-early:015",
           "type": "fight",
           "summary": "Break Marcus & Faleris at PIDF Tower",
-          "detail": "Storm the desert tower, drench Faleris with water attacks and outmaneuver Marcus\u2019s explosives for the fourth clear.",
+          "detail": "Storm the desert tower, drench Faleris with water attacks and outmaneuver Marcus’s explosives for the fourth clear.",
           "targets": [],
           "locations": [
             {
@@ -12241,7 +12241,7 @@
           "step_id": "quest-main-story-early:016",
           "type": "fight",
           "summary": "Topple Victor & Shadowbeak at PAL Research",
-          "detail": "Climb the frozen tower, deploy dragon Pals against Shadowbeak and suppress Victor\u2019s gadgets to secure Ancient tech.",
+          "detail": "Climb the frozen tower, deploy dragon Pals against Shadowbeak and suppress Victor’s gadgets to secure Ancient tech.",
           "targets": [],
           "locations": [
             {
@@ -12692,7 +12692,7 @@
         "resource_shortages": [
           {
             "item_id": "beautiful-flower",
-            "solution": "Lean on step :002 captures\u2014Petallia guarantees 2-3 Beautiful Flowers per defeat, stabilising stock quickly."
+            "solution": "Lean on step :002 captures—Petallia guarantees 2-3 Beautiful Flowers per defeat, stabilising stock quickly."
           }
         ],
         "time_limited": "Run the shore perimeter of Sanctuary No. 1, netting Petallia spawns nearest the landing before PIDF heat builds.",
@@ -12778,7 +12778,7 @@
           "step_id": "resource-beautiful-flower:001",
           "type": "travel",
           "summary": "Approach No. 1 Wildlife Sanctuary",
-          "detail": "Glide or sail south to the No. 1 Wildlife Sanctuary (90,-735) and set a shoreline camp. Trespassing warnings summon PIDF forces, so keep encumbrance light for fast extractions.\u3010fe9924\u2020L1-L18\u3011\u3010f574c5\u2020L5-L24\u3011",
+          "detail": "Glide or sail south to the No. 1 Wildlife Sanctuary (90,-735) and set a shoreline camp. Trespassing warnings summon PIDF forces, so keep encumbrance light for fast extractions.【fe9924†L1-L18】【f574c5†L5-L24】",
           "targets": [],
           "locations": [
             {
@@ -12819,7 +12819,7 @@
           "step_id": "resource-beautiful-flower:002",
           "type": "capture",
           "summary": "Farm Petallia and Ribbuny spawns",
-          "detail": "Sweep the inner gardens for Petallia and Ribbuny. Petallia always drops 2-3 Beautiful Flowers, while Ribbuny has a 5% flower drop chance\u2014bring fire or dark attackers like Blazehowl or Katress to accelerate clears.\u3010ba24e5\u2020L18-L37\u3011\u30109be50c\u2020L31-L59\u3011\u30109f35a4\u2020L31-L56\u3011",
+          "detail": "Sweep the inner gardens for Petallia and Ribbuny. Petallia always drops 2-3 Beautiful Flowers, while Ribbuny has a 5% flower drop chance—bring fire or dark attackers like Blazehowl or Katress to accelerate clears.【ba24e5†L18-L37】【9be50c†L31-L59】【9f35a4†L31-L56】",
           "targets": [
             {
               "kind": "item",
@@ -12892,7 +12892,7 @@
           "step_id": "resource-beautiful-flower:003",
           "type": "gather",
           "summary": "Rotate Sanctuaries No. 2 and No. 3",
-          "detail": "Graduate to Sanctuary No. 2 (-675,-113) and No. 3 (669,640) for Wumpo Botan and Lyleen runs\u2014level 50 patrols drop guaranteed flowers quickly, so plan fast extractions after each sweep.\u3010ba24e5\u2020L24-L33\u3011\u301015adf0\u2020L1-L24\u3011\u3010c5acbe\u2020L1-L18\u3011\u3010f574c5\u2020L13-L20\u3011",
+          "detail": "Graduate to Sanctuary No. 2 (-675,-113) and No. 3 (669,640) for Wumpo Botan and Lyleen runs—level 50 patrols drop guaranteed flowers quickly, so plan fast extractions after each sweep.【ba24e5†L24-L33】【15adf0†L1-L24】【c5acbe†L1-L18】【f574c5†L13-L20】",
           "targets": [
             {
               "kind": "item",
@@ -13032,15 +13032,15 @@
         "hardcore": "Hardcore trespass wipes can snowball into gear loss and pal deaths, so extract before heat spikes."
       },
       "adaptive_guidance": {
-        "underleveled": "Lean on merchant stockpiles until level 30, then hit Sanctuary No.1 with burst captures before patrols escalate.\u3010palwiki-wandering-merchant-raw\u2020L24-L39\u3011\u3010palwiki-wildlife-sanctuary\u2020L6-L21\u3011",
-        "overleveled": "Chain Sanctuaries No.1 and No.2 in a single sortie, emptying oil pals then resupplying merchants on the way home.\u3010palwiki-high-quality-pal-oil\u2020L1-L50\u3011\u3010palwiki-wildlife-sanctuary-2\u2020L1-L7\u3011",
+        "underleveled": "Lean on merchant stockpiles until level 30, then hit Sanctuary No.1 with burst captures before patrols escalate.【palwiki-wandering-merchant-raw†L24-L39】【palwiki-wildlife-sanctuary†L6-L21】",
+        "overleveled": "Chain Sanctuaries No.1 and No.2 in a single sortie, emptying oil pals then resupplying merchants on the way home.【palwiki-high-quality-pal-oil†L1-L50】【palwiki-wildlife-sanctuary-2†L1-L7】",
         "resource_shortages": [
           {
             "item_id": "high_quality_pal_oil",
-            "solution": "Buy out settlement merchants first, then fill gaps with Elphidran and Quivern runs so polymer recipes stay fed.\u3010palwiki-wandering-merchant-raw\u2020L24-L39\u3011\u3010palworldgg-quivern-drops\u2020L1-L2\u3011"
+            "solution": "Buy out settlement merchants first, then fill gaps with Elphidran and Quivern runs so polymer recipes stay fed.【palwiki-wandering-merchant-raw†L24-L39】【palworldgg-quivern-drops†L1-L2】"
           }
         ],
-        "time_limited": "Do the merchant loop only, banking 600 gold and 6 oil in five minutes before logging off.\u3010palwiki-wandering-merchant-raw\u2020L24-L39\u3011\u3010palwiki-wandering-merchant-raw\u2020L176-L180\u3011",
+        "time_limited": "Do the merchant loop only, banking 600 gold and 6 oil in five minutes before logging off.【palwiki-wandering-merchant-raw†L24-L39】【palwiki-wandering-merchant-raw†L176-L180】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -13108,7 +13108,7 @@
           "step_id": "resource-high-quality-pal-oil:001",
           "type": "trade",
           "summary": "Clear settlement merchants",
-          "detail": "Teleport to the Small Settlement (78,-477) and Sea Breeze Archipelago merchant (-190,-600) every morning, buying every High Quality Pal Oil for 300 Gold before stock rotates.\u3010palwiki-wandering-merchant-raw\u2020L24-L39\u3011\u3010palwiki-wandering-merchant-raw\u2020L176-L180\u3011",
+          "detail": "Teleport to the Small Settlement (78,-477) and Sea Breeze Archipelago merchant (-190,-600) every morning, buying every High Quality Pal Oil for 300 Gold before stock rotates.【palwiki-wandering-merchant-raw†L24-L39】【palwiki-wandering-merchant-raw†L176-L180】",
           "targets": [
             {
               "kind": "item",
@@ -13183,15 +13183,15 @@
             }
           ],
           "citations": [
-            "palwiki-wandering-merchant-raw\u2020L24-L39",
-            "palwiki-wandering-merchant-raw\u2020L176-L180"
+            "palwiki-wandering-merchant-raw†L24-L39",
+            "palwiki-wandering-merchant-raw†L176-L180"
           ]
         },
         {
           "step_id": "resource-high-quality-pal-oil:002",
           "type": "capture",
           "summary": "Capture Elphidran in Sanctuary No. 1",
-          "detail": "Glide into No. 1 Wildlife Sanctuary (90,-735), snag Elphidran with Mega or Giga Spheres, and bank the guaranteed 2\u20133 oil per capture before PIDF patrols close in.\u3010palwiki-wildlife-sanctuary-1\u2020L1-L8\u3011\u3010palwiki-wildlife-sanctuary\u2020L6-L21\u3011\u3010palwiki-high-quality-pal-oil\u2020L9-L36\u3011\u3010palworldgg-elphidran-drops\u2020L1-L2\u3011",
+          "detail": "Glide into No. 1 Wildlife Sanctuary (90,-735), snag Elphidran with Mega or Giga Spheres, and bank the guaranteed 2–3 oil per capture before PIDF patrols close in.【palwiki-wildlife-sanctuary-1†L1-L8】【palwiki-wildlife-sanctuary†L6-L21】【palwiki-high-quality-pal-oil†L9-L36】【palworldgg-elphidran-drops†L1-L2】",
           "targets": [
             {
               "kind": "item",
@@ -13212,7 +13212,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Stay airborne on entry, tag Elphidran from range, and extract once heat hits two stars.\u3010palwiki-wildlife-sanctuary\u2020L6-L21\u3011",
+              "tactics": "Stay airborne on entry, tag Elphidran from range, and extract once heat hits two stars.【palwiki-wildlife-sanctuary†L6-L21】",
               "mode_scope": [
                 "hardcore"
               ]
@@ -13248,17 +13248,17 @@
           },
           "branching": [],
           "citations": [
-            "palwiki-wildlife-sanctuary-1\u2020L1-L8",
-            "palwiki-wildlife-sanctuary\u2020L6-L21",
-            "palwiki-high-quality-pal-oil\u2020L9-L36",
-            "palworldgg-elphidran-drops\u2020L1-L2"
+            "palwiki-wildlife-sanctuary-1†L1-L8",
+            "palwiki-wildlife-sanctuary†L6-L21",
+            "palwiki-high-quality-pal-oil†L9-L36",
+            "palworldgg-elphidran-drops†L1-L2"
           ]
         },
         {
           "step_id": "resource-high-quality-pal-oil:003",
           "type": "combat",
           "summary": "Cull Quivern flights in Sanctuary No. 2",
-          "detail": "Sail to No. 2 Wildlife Sanctuary (-675,-113), ground Quivern patrols with electric or ice pals, and scoop the 3-stack oil drops before withdrawing.\u3010palwiki-wildlife-sanctuary-2\u2020L1-L7\u3011\u3010palwiki-wildlife-sanctuary\u2020L6-L21\u3011\u3010palwiki-high-quality-pal-oil\u2020L9-L36\u3011\u3010palworldgg-quivern-drops\u2020L1-L2\u3011",
+          "detail": "Sail to No. 2 Wildlife Sanctuary (-675,-113), ground Quivern patrols with electric or ice pals, and scoop the 3-stack oil drops before withdrawing.【palwiki-wildlife-sanctuary-2†L1-L7】【palwiki-wildlife-sanctuary†L6-L21】【palwiki-high-quality-pal-oil†L9-L36】【palworldgg-quivern-drops†L1-L2】",
           "targets": [
             {
               "kind": "item",
@@ -13279,7 +13279,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Rotate aerial mounts to stay above PIDF aggro cones and disengage after each Quivern down.\u3010palwiki-wildlife-sanctuary\u2020L6-L21\u3011",
+              "tactics": "Rotate aerial mounts to stay above PIDF aggro cones and disengage after each Quivern down.【palwiki-wildlife-sanctuary†L6-L21】",
               "mode_scope": [
                 "hardcore"
               ]
@@ -13315,17 +13315,17 @@
           },
           "branching": [],
           "citations": [
-            "palwiki-wildlife-sanctuary-2\u2020L1-L7",
-            "palwiki-wildlife-sanctuary\u2020L6-L21",
-            "palwiki-high-quality-pal-oil\u2020L9-L36",
-            "palworldgg-quivern-drops\u2020L1-L2"
+            "palwiki-wildlife-sanctuary-2†L1-L7",
+            "palwiki-wildlife-sanctuary†L6-L21",
+            "palwiki-high-quality-pal-oil†L9-L36",
+            "palworldgg-quivern-drops†L1-L2"
           ]
         },
         {
           "step_id": "resource-high-quality-pal-oil:004",
           "type": "base",
           "summary": "Automate oil at base",
-          "detail": "Assign Dumud or spare Elphidran to a Ranch so they drip High Quality Pal Oil between merchant loops, then stash at least 30 units for polymer and elixir batches.\u3010palwiki-high-quality-pal-oil\u2020L30-L50\u3011",
+          "detail": "Assign Dumud or spare Elphidran to a Ranch so they drip High Quality Pal Oil between merchant loops, then stash at least 30 units for polymer and elixir batches.【palwiki-high-quality-pal-oil†L30-L50】",
           "targets": [
             {
               "kind": "item",
@@ -13370,7 +13370,7 @@
           },
           "branching": [],
           "citations": [
-            "palwiki-high-quality-pal-oil\u2020L30-L50"
+            "palwiki-high-quality-pal-oil†L30-L50"
           ]
         }
       ],
@@ -13449,22 +13449,22 @@
       "risk_profile": "high",
       "failure_penalties": {
         "normal": "Wiping in the sealed realm burns spheres and repair kits while you wait on the respawn timer.",
-        "hardcore": "Hardcore failure despawns Sibelyx permanently and deletes late-game gear\u2014withdraw if shields break."
+        "hardcore": "Hardcore failure despawns Sibelyx permanently and deletes late-game gear—withdraw if shields break."
       },
       "adaptive_guidance": {
-        "underleveled": "Bring fire or electric pals that counter ice to stagger Sibelyx and avoid Blizzard Spike one-shots while you kite its frontal cone.\u3010palwiki-sibelyx\u2020L1-L62\u3011",
-        "overleveled": "After unlocking the recipe, convert spare wool piles into cloth between realm rotations so your tailors never idle.\u3010palwiki-high-quality-cloth\u2020L1-L26\u3011",
+        "underleveled": "Bring fire or electric pals that counter ice to stagger Sibelyx and avoid Blizzard Spike one-shots while you kite its frontal cone.【palwiki-sibelyx†L1-L62】",
+        "overleveled": "After unlocking the recipe, convert spare wool piles into cloth between realm rotations so your tailors never idle.【palwiki-high-quality-cloth†L1-L26】",
         "resource_shortages": [
           {
             "item_id": "wool",
-            "solution": "Run the resource-wool route again to refill bales before queueing 10-wool crafts for each cloth batch.\u3010palwiki-high-quality-cloth\u2020L17-L24\u3011"
+            "solution": "Run the resource-wool route again to refill bales before queueing 10-wool crafts for each cloth batch.【palwiki-high-quality-cloth†L17-L24】"
           },
           {
             "item_id": "high-quality-cloth",
-            "solution": "Assign Sibelyx to a ranch so its Silk Maker passive produces cloth while workshops finish the remaining workload.\u3010palwiki-sibelyx\u2020L1-L64\u3011"
+            "solution": "Assign Sibelyx to a ranch so its Silk Maker passive produces cloth while workshops finish the remaining workload.【palwiki-sibelyx†L1-L64】"
           }
         ],
-        "time_limited": "Skip optional wool crafts and just clear the Sealed Realm once; Sibelyx drops cloth on capture so you can deliver the minimum quota quickly.\u3010palwiki-sibelyx\u2020L1-L62\u3011",
+        "time_limited": "Skip optional wool crafts and just clear the Sealed Realm once; Sibelyx drops cloth on capture so you can deliver the minimum quota quickly.【palwiki-sibelyx†L1-L62】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -13521,7 +13521,7 @@
           "step_id": "resource-high-quality-cloth:001",
           "type": "build",
           "summary": "Unlock High Quality Cloth tech",
-          "detail": "Spend two technology points at level 36 to unlock High Quality Cloth, place a High Quality Workbench, and queue wool shipments so tailors can work between boss runs.\u3010palwiki-high-quality-cloth\u2020L1-L26\u3011",
+          "detail": "Spend two technology points at level 36 to unlock High Quality Cloth, place a High Quality Workbench, and queue wool shipments so tailors can work between boss runs.【palwiki-high-quality-cloth†L1-L26】",
           "targets": [
             {
               "kind": "tech",
@@ -13574,7 +13574,7 @@
           "step_id": "resource-high-quality-cloth:002",
           "type": "combat",
           "summary": "Clear Sealed Realm of the Pristine",
-          "detail": "Travel to the Sealed Realm of the Pristine (250,70), break Sibelyx\u2019s shield, and capture it for guaranteed cloth drops and the Silk Maker ranch passive.\u3010palwiki-sealed-realms\u2020L44-L48\u3011\u3010palwiki-sibelyx\u2020L1-L64\u3011",
+          "detail": "Travel to the Sealed Realm of the Pristine (250,70), break Sibelyx’s shield, and capture it for guaranteed cloth drops and the Silk Maker ranch passive.【palwiki-sealed-realms†L44-L48】【palwiki-sibelyx†L1-L64】",
           "targets": [
             {
               "kind": "pal",
@@ -13650,7 +13650,7 @@
           "step_id": "resource-high-quality-cloth:003",
           "type": "base",
           "summary": "Automate cloth output",
-          "detail": "Assign Sibelyx to a Ranch so it periodically produces High Quality Cloth, then craft additional cloth in 10-wool batches at the High Quality Workbench to sustain legendary armor builds.\u3010palwiki-sibelyx\u2020L1-L64\u3011\u3010palwiki-high-quality-cloth\u2020L17-L24\u3011",
+          "detail": "Assign Sibelyx to a Ranch so it periodically produces High Quality Cloth, then craft additional cloth in 10-wool batches at the High Quality Workbench to sustain legendary armor builds.【palwiki-sibelyx†L1-L64】【palwiki-high-quality-cloth†L17-L24】",
           "targets": [
             {
               "kind": "item",
@@ -13732,7 +13732,7 @@
       "next_routes": [
         {
           "route_id": "resource-carbon-fiber",
-          "reason": "Carbon Fiber and High Quality Cloth combine for legendary armor sets\u2014keep both queues supplied."
+          "reason": "Carbon Fiber and High Quality Cloth combine for legendary armor sets—keep both queues supplied."
         },
         {
           "route_id": "resource-ice-organ",
@@ -13875,14 +13875,14 @@
       },
       "failure_recovery": {
         "normal": "If the herd flees, rest at a nearby fast travel and return after five minutes; Mozzarina respawn near the Swordmaster arena.",
-        "hardcore": "Extract the captured Mozzarina immediately and store them before returning for another try\u2014don't risk chain deaths."
+        "hardcore": "Extract the captured Mozzarina immediately and store them before returning for another try—don't risk chain deaths."
       },
       "steps": [
         {
           "step_id": "resource-milk:001",
           "type": "build",
           "summary": "Unlock and place the Ranch",
-          "detail": "Spend 2 technology points at level 5 to unlock the Ranch, then craft it with 50 Wood, 20 Stone, and 30 Fiber next to food storage so milk drops land by your collection chest.\u30101a1614\u2020L1-L16\u3011",
+          "detail": "Spend 2 technology points at level 5 to unlock the Ranch, then craft it with 50 Wood, 20 Stone, and 30 Fiber next to food storage so milk drops land by your collection chest.【1a1614†L1-L16】",
           "targets": [
             {
               "kind": "tech",
@@ -13947,7 +13947,7 @@
           "step_id": "resource-milk:002",
           "type": "capture",
           "summary": "Capture Mozzarina north of the Swordmaster arena",
-          "detail": "Glide into the Bamboo Groves herd just north of the Sealed Realm of the Swordmaster (\u2212117, \u2212490). Dark pals burst the neutral mobs quickly while you toss Mega Spheres at two Mozzarina before patrols rotate in from the Ravine Entrance teleport.\u301069a959\u2020L1-L6\u3011\u3010124c92\u2020L57-L61\u3011",
+          "detail": "Glide into the Bamboo Groves herd just north of the Sealed Realm of the Swordmaster (−117, −490). Dark pals burst the neutral mobs quickly while you toss Mega Spheres at two Mozzarina before patrols rotate in from the Ravine Entrance teleport.【69a959†L1-L6】【124c92†L57-L61】",
           "targets": [
             {
               "kind": "pal",
@@ -14026,7 +14026,7 @@
           "step_id": "resource-milk:003",
           "type": "assign",
           "summary": "Staff the Ranch and harvest milk",
-          "detail": "Drop one Mozzarina into the Ranch and let it graze\u2014Milk Maker guarantees a bottle every production cycle, and alpha variants keep 100% drop rates as well.\u3010a877d4\u2020L10-L35\u3011",
+          "detail": "Drop one Mozzarina into the Ranch and let it graze—Milk Maker guarantees a bottle every production cycle, and alpha variants keep 100% drop rates as well.【a877d4†L10-L35】",
           "targets": [
             {
               "kind": "item",
@@ -14092,7 +14092,7 @@
           "step_id": "resource-milk:004",
           "type": "trade",
           "summary": "Top up from the Small Settlement merchant",
-          "detail": "Ride to the Small Settlement (~75, \u2212479) and buy extra bottles for 100 gold when ranch output lags; consider capturing the merchant later for permanent base access.\u301063794d\u2020L8-L14\u3011\u3010165dd8\u2020L71-L90\u3011",
+          "detail": "Ride to the Small Settlement (~75, −479) and buy extra bottles for 100 gold when ranch output lags; consider capturing the merchant later for permanent base access.【63794d†L8-L14】【165dd8†L71-L90】",
           "targets": [
             {
               "kind": "item",
@@ -14216,15 +14216,15 @@
         "hardcore": "Misusing the cleaver can trigger base morale loss and raids, costing you captured layers."
       },
       "adaptive_guidance": {
-        "underleveled": "Work within sight of the Palbox so aggroed flocks leash and you can reset without burning spheres.\u3010palwiki-chikipi\u2020L29-L35\u3011",
-        "overleveled": "Alternate meadow sweeps with butcher sessions to bank a stack of poultry before raids escalate.\u3010palwiki-chikipi\u2020L29-L35\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011",
+        "underleveled": "Work within sight of the Palbox so aggroed flocks leash and you can reset without burning spheres.【palwiki-chikipi†L29-L35】",
+        "overleveled": "Alternate meadow sweeps with butcher sessions to bank a stack of poultry before raids escalate.【palwiki-chikipi†L29-L35】【palwiki-meat-cleaver†L20-L39】",
         "resource_shortages": [
           {
             "item_id": "chikipi-poultry",
-            "solution": "Cull one captured pair per loop after eggs hatch, then let timers refill ranch slots before the next hunt.\u3010palwiki-chikipi\u2020L63-L72\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011"
+            "solution": "Cull one captured pair per loop after eggs hatch, then let timers refill ranch slots before the next hunt.【palwiki-chikipi†L63-L72】【palwiki-meat-cleaver†L20-L39】"
           }
         ],
-        "time_limited": "Do a quick meadow sweep, butcher the surplus, then refrigerate the cuts so cooking can resume later.\u3010palwiki-chikipi\u2020L63-L72\u3011\u3010palwiki-meat-cleaver\u2020L37-L41\u3011",
+        "time_limited": "Do a quick meadow sweep, butcher the surplus, then refrigerate the cuts so cooking can resume later.【palwiki-chikipi†L63-L72】【palwiki-meat-cleaver†L37-L41】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -14269,7 +14269,7 @@
           "step_id": "resource-chikipi-poultry:001",
           "type": "capture",
           "summary": "Sweep Palbox meadow for Chikipi",
-          "detail": "Teleport to the Windswept Hills statue (~-42,-498) and loop the grass flats, bolaing docile Chikipi before they flock. Scoop ground eggs while you net four prime layers for the ranch.\u3010palwiki-chikipi\u2020L29-L35\u3011",
+          "detail": "Teleport to the Windswept Hills statue (~-42,-498) and loop the grass flats, bolaing docile Chikipi before they flock. Scoop ground eggs while you net four prime layers for the ranch.【palwiki-chikipi†L29-L35】",
           "targets": [
             {
               "kind": "pal",
@@ -14290,7 +14290,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Use bolas or Frost Grenades so incidental damage doesn\u2019t snowball into flock aggro.",
+              "tactics": "Use bolas or Frost Grenades so incidental damage doesn’t snowball into flock aggro.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -14344,7 +14344,7 @@
           "step_id": "resource-chikipi-poultry:002",
           "type": "craft",
           "summary": "Forge the Meat Cleaver and butcher extras",
-          "detail": "Craft the Meat Cleaver at the Primitive Workbench (5 Ingots, 20 Wood, 5 Stone), then use the Pet command wheel to butcher surplus Chikipi. Each culled bird yields guaranteed poultry for stews\u2014stagger culls to avoid wiping the ranch.\u3010palwiki-meat-cleaver\u2020L20-L39\u3011\u3010palwiki-meat-cleaver\u2020L25-L34\u3011\u3010palwiki-chikipi\u2020L69-L76\u3011",
+          "detail": "Craft the Meat Cleaver at the Primitive Workbench (5 Ingots, 20 Wood, 5 Stone), then use the Pet command wheel to butcher surplus Chikipi. Each culled bird yields guaranteed poultry for stews—stagger culls to avoid wiping the ranch.【palwiki-meat-cleaver†L20-L39】【palwiki-meat-cleaver†L25-L34】【palwiki-chikipi†L69-L76】",
           "targets": [
             {
               "kind": "item",
@@ -14365,7 +14365,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Back up save birds with Pal Spheres before butchering so a misclick doesn\u2019t delete your only egg layers.",
+              "tactics": "Back up save birds with Pal Spheres before butchering so a misclick doesn’t delete your only egg layers.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -14402,7 +14402,7 @@
           "step_id": "resource-chikipi-poultry:003",
           "type": "base",
           "summary": "Balance ranch timers and cold storage",
-          "detail": "Assign two Chikipi to the ranch for steady eggs, chill butchered poultry in a Cooler Box, and rotate captures each loop so new birds replace those culled for meat.\u3010palwiki-chikipi\u2020L63-L72\u3011",
+          "detail": "Assign two Chikipi to the ranch for steady eggs, chill butchered poultry in a Cooler Box, and rotate captures each loop so new birds replace those culled for meat.【palwiki-chikipi†L63-L72】",
           "targets": [
             {
               "kind": "item",
@@ -14526,15 +14526,15 @@
         "hardcore": "Overextending on the cliffs risks lethal falls and pal losses, forcing you to rebuild the flock before butchering."
       },
       "adaptive_guidance": {
-        "underleveled": "Anchor at the Small Settlement statue (75,-479) and chip away at the nearest Galeclaw pairs before retreating to the Palbox if they swarm.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palfandom-windswept-hills-raw\u2020L24-L40\u3011",
-        "overleveled": "Chain ridge sweeps with cleaver runs so every guaranteed drop turns into chilled stock before raids pull you elsewhere.\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011",
+        "underleveled": "Anchor at the Small Settlement statue (75,-479) and chip away at the nearest Galeclaw pairs before retreating to the Palbox if they swarm.【palwiki-small-settlement†L3-L15】【palfandom-windswept-hills-raw†L24-L40】",
+        "overleveled": "Chain ridge sweeps with cleaver runs so every guaranteed drop turns into chilled stock before raids pull you elsewhere.【palwiki-galeclaw-raw†L6-L33】【palwiki-meat-cleaver†L20-L39】",
         "resource_shortages": [
           {
             "item_id": "galeclaw_poultry",
-            "solution": "Cull two captured Galeclaw per loop\u2014each yields one Galeclaw Poultry at 100%\u2014then let the rest respawn for the next hunt.\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-meat-cleaver\u2020L20-L39\u3011"
+            "solution": "Cull two captured Galeclaw per loop—each yields one Galeclaw Poultry at 100%—then let the rest respawn for the next hunt.【palwiki-galeclaw-raw†L6-L33】【palwiki-meat-cleaver†L20-L39】"
           }
         ],
-        "time_limited": "Fast travel to the Small Settlement, drop two flights, butcher them, and stash the cuts in a Cooler Box before logging off.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011",
+        "time_limited": "Fast travel to the Small Settlement, drop two flights, butcher them, and stash the cuts in a Cooler Box before logging off.【palwiki-small-settlement†L3-L15】【palwiki-galeclaw-raw†L6-L33】【palwiki-cooler-box-raw†L1-L24】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -14580,7 +14580,7 @@
           "step_id": "resource-galeclaw-poultry:001",
           "type": "capture",
           "summary": "Clip Galeclaw along the Small Settlement ridge",
-          "detail": "Teleport to the Small Settlement (75,-479), climb the western ridge, and ground Galeclaw with bolas before throwing spheres so you bank three flyers for butchering.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palfandom-windswept-hills-raw\u2020L24-L40\u3011",
+          "detail": "Teleport to the Small Settlement (75,-479), climb the western ridge, and ground Galeclaw with bolas before throwing spheres so you bank three flyers for butchering.【palwiki-small-settlement†L3-L15】【palfandom-windswept-hills-raw†L24-L40】",
           "targets": [
             {
               "kind": "pal",
@@ -14652,7 +14652,7 @@
           "step_id": "resource-galeclaw-poultry:002",
           "type": "craft",
           "summary": "Butcher Galeclaw for guaranteed poultry",
-          "detail": "Equip the Meat Cleaver (crafted at the Primitive Workbench for 5 Ingots, 20 Wood, 5 Stone) and butcher captured Galeclaw\u2014each yields one Galeclaw Poultry at a 100% rate, so stagger culls to keep flyers in reserve.\u3010palwiki-meat-cleaver\u2020L20-L39\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011",
+          "detail": "Equip the Meat Cleaver (crafted at the Primitive Workbench for 5 Ingots, 20 Wood, 5 Stone) and butcher captured Galeclaw—each yields one Galeclaw Poultry at a 100% rate, so stagger culls to keep flyers in reserve.【palwiki-meat-cleaver†L20-L39】【palwiki-galeclaw-raw†L6-L33】",
           "targets": [
             {
               "kind": "item",
@@ -14673,7 +14673,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Back up captures with spare spheres before butchering so a misclick doesn\u2019t erase your only flyers.",
+              "tactics": "Back up captures with spare spheres before butchering so a misclick doesn’t erase your only flyers.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -14710,7 +14710,7 @@
           "step_id": "resource-galeclaw-poultry:003",
           "type": "base",
           "summary": "Chill and rotate poultry reserves",
-          "detail": "Unlock the Cooler Box at tech level 13, craft it (20 Ingots, 20 Stone, 5 Ice Organs), and assign a Cooling pal so butchered Galeclaw Poultry stays fresh between hunts.\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011\u3010palwiki-galeclaw-raw\u2020L6-L33\u3011",
+          "detail": "Unlock the Cooler Box at tech level 13, craft it (20 Ingots, 20 Stone, 5 Ice Organs), and assign a Cooling pal so butchered Galeclaw Poultry stays fresh between hunts.【palwiki-cooler-box-raw†L1-L24】【palwiki-galeclaw-raw†L6-L33】",
           "targets": [
             {
               "kind": "item",
@@ -14833,15 +14833,15 @@
         "hardcore": "Hardcore wipes while escorting merchants can delete Mau/Vixy producers and stall your entire economy for hours."
       },
       "adaptive_guidance": {
-        "underleveled": "Stage near the Small Settlement statue and focus on Vixy captures before pushing into night camps for Mau coins.\u3010palwiki-small-settlement\u2020L1-L9\u3011\u3010palwiki-vixy\u2020L118-L176\u3011",
-        "overleveled": "Chain dungeon clears with settlement sell runs so every patrol and chest becomes coin yield, not wasted time.\u3010palwiki-mau-raw\u2020L109-L114\u3011\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011",
+        "underleveled": "Stage near the Small Settlement statue and focus on Vixy captures before pushing into night camps for Mau coins.【palwiki-small-settlement†L1-L9】【palwiki-vixy†L118-L176】",
+        "overleveled": "Chain dungeon clears with settlement sell runs so every patrol and chest becomes coin yield, not wasted time.【palwiki-mau-raw†L109-L114】【palwiki-gold-coin-raw†L20-L28】",
         "resource_shortages": [
           {
             "item_id": "gold-coin",
-            "solution": "Rotate Mau and Vixy through the ranch before departing so Gold Digger and Dig Here! keep banking coins between raids.\u3010palwiki-mau-raw\u2020L11-L115\u3011\u3010palwiki-vixy\u2020L118-L176\u3011"
+            "solution": "Rotate Mau and Vixy through the ranch before departing so Gold Digger and Dig Here! keep banking coins between raids.【palwiki-mau-raw†L11-L115】【palwiki-vixy†L118-L176】"
           }
         ],
-        "time_limited": "Sell high-value drops at the Small Settlement merchant each pass, then sprint back to base before raids hit.\u3010palwiki-wandering-merchant-raw\u2020L24-L119\u3011",
+        "time_limited": "Sell high-value drops at the Small Settlement merchant each pass, then sprint back to base before raids hit.【palwiki-wandering-merchant-raw†L24-L119】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -14887,7 +14887,7 @@
           "step_id": "resource-gold-coin:001",
           "type": "capture",
           "summary": "Sweep Windswept Hills nights for Mau",
-          "detail": "Teleport to the Small Settlement (75,-479), clear nearby faction camps, and dive Windswept Hills dungeons at night to capture at least two Mau for coin production and drops.\u3010palwiki-small-settlement\u2020L1-L9\u3011\u3010palwiki-mau-raw\u2020L11-L115\u3011",
+          "detail": "Teleport to the Small Settlement (75,-479), clear nearby faction camps, and dive Windswept Hills dungeons at night to capture at least two Mau for coin production and drops.【palwiki-small-settlement†L1-L9】【palwiki-mau-raw†L11-L115】",
           "targets": [
             {
               "kind": "pal",
@@ -14951,7 +14951,7 @@
           "step_id": "resource-gold-coin:002",
           "type": "assign",
           "summary": "Automate Mau and Vixy at the ranch",
-          "detail": "Assign Mau and Vixy to ranch slots so Gold Digger and Dig Here! continuously dig coins, spheres, and arrows between field runs.\u3010palwiki-mau-raw\u2020L11-L115\u3011\u3010palwiki-vixy\u2020L118-L176\u3011\u3010palwiki-gold-coin-raw\u2020L20-L27\u3011",
+          "detail": "Assign Mau and Vixy to ranch slots so Gold Digger and Dig Here! continuously dig coins, spheres, and arrows between field runs.【palwiki-mau-raw†L11-L115】【palwiki-vixy†L118-L176】【palwiki-gold-coin-raw†L20-L27】",
           "targets": [
             {
               "kind": "item",
@@ -15007,7 +15007,7 @@
           "step_id": "resource-gold-coin:003",
           "type": "trade",
           "summary": "Sell loot to settlement merchants",
-          "detail": "Haul crafted goods, spare bones, and excess pals to the Small Settlement merchants to convert inventory into gold coins before the next hunt.\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011\u3010palwiki-gold-coin\u2020L28-L44\u3011\u3010palwiki-wandering-merchant-raw\u2020L1-L119\u3011",
+          "detail": "Haul crafted goods, spare bones, and excess pals to the Small Settlement merchants to convert inventory into gold coins before the next hunt.【palwiki-gold-coin-raw†L20-L28】【palwiki-gold-coin†L28-L44】【palwiki-wandering-merchant-raw†L1-L119】",
           "targets": [
             {
               "kind": "item",
@@ -15074,7 +15074,7 @@
           "step_id": "resource-gold-coin:004",
           "type": "combat",
           "summary": "Clear patrols and open chests along the circuit",
-          "detail": "Sweep the crossroads between merchant stops, eliminate Syndicate patrols, and crack open treasure chests to top off coins between ranch payouts.\u3010palwiki-gold-coin-raw\u2020L20-L28\u3011\u3010palwiki-wandering-merchant-raw\u2020L12-L18\u3011",
+          "detail": "Sweep the crossroads between merchant stops, eliminate Syndicate patrols, and crack open treasure chests to top off coins between ranch payouts.【palwiki-gold-coin-raw†L20-L28】【palwiki-wandering-merchant-raw†L12-L18】",
           "targets": [
             {
               "kind": "item",
@@ -15207,19 +15207,19 @@
       },
       "risk_profile": "high",
       "failure_penalties": {
-        "normal": "Missing an alpha clear delays the next in-game day respawn and stalls gemstone income until bosses return.\u3010palwiki-alpha-pals\u2020L12-L25\u3011",
-        "hardcore": "Hardcore wipes on alpha bosses risk permanent Pal losses and waste sealed realm timers before they reset an hour later.\u3010palwiki-alpha-pals\u2020L18-L25\u3011\u3010palwiki-sealed-realms\u2020L24-L29\u3011"
+        "normal": "Missing an alpha clear delays the next in-game day respawn and stalls gemstone income until bosses return.【palwiki-alpha-pals†L12-L25】",
+        "hardcore": "Hardcore wipes on alpha bosses risk permanent Pal losses and waste sealed realm timers before they reset an hour later.【palwiki-alpha-pals†L18-L25】【palwiki-sealed-realms†L24-L29】"
       },
       "adaptive_guidance": {
-        "underleveled": "Focus on level 11-23 overworld alphas like Chillet, Gumoss, Broncherry, and Kingpaca until your capture gear and team can handle higher tiers.\u3010palwiki-alpha-pals\u2020L40-L72\u3011",
-        "overleveled": "Add Warsect, Quivern, Verdash, and other late-game alphas to the loop so every respawn cycle yields extra stones and schematics.\u3010palwiki-alpha-pals\u2020L72-L104\u3011",
+        "underleveled": "Focus on level 11-23 overworld alphas like Chillet, Gumoss, Broncherry, and Kingpaca until your capture gear and team can handle higher tiers.【palwiki-alpha-pals†L40-L72】",
+        "overleveled": "Add Warsect, Quivern, Verdash, and other late-game alphas to the loop so every respawn cycle yields extra stones and schematics.【palwiki-alpha-pals†L72-L104】",
         "resource_shortages": [
           {
             "item_id": "precious-dragon-stone",
-            "solution": "Chain sealed realm clears between overworld sweeps; each fight rolls the alpha drop table and feeds additional gemstones before the hour-long reset.\u3010palwiki-precious-dragon-stone\u2020L1-L18\u3011\u3010palwiki-sealed-realms\u2020L7-L29\u3011"
+            "solution": "Chain sealed realm clears between overworld sweeps; each fight rolls the alpha drop table and feeds additional gemstones before the hour-long reset.【palwiki-precious-dragon-stone†L1-L18】【palwiki-sealed-realms†L7-L29】"
           }
         ],
-        "time_limited": "Hit overworld alphas first\u2014they respawn every in-game day\u2014then spend remaining time on sealed realms that refresh hourly.\u3010palwiki-alpha-pals\u2020L12-L25\u3011\u3010palwiki-sealed-realms\u2020L7-L29\u3011",
+        "time_limited": "Hit overworld alphas first—they respawn every in-game day—then spend remaining time on sealed realms that refresh hourly.【palwiki-alpha-pals†L12-L25】【palwiki-sealed-realms†L7-L29】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -15307,15 +15307,15 @@
         ]
       },
       "failure_recovery": {
-        "normal": "Sleep at camp to roll the in-game day, restock spheres, and rerun the overworld loop once bosses respawn.\u3010palwiki-alpha-pals\u2020L12-L25\u3011",
-        "hardcore": "Rotate sealed realms while waiting on overworld respawns\u2014the arenas refresh hourly even if you had to retreat.\u3010palwiki-sealed-realms\u2020L24-L29\u3011"
+        "normal": "Sleep at camp to roll the in-game day, restock spheres, and rerun the overworld loop once bosses respawn.【palwiki-alpha-pals†L12-L25】",
+        "hardcore": "Rotate sealed realms while waiting on overworld respawns—the arenas refresh hourly even if you had to retreat.【palwiki-sealed-realms†L24-L29】"
       },
       "steps": [
         {
           "step_id": "resource-precious-dragon-stone:001",
           "type": "prepare",
           "summary": "Stage the alpha hunt kit",
-          "detail": "Restock Mega and Hyper Spheres, healing, and elemental counters at base, then sleep until dawn so overworld Alpha Pals are alive when you deploy\u2014they respawn each in-game day and drop Precious Dragon Stones when defeated.\u3010palwiki-alpha-pals\u2020L12-L25\u3011\u3010palwiki-precious-dragon-stone\u2020L1-L18\u3011",
+          "detail": "Restock Mega and Hyper Spheres, healing, and elemental counters at base, then sleep until dawn so overworld Alpha Pals are alive when you deploy—they respawn each in-game day and drop Precious Dragon Stones when defeated.【palwiki-alpha-pals†L12-L25】【palwiki-precious-dragon-stone†L1-L18】",
           "targets": [],
           "locations": [
             {
@@ -15371,7 +15371,7 @@
           "step_id": "resource-precious-dragon-stone:002",
           "type": "combat",
           "summary": "Clear the overworld alpha circuit",
-          "detail": "Fast travel to nearby statues and sweep Chillet (172,-419), Gumoss (-113,-628), Broncherry (-222,-669), and Kingpaca (49,-460) each day; these overworld alphas sit between level 11 and 23 and reliably drop Precious Dragon Stones for every kill.\u3010palwiki-alpha-pals\u2020L40-L72\u3011\u3010palwiki-precious-dragon-stone\u2020L1-L18\u3011\u3010palfandom-precious-dragon-stone\u2020L1-L18\u3011",
+          "detail": "Fast travel to nearby statues and sweep Chillet (172,-419), Gumoss (-113,-628), Broncherry (-222,-669), and Kingpaca (49,-460) each day; these overworld alphas sit between level 11 and 23 and reliably drop Precious Dragon Stones for every kill.【palwiki-alpha-pals†L40-L72】【palwiki-precious-dragon-stone†L1-L18】【palfandom-precious-dragon-stone†L1-L18】",
           "targets": [
             {
               "kind": "item",
@@ -15471,7 +15471,7 @@
           "step_id": "resource-precious-dragon-stone:003",
           "type": "combat",
           "summary": "Rotate sealed realms for hourly resets",
-          "detail": "Dive the Sealed Realm of Spirits (-19,-264) for Petallia, the Swordmaster (-117,-490) for Bushi, and the Abyssal Nights (-411,-54) for Felbat to add hourly gemstone rolls between daily overworld clears.\u3010palwiki-sealed-realms\u2020L7-L29\u3011\u3010palwiki-alpha-pals\u2020L46-L88\u3011\u3010palwiki-precious-dragon-stone\u2020L1-L18\u3011",
+          "detail": "Dive the Sealed Realm of Spirits (-19,-264) for Petallia, the Swordmaster (-117,-490) for Bushi, and the Abyssal Nights (-411,-54) for Felbat to add hourly gemstone rolls between daily overworld clears.【palwiki-sealed-realms†L7-L29】【palwiki-alpha-pals†L46-L88】【palwiki-precious-dragon-stone†L1-L18】",
           "targets": [
             {
               "kind": "item",
@@ -15556,7 +15556,7 @@
           "step_id": "resource-precious-dragon-stone:004",
           "type": "trade",
           "summary": "Liquidate gemstones with merchants",
-          "detail": "Teleport to the Small Settlement (75,-479) or visit wandering merchants to sell surplus stones for 1,000 Gold Coins each, banking profits for schematics or keeping a buffer for future hunts.\u3010palwiki-precious-dragon-stone\u2020L1-L18\u3011\u3010palfandom-precious-dragon-stone\u2020L1-L18\u3011\u3010palwiki-wandering-merchant-raw\u2020L24-L119\u3011\u3010palwiki-small-settlement\u2020L1-L13\u3011",
+          "detail": "Teleport to the Small Settlement (75,-479) or visit wandering merchants to sell surplus stones for 1,000 Gold Coins each, banking profits for schematics or keeping a buffer for future hunts.【palwiki-precious-dragon-stone†L1-L18】【palfandom-precious-dragon-stone†L1-L18】【palwiki-wandering-merchant-raw†L24-L119】【palwiki-small-settlement†L1-L13】",
           "targets": [
             {
               "kind": "item",
@@ -15772,7 +15772,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Drag Lamball away from Syndicate patrols before throwing spheres so stray shots don\u2019t delete your breeders.",
+              "tactics": "Drag Lamball away from Syndicate patrols before throwing spheres so stray shots don’t delete your breeders.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -15831,7 +15831,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Capture backup Lamball before carving so accidents don\u2019t strand you without wool or mutton income.",
+              "tactics": "Capture backup Lamball before carving so accidents don’t strand you without wool or mutton income.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -15999,11 +15999,11 @@
       },
       "adaptive_guidance": {
         "underleveled": "Sweep the grove at dawn, use Dark pals to stagger the herd, and pick off sleepy Mozzarina in small pulls.",
-        "overleveled": "Rotate hunts day and night\u2014herds respawn in pairs so you can chain captures into a cull cycle.",
+        "overleveled": "Rotate hunts day and night—herds respawn in pairs so you can chain captures into a cull cycle.",
         "resource_shortages": [
           {
             "item_id": "mozzarina-meat",
-            "solution": "Cull two Mozzarina per loop with the cleaver; each yields 2\u20133 meat at a 100% rate so chill the cuts immediately."
+            "solution": "Cull two Mozzarina per loop with the cleaver; each yields 2–3 meat at a 100% rate so chill the cuts immediately."
           }
         ],
         "time_limited": "Butcher two captives, stash the meat in a Cooler Box, then let ranchers refill stocks between raids.",
@@ -16063,7 +16063,7 @@
           "step_id": "resource-mozzarina-meat:001",
           "type": "capture",
           "summary": "Reinforce the Swordmaster pasture",
-          "detail": "Glide to the Sealed Realm of the Swordmaster (\u2212117, \u2212490) and sweep the southern Bamboo Groves. Mozzarina spawn in peaceful pairs all day, so use Dark pals to stagger them and throw Mega Spheres before Syndicate patrols rotate in.",
+          "detail": "Glide to the Sealed Realm of the Swordmaster (−117, −490) and sweep the southern Bamboo Groves. Mozzarina spawn in peaceful pairs all day, so use Dark pals to stagger them and throw Mega Spheres before Syndicate patrols rotate in.",
           "targets": [
             {
               "kind": "pal",
@@ -16197,7 +16197,7 @@
           "step_id": "resource-mozzarina-meat:003",
           "type": "base",
           "summary": "Balance dairy and butcher rotations",
-          "detail": "Keep two Mozzarina assigned to the ranch for milk while cycling the extras through the cleaver. Each cull yields 2\u20133 Mozzarina Meat at 100%, so stage Cooler Box slots or cook high-SAN meals as needed.",
+          "detail": "Keep two Mozzarina assigned to the ranch for milk while cycling the extras through the cleaver. Each cull yields 2–3 Mozzarina Meat at 100%, so stage Cooler Box slots or cook high-SAN meals as needed.",
           "targets": [
             {
               "kind": "item",
@@ -16327,12 +16327,12 @@
         "hardcore": "Hardcore arrests during trespass can cascade into squad deletions, so bail before heat hits three stars."
       },
       "adaptive_guidance": {
-        "underleveled": "Stay airborne over Sanctuary No.1, land briefly to gather nodes, and avoid prolonged firefights with level 20\u201325 patrols.",
-        "overleveled": "Rotate through Sanctuaries No.1\u20133 in a single outing to restock flowers and rare drops once you can comfortably clear level 50 threats.",
+        "underleveled": "Stay airborne over Sanctuary No.1, land briefly to gather nodes, and avoid prolonged firefights with level 20–25 patrols.",
+        "overleveled": "Rotate through Sanctuaries No.1–3 in a single outing to restock flowers and rare drops once you can comfortably clear level 50 threats.",
         "resource_shortages": [
           {
             "item_id": "beautiful-flower",
-            "solution": "Alternate node harvests with Petallia and Lyleen hunts\u2014each sweep yields flowers from both spawns and pickup nodes."
+            "solution": "Alternate node harvests with Petallia and Lyleen hunts—each sweep yields flowers from both spawns and pickup nodes."
           }
         ],
         "time_limited": "Do a single perimeter glide, grab the southern node clusters, and extract before PIDF reinforcements escalate trespass charges.",
@@ -16397,7 +16397,7 @@
       },
       "failure_recovery": {
         "normal": "Escape via glider, wait for trespass heat to decay, then restock spheres before the next insertion run.",
-        "hardcore": "Extract immediately when reinforcements spawn\u2014reset at a mainland base, repair gear, and relaunch once timers clear."
+        "hardcore": "Extract immediately when reinforcements spawn—reset at a mainland base, repair gear, and relaunch once timers clear."
       },
       "steps": [
         {
@@ -16937,7 +16937,7 @@
           "step_id": "resource-ore:004",
           "type": "craft",
           "summary": "Smelt ore into Ingots",
-          "detail": "At base, feed ore into the Primitive Furnace\u2014each batch converts two ore into an Ingot that fuels mid-game weapons and armor.",
+          "detail": "At base, feed ore into the Primitive Furnace—each batch converts two ore into an Ingot that fuels mid-game weapons and armor.",
           "targets": [
             {
               "kind": "item",
@@ -17064,17 +17064,17 @@
         "hardcore": "Death in Windswept Hills risks seed stacks; stash extras at base before traveling."
       },
       "adaptive_guidance": {
-        "underleveled": "Stick to day runs around Small Settlement to avoid Syndicate patrols while you buy seeds and wood.\u3010c6adb4\u2020L70-L87\u3011\u301014a18a\u2020L6-L13\u3011",
-        "overleveled": "Expand to two Wheat Plantations and assign higher-tier planters to keep the mill busy between combat outings.\u3010af5fcd\u2020L1-L12\u3011",
+        "underleveled": "Stick to day runs around Small Settlement to avoid Syndicate patrols while you buy seeds and wood.【c6adb4†L70-L87】【14a18a†L6-L13】",
+        "overleveled": "Expand to two Wheat Plantations and assign higher-tier planters to keep the mill busy between combat outings.【af5fcd†L1-L12】",
         "resource_shortages": [
           {
             "item_id": "wheat-seeds",
-            "solution": "Trigger the resource-berry-seeds subroute or re-buy Wheat Seeds from the Small Settlement merchant when the stock refreshes every day.\u3010c6adb4\u2020L70-L85\u3011",
+            "solution": "Trigger the resource-berry-seeds subroute or re-buy Wheat Seeds from the Small Settlement merchant when the stock refreshes every day.【c6adb4†L70-L85】",
             "subroute_ref": "resource-berry-seeds"
           },
           {
             "item_id": "flour",
-            "solution": "Run step :004 twice before leaving base to keep 40+ flour queued for bakeries.\u3010bfc9eb\u2020L1-L17\u3011"
+            "solution": "Run step :004 twice before leaving base to keep 40+ flour queued for bakeries.【bfc9eb†L1-L17】"
           }
         ],
         "time_limited": "Buy seeds and wood in one trip, queue a single plantation harvest, and mill only enough flour for the immediate recipe."
@@ -17121,7 +17121,7 @@
           "step_id": "resource-flour:001",
           "type": "travel",
           "summary": "Buy Wheat Seeds from the Small Settlement",
-          "detail": "Fast travel to the Small Settlement (75,-479), trade with the Wandering Merchant for Wheat Seeds, Wheat, and spare berries so plantations can cycle immediately.\u3010c6adb4\u2020L70-L87\u3011\u301014a18a\u2020L6-L13\u3011",
+          "detail": "Fast travel to the Small Settlement (75,-479), trade with the Wandering Merchant for Wheat Seeds, Wheat, and spare berries so plantations can cycle immediately.【c6adb4†L70-L87】【14a18a†L6-L13】",
           "targets": [
             {
               "kind": "item",
@@ -17202,7 +17202,7 @@
           "step_id": "resource-flour:002",
           "type": "build",
           "summary": "Raise Wheat Plantations",
-          "detail": "Spend 3 Wheat Seeds, 35 Wood, and 35 Stone per plot to build Wheat Plantations, then assign planters, waterers, and gatherers so grain cycles without supervision.\u3010af5fcd\u2020L1-L12\u3011",
+          "detail": "Spend 3 Wheat Seeds, 35 Wood, and 35 Stone per plot to build Wheat Plantations, then assign planters, waterers, and gatherers so grain cycles without supervision.【af5fcd†L1-L12】",
           "targets": [
             {
               "kind": "structure",
@@ -17271,7 +17271,7 @@
           "step_id": "resource-flour:003",
           "type": "build",
           "summary": "Construct the Mill",
-          "detail": "Unlock the Mill at technology level 15, spend 50 Wood and 40 Stone, and assign a Watering-suited Pal to spin the wheel.\u3010ecbbdd\u2020L1-L16\u3011",
+          "detail": "Unlock the Mill at technology level 15, spend 50 Wood and 40 Stone, and assign a Watering-suited Pal to spin the wheel.【ecbbdd†L1-L16】",
           "targets": [
             {
               "kind": "structure",
@@ -17320,7 +17320,7 @@
           "step_id": "resource-flour:004",
           "type": "craft",
           "summary": "Grind wheat into flour",
-          "detail": "Feed harvested Wheat into the Mill in batches of three to produce Flour, then store finished sacks in cooled storage to avoid spoilage.\u3010bfc9eb\u2020L1-L17\u3011\u301015b61b\u2020L1-L11\u3011",
+          "detail": "Feed harvested Wheat into the Mill in batches of three to produce Flour, then store finished sacks in cooled storage to avoid spoilage.【bfc9eb†L1-L17】【15b61b†L1-L11】",
           "targets": [
             {
               "kind": "item",
@@ -17453,7 +17453,7 @@
       },
       "adaptive_guidance": {
         "underleveled": "Prioritize automation first: set ranchers and plantations before pushing tower fights so breeding never stalls.",
-        "overleveled": "Expand to multiple plantations and mills so every breeding cycle consumes from overflow instead of active time.\u3010af5fcd\u2020L1-L12\u3011\u30108f2b7b\u2020L1-L11\u3011",
+        "overleveled": "Expand to multiple plantations and mills so every breeding cycle consumes from overflow instead of active time.【af5fcd†L1-L12】【8f2b7b†L1-L11】",
         "resource_shortages": [
           {
             "item_id": "honey",
@@ -17523,7 +17523,7 @@
         ]
       },
       "failure_recovery": {
-        "normal": "Farm Lovander for a slim cake drop chance while automation recovers.\u301060f5d7\u2020L10-L12\u3011",
+        "normal": "Farm Lovander for a slim cake drop chance while automation recovers.【60f5d7†L10-L12】",
         "hardcore": "Split ingredient herds across multiple bases so a raid can't depopulate every ranch at once."
       },
       "steps": [
@@ -17531,7 +17531,7 @@
           "step_id": "resource-cake:001",
           "type": "build",
           "summary": "Expand plantations for berries and wheat",
-          "detail": "Construct at least one Berry Plantation (3 Berry Seeds, 20 Wood, 20 Stone) and a Wheat Plantation (3 Wheat Seeds, 35 Wood, 35 Stone), then assign planters, waterers, and gatherers.\u30108f2b7b\u2020L1-L11\u3011\u3010af5fcd\u2020L1-L12\u3011",
+          "detail": "Construct at least one Berry Plantation (3 Berry Seeds, 20 Wood, 20 Stone) and a Wheat Plantation (3 Wheat Seeds, 35 Wood, 35 Stone), then assign planters, waterers, and gatherers.【8f2b7b†L1-L11】【af5fcd†L1-L12】",
           "targets": [
             {
               "kind": "structure",
@@ -17614,7 +17614,7 @@
           "step_id": "resource-cake:002",
           "type": "assign",
           "summary": "Stabilize ranch ingredient output",
-          "detail": "Keep Chikipi, Mozzarina, and Beegarde assigned to ranches so eggs, milk, and honey flow while bakeries prep. Kick off the linked resource routes if any stockpile dips.\u301060f5d7\u2020L13-L20\u3011",
+          "detail": "Keep Chikipi, Mozzarina, and Beegarde assigned to ranches so eggs, milk, and honey flow while bakeries prep. Kick off the linked resource routes if any stockpile dips.【60f5d7†L13-L20】",
           "targets": [
             {
               "kind": "item",
@@ -17698,7 +17698,7 @@
           "step_id": "resource-cake:003",
           "type": "craft",
           "summary": "Mill flour in advance",
-          "detail": "Run the Flour Milling Network route or feed harvested wheat into your mill to maintain at least 30 flour on ice ahead of baking sessions.\u3010bfc9eb\u2020L1-L17\u3011",
+          "detail": "Run the Flour Milling Network route or feed harvested wheat into your mill to maintain at least 30 flour on ice ahead of baking sessions.【bfc9eb†L1-L17】",
           "targets": [
             {
               "kind": "item",
@@ -17752,7 +17752,7 @@
           "step_id": "resource-cake:004",
           "type": "craft",
           "summary": "Bake cakes at the Cooking Pot",
-          "detail": "Build a Cooking Pot (20 Wood, 15 Ingots, 3 Flame Organs) and craft cakes using 5 Flour, 8 Red Berries, 7 Milk, 8 Eggs, and 2 Honey per batch. Store finished cakes in the Breeding Farm chest so they never spoil.\u3010f8b394\u2020L1-L12\u3011\u301060f5d7\u2020L1-L16\u3011",
+          "detail": "Build a Cooking Pot (20 Wood, 15 Ingots, 3 Flame Organs) and craft cakes using 5 Flour, 8 Red Berries, 7 Milk, 8 Eggs, and 2 Honey per batch. Store finished cakes in the Breeding Farm chest so they never spoil.【f8b394†L1-L12】【60f5d7†L1-L16】",
           "targets": [
             {
               "kind": "item",
@@ -17897,24 +17897,24 @@
         "hardcore": "Alpha pals in the sanctuary can one-shot lightly geared hunters; retreat rather than risk permadeath."
       },
       "adaptive_guidance": {
-        "underleveled": "Loop the Small Settlement and Duneshelter merchants until your squad can stomach sanctuary aggro; both vendors keep Tomato Seeds in stock for 200 gold.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-duneshelter\u2020L506-L516\u3011\u3010palwiki-tomato-seeds\u2020L552-L565\u3011",
-        "overleveled": "Once you're comfortable in sanctuaries, alternate Wumpo Botan circuits with Sealed Realm of the Guardian clears to stockpile seeds fast.\u3010palwiki-wumpo-botan-raw\u2020L109-L116\u3011\u3010palwiki-vaelet-raw\u2020L108-L116\u3011\u3010palwiki-tomato-seeds\u2020L608-L826\u3011",
+        "underleveled": "Loop the Small Settlement and Duneshelter merchants until your squad can stomach sanctuary aggro; both vendors keep Tomato Seeds in stock for 200 gold.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-duneshelter†L506-L516】【palwiki-tomato-seeds†L552-L565】",
+        "overleveled": "Once you're comfortable in sanctuaries, alternate Wumpo Botan circuits with Sealed Realm of the Guardian clears to stockpile seeds fast.【palwiki-wumpo-botan-raw†L109-L116】【palwiki-vaelet-raw†L108-L116】【palwiki-tomato-seeds†L608-L826】",
         "resource_shortages": [
           {
             "item_id": "tomato-seeds",
-            "solution": "Rotate Wumpo Botan, Oasis Braloha, and the Vaelet alpha before plantations stall to refill the chest in one sweep.\u3010palwiki-wumpo-botan-raw\u2020L109-L116\u3011\u3010palwiki-braloha-raw\u2020L121-L125\u3011\u3010palwiki-vaelet-raw\u2020L108-L116\u3011\u3010palwiki-tomato-seeds\u2020L608-L826\u3011"
+            "solution": "Rotate Wumpo Botan, Oasis Braloha, and the Vaelet alpha before plantations stall to refill the chest in one sweep.【palwiki-wumpo-botan-raw†L109-L116】【palwiki-braloha-raw†L121-L125】【palwiki-vaelet-raw†L108-L116】【palwiki-tomato-seeds†L608-L826】"
           },
           {
             "item_id": "gold-coin",
-            "solution": "Carry at least 1,200 gold per loop so you can buy six seeds from both merchants without waiting on restocks.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-tomato-seeds\u2020L552-L565\u3011"
+            "solution": "Carry at least 1,200 gold per loop so you can buy six seeds from both merchants without waiting on restocks.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-tomato-seeds†L552-L565】"
           }
         ],
-        "time_limited": "Short on time? Buy a merchant stack, drop the plantation build, and let staffed pals harvest while you're away.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-tomato-plantation-raw\u2020L1-L34\u3011",
+        "time_limited": "Short on time? Buy a merchant stack, drop the plantation build, and let staffed pals harvest while you're away.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-tomato-plantation-raw†L1-L34】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Split duties so one partner handles merchant runs while the other clears sanctuary targets and ferries seeds home.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-wumpo-botan-raw\u2020L109-L116\u3011\u3010palwiki-vaelet-raw\u2020L108-L116\u3011",
+            "adjustment": "Split duties so one partner handles merchant runs while the other clears sanctuary targets and ferries seeds home.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-wumpo-botan-raw†L109-L116】【palwiki-vaelet-raw†L108-L116】",
             "priority": 2,
             "mode_scope": [
               "coop"
@@ -17954,7 +17954,7 @@
           "step_id": "resource-tomato-seeds:001",
           "type": "trade",
           "summary": "Buy Tomato Seeds from settlement and desert merchants",
-          "detail": "Fast travel to the Small Settlement (78,-477) for the shared wandering merchant stock, then ride south to Duneshelter (357,347) and clear out the red-coat merchant's Tomato Seeds at 200 gold each before heading into the desert loops.\u3010palwiki-wandering-merchant-raw\u2020L197-L252\u3011\u3010palwiki-duneshelter\u2020L506-L516\u3011\u3010palwiki-tomato-seeds\u2020L552-L565\u3011",
+          "detail": "Fast travel to the Small Settlement (78,-477) for the shared wandering merchant stock, then ride south to Duneshelter (357,347) and clear out the red-coat merchant's Tomato Seeds at 200 gold each before heading into the desert loops.【palwiki-wandering-merchant-raw†L197-L252】【palwiki-duneshelter†L506-L516】【palwiki-tomato-seeds†L552-L565】",
           "targets": [
             {
               "kind": "item",
@@ -18022,7 +18022,7 @@
           "step_id": "resource-tomato-seeds:002",
           "type": "hunt",
           "summary": "Chain Wumpo Botan, Braloha, and Vaelet drops",
-          "detail": "Sail to No. 2 Wildlife Sanctuary (-675,-113) for Wumpo Botan's guaranteed tomato seed drops, glide east from Duneshelter (357,347) to Oasis Isle to cull Braloha herds at a 50% seed rate, then clear the Sealed Realm of the Guardian (113,-353) for the Vaelet alpha's sanctuary haul before rotating back to merchants.\u3010palwiki-wumpo-botan-raw\u2020L109-L116\u3011\u3010palwiki-tomato-seeds\u2020L608-L826\u3011\u3010palwiki-braloha-raw\u2020L121-L125\u3011\u3010palwiki-duneshelter\u2020L506-L516\u3011\u3010palwiki-vaelet-raw\u2020L108-L116\u3011\u3010palwiki-sealed-guardian\u2020L631-L660\u3011",
+          "detail": "Sail to No. 2 Wildlife Sanctuary (-675,-113) for Wumpo Botan's guaranteed tomato seed drops, glide east from Duneshelter (357,347) to Oasis Isle to cull Braloha herds at a 50% seed rate, then clear the Sealed Realm of the Guardian (113,-353) for the Vaelet alpha's sanctuary haul before rotating back to merchants.【palwiki-wumpo-botan-raw†L109-L116】【palwiki-tomato-seeds†L608-L826】【palwiki-braloha-raw†L121-L125】【palwiki-duneshelter†L506-L516】【palwiki-vaelet-raw†L108-L116】【palwiki-sealed-guardian†L631-L660】",
           "targets": [
             {
               "kind": "item",
@@ -18123,7 +18123,7 @@
           "step_id": "resource-tomato-seeds:003",
           "type": "build",
           "summary": "Construct and staff a Tomato Plantation",
-          "detail": "Spend 3 Tomato Seeds, 70 Wood, 50 Stone, and 5 Pal Fluids to place a Tomato Plantation, then assign Planting, Watering, and Gathering pals so tomatoes flow between merchant runs and sanctuary sweeps.\u3010palwiki-tomato-plantation-raw\u2020L1-L34\u3011\u3010palwiki-tomato-seeds\u2020L847-L868\u3011",
+          "detail": "Spend 3 Tomato Seeds, 70 Wood, 50 Stone, and 5 Pal Fluids to place a Tomato Plantation, then assign Planting, Watering, and Gathering pals so tomatoes flow between merchant runs and sanctuary sweeps.【palwiki-tomato-plantation-raw†L1-L34】【palwiki-tomato-seeds†L847-L868】",
           "targets": [
             {
               "kind": "station",
@@ -18262,20 +18262,20 @@
         "hardcore": "Sanctuary elites and alpha bosses can wipe an unprepared crew; disengage rather than risking permanent losses."
       },
       "adaptive_guidance": {
-        "underleveled": "Lean on merchant purchases and pacifist Bristla forests until your team can absorb sanctuary hits.\u3010cf6b68\u2020L1-L4\u3011\u3010bb2b70\u2020L1-L7\u3011",
-        "overleveled": "Farm No. 2 Wildlife Sanctuary on repeat; Wumpo Botan provide both Lettuce and Tomato Seeds while Dinossom Lux tops up extras.\u3010fb8f93\u2020L1-L2\u3011\u3010ca10a8\u2020L1-L6\u3011",
+        "underleveled": "Lean on merchant purchases and pacifist Bristla forests until your team can absorb sanctuary hits.【cf6b68†L1-L4】【bb2b70†L1-L7】",
+        "overleveled": "Farm No. 2 Wildlife Sanctuary on repeat; Wumpo Botan provide both Lettuce and Tomato Seeds while Dinossom Lux tops up extras.【fb8f93†L1-L2】【ca10a8†L1-L6】",
         "resource_shortages": [
           {
             "item_id": "lettuce-seeds",
-            "solution": "Rotate between the sanctuary Wumpo Botan spawn and Bristla forest patrols to refill reserves before plantations stall.\u3010ca10a8\u2020L1-L6\u3011\u3010fb8f93\u2020L1-L2\u3011\u3010bb2b70\u2020L1-L7\u3011"
+            "solution": "Rotate between the sanctuary Wumpo Botan spawn and Bristla forest patrols to refill reserves before plantations stall.【ca10a8†L1-L6】【fb8f93†L1-L2】【bb2b70†L1-L7】"
           }
         ],
-        "time_limited": "Grab a handful of merchant seeds and drop the plantation; you can return later for sanctuary hunting.\u3010cf6b68\u2020L1-L4\u3011\u3010ec48c2\u2020L1-L5\u3011",
+        "time_limited": "Grab a handful of merchant seeds and drop the plantation; you can return later for sanctuary hunting.【cf6b68†L1-L4】【ec48c2†L1-L5】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Split duties so one player escorts seeds while the other clears sanctuary packs and keeps the boat ready for extraction.\u3010fb8f93\u2020L1-L2\u3011",
+            "adjustment": "Split duties so one player escorts seeds while the other clears sanctuary packs and keeps the boat ready for extraction.【fb8f93†L1-L2】",
             "priority": 2,
             "mode_scope": [
               "coop"
@@ -18315,7 +18315,7 @@
           "step_id": "resource-lettuce-seeds:001",
           "type": "trade",
           "summary": "Buy Lettuce Seeds from the Small Settlement merchant",
-          "detail": "Visit the Small Settlement vendor to buy Lettuce Seeds for 200 gold each while restocking wood and stone for the plantation build.\u3010cf6b68\u2020L1-L4\u3011\u3010c6adb4\u2020L34-L114\u3011\u3010165dd8\u2020L71-L90\u3011",
+          "detail": "Visit the Small Settlement vendor to buy Lettuce Seeds for 200 gold each while restocking wood and stone for the plantation build.【cf6b68†L1-L4】【c6adb4†L34-L114】【165dd8†L71-L90】",
           "targets": [
             {
               "kind": "item",
@@ -18380,7 +18380,7 @@
           "step_id": "resource-lettuce-seeds:002",
           "type": "hunt",
           "summary": "Loop sanctuary Wumpo Botan and Bristla forests",
-          "detail": "Farm No. 2 Wildlife Sanctuary (-675,-113) for Wumpo Botan, then sweep Verdant Brook forests where Bristla mingle with Cinnamoth to top off Lettuce Seeds without elite pressure.\u3010fb8f93\u2020L1-L2\u3011\u3010ca10a8\u2020L1-L6\u3011\u3010bb2b70\u2020L1-L7\u3011\u301015adf0\u2020L1-L22\u3011",
+          "detail": "Farm No. 2 Wildlife Sanctuary (-675,-113) for Wumpo Botan, then sweep Verdant Brook forests where Bristla mingle with Cinnamoth to top off Lettuce Seeds without elite pressure.【fb8f93†L1-L2】【ca10a8†L1-L6】【bb2b70†L1-L7】【15adf0†L1-L22】",
           "targets": [
             {
               "kind": "item",
@@ -18451,7 +18451,7 @@
           "step_id": "resource-lettuce-seeds:003",
           "type": "build",
           "summary": "Construct and staff a Lettuce Plantation",
-          "detail": "Invest 3 Lettuce Seeds, 100 Wood, 70 Stone, and 10 Pal Fluids into a Lettuce Plantation, then assign Planting, Watering, and Gathering pals to keep greens flowing.\u3010ec48c2\u2020L1-L5\u3011\u301023bbf1\u2020L1-L3\u3011\u3010fb8486\u2020L1-L4\u3011",
+          "detail": "Invest 3 Lettuce Seeds, 100 Wood, 70 Stone, and 10 Pal Fluids into a Lettuce Plantation, then assign Planting, Watering, and Gathering pals to keep greens flowing.【ec48c2†L1-L5】【23bbf1†L1-L3】【fb8486†L1-L4】",
           "targets": [
             {
               "kind": "station",
@@ -18590,15 +18590,15 @@
         "hardcore": "Hardcore wipes while farming Sakurajima elites cost irreplaceable ranch producers and stall medicine crafting."
       },
       "adaptive_guidance": {
-        "underleveled": "Loop the Plateau of Beginnings near the Small Settlement and focus on Vixy or Rushoar pairs until you can safely branch into night hunts.\u3010palwiki-windswept-hills\u2020L14-L21\u3011\u3010palfandom-bone\u2020L36-L55\u3011",
-        "overleveled": "Layer in Sakurajima Sootseer sweeps at night before returning to the hills so ranch automation keeps up with late-game demand.\u3010palwiki-sootseer\u2020L12-L16\u3011\u3010palwiki-sootseer\u2020L114-L114\u3011",
+        "underleveled": "Loop the Plateau of Beginnings near the Small Settlement and focus on Vixy or Rushoar pairs until you can safely branch into night hunts.【palwiki-windswept-hills†L14-L21】【palfandom-bone†L36-L55】",
+        "overleveled": "Layer in Sakurajima Sootseer sweeps at night before returning to the hills so ranch automation keeps up with late-game demand.【palwiki-sootseer†L12-L16】【palwiki-sootseer†L114-L114】",
         "resource_shortages": [
           {
             "item_id": "bone",
-            "solution": "Keep at least one ranch slot staffed with a bone producer before launching long expeditions.\u3010palwiki-bone\u2020L20-L27\u3011"
+            "solution": "Keep at least one ranch slot staffed with a bone producer before launching long expeditions.【palwiki-bone†L20-L27】"
           }
         ],
-        "time_limited": "Buy merchant bones on each Small Settlement pass, then bank the haul before leaving for tower runs.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palwiki-bone\u2020L22-L27\u3011",
+        "time_limited": "Buy merchant bones on each Small Settlement pass, then bank the haul before leaving for tower runs.【palwiki-small-settlement†L3-L15】【palwiki-bone†L22-L27】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -18615,7 +18615,7 @@
           {
             "signal": "resource_gap:cement_high",
             "condition": "resource_gaps['cement'] >= 5",
-            "adjustment": "Push merchant buys to hit at least 30 bones before swapping back to building queues.\u3010palwiki-bone\u2020L20-L27\u3011",
+            "adjustment": "Push merchant buys to hit at least 30 bones before swapping back to building queues.【palwiki-bone†L20-L27】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -18679,7 +18679,7 @@
           "step_id": "resource-bone:001",
           "type": "travel",
           "summary": "Stage Small Settlement bone hunts",
-          "detail": "Fast travel to the Small Settlement (75,-479), clear poachers, then circle the surrounding Plateau of Beginnings to defeat or capture Rushoar and Vixy for guaranteed bones.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palwiki-windswept-hills\u2020L14-L21\u3011\u3010palwiki-rushoar\u2020L65-L76\u3011\u3010palfandom-bone\u2020L36-L55\u3011",
+          "detail": "Fast travel to the Small Settlement (75,-479), clear poachers, then circle the surrounding Plateau of Beginnings to defeat or capture Rushoar and Vixy for guaranteed bones.【palwiki-small-settlement†L3-L15】【palwiki-windswept-hills†L14-L21】【palwiki-rushoar†L65-L76】【palfandom-bone†L36-L55】",
           "targets": [
             {
               "kind": "item",
@@ -18756,7 +18756,7 @@
           "step_id": "resource-bone:002",
           "type": "assign",
           "summary": "Put ranch pals on bone duty",
-          "detail": "Bring captured Vixy back to base so Dig Here! feeds bones and arrows, then add a Sakurajima Sootseer once you can handle night patrols for guaranteed ranch bones.\u3010palwiki-vixy\u2020L9-L49\u3011\u3010palfandom-bone\u2020L36-L55\u3011\u3010palwiki-sootseer\u2020L12-L16\u3011\u3010palwiki-sootseer\u2020L114-L114\u3011",
+          "detail": "Bring captured Vixy back to base so Dig Here! feeds bones and arrows, then add a Sakurajima Sootseer once you can handle night patrols for guaranteed ranch bones.【palwiki-vixy†L9-L49】【palfandom-bone†L36-L55】【palwiki-sootseer†L12-L16】【palwiki-sootseer†L114-L114】",
           "targets": [
             {
               "kind": "pal",
@@ -18818,7 +18818,7 @@
           "step_id": "resource-bone:003",
           "type": "trade",
           "summary": "Buy out wandering merchants",
-          "detail": "Spend spare gold at the Small Settlement wandering merchant for 100G bones whenever you bank a hunt, keeping cement queues topped up.\u3010palwiki-small-settlement\u2020L3-L15\u3011\u3010palwiki-bone\u2020L20-L27\u3011",
+          "detail": "Spend spare gold at the Small Settlement wandering merchant for 100G bones whenever you bank a hunt, keeping cement queues topped up.【palwiki-small-settlement†L3-L15】【palwiki-bone†L20-L27】",
           "targets": [
             {
               "kind": "item",
@@ -18968,15 +18968,15 @@
         "hardcore": "Hardcore deaths while hauling ore can wipe tech unlock progress and stall weapon upgrades."
       },
       "adaptive_guidance": {
-        "underleveled": "Prioritise the level 10 tech unlock, then smelt a starter batch of ingots before expanding the queue.\u3010palwiki-nail\u2020L13-L22\u3011\u3010game8-nail\u2020L118-L124\u3011",
-        "overleveled": "Unlock the Production Assembly Line as soon as you have spare power cores so nail batches keep up with mid-game structures.\u3010game8-nail\u2020L111-L117\u3011",
+        "underleveled": "Prioritise the level 10 tech unlock, then smelt a starter batch of ingots before expanding the queue.【palwiki-nail†L13-L22】【game8-nail†L118-L124】",
+        "overleveled": "Unlock the Production Assembly Line as soon as you have spare power cores so nail batches keep up with mid-game structures.【game8-nail†L111-L117】",
         "resource_shortages": [
           {
             "item_id": "nail",
-            "solution": "Maintain a 2:1 ingot-to-nail conversion cycle so base expansions never stall.\u3010palwiki-nail\u2020L3-L33\u3011"
+            "solution": "Maintain a 2:1 ingot-to-nail conversion cycle so base expansions never stall.【palwiki-nail†L3-L33】"
           }
         ],
-        "time_limited": "Craft nails in short workbench bursts each time you return from ore runs to avoid idle furnaces.\u3010game8-nail\u2020L118-L124\u3011",
+        "time_limited": "Craft nails in short workbench bursts each time you return from ore runs to avoid idle furnaces.【game8-nail†L118-L124】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -18994,7 +18994,7 @@
           {
             "signal": "resource_gap:ingot_low",
             "condition": "resource_gaps['ingot'] <= 10",
-            "adjustment": "Pause workbench crafting until the furnace rebuilds at least 20 spare ingots for the next batch.\u3010game8-nail\u2020L118-L124\u3011",
+            "adjustment": "Pause workbench crafting until the furnace rebuilds at least 20 spare ingots for the next batch.【game8-nail†L118-L124】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -19058,7 +19058,7 @@
           "step_id": "resource-nail:001",
           "type": "craft",
           "summary": "Unlock Nail tech and smelt ingots",
-          "detail": "Reach level 10, spend the tech point on Nail, and keep a Primitive Furnace smelting ore into ingots for upcoming batches.\u3010palwiki-nail\u2020L13-L22\u3011\u3010game8-nail\u2020L118-L124\u3011",
+          "detail": "Reach level 10, spend the tech point on Nail, and keep a Primitive Furnace smelting ore into ingots for upcoming batches.【palwiki-nail†L13-L22】【game8-nail†L118-L124】",
           "targets": [
             {
               "kind": "item",
@@ -19124,7 +19124,7 @@
           "step_id": "resource-nail:002",
           "type": "craft",
           "summary": "Forge nails at workbenches",
-          "detail": "Queue nails at a Primitive or High Quality Workbench, converting one ingot into two nails per recipe cycle.\u3010palwiki-nail\u2020L3-L33\u3011\u3010game8-nail\u2020L102-L124\u3011",
+          "detail": "Queue nails at a Primitive or High Quality Workbench, converting one ingot into two nails per recipe cycle.【palwiki-nail†L3-L33】【game8-nail†L102-L124】",
           "targets": [
             {
               "kind": "item",
@@ -19186,7 +19186,7 @@
           "step_id": "resource-nail:003",
           "type": "build",
           "summary": "Automate nails with an assembly line",
-          "detail": "Place a Production Assembly Line once unlocked so ingot deliveries turn into bulk nail batches without tying up handcrafting time.\u3010game8-nail\u2020L111-L117\u3011\u3010palwiki-nail\u2020L3-L17\u3011",
+          "detail": "Place a Production Assembly Line once unlocked so ingot deliveries turn into bulk nail batches without tying up handcrafting time.【game8-nail†L111-L117】【palwiki-nail†L3-L17】",
           "targets": [
             {
               "kind": "station",
@@ -19325,19 +19325,19 @@
         "hardcore": "Hardcore wipes in the desert ridge cost mining pals and tech progress, delaying improved furnace output."
       },
       "adaptive_guidance": {
-        "underleveled": "Rush level 34, then drop your Improved Furnace on the (191,-36) ridge so you can mine coal and ore without deep desert fights.\u3010segmentnext-refined-ingot\u2020L2-L5\u3011",
-        "overleveled": "Chain multiple Improved Furnaces and maintain a 2:2 ore-to-coal delivery loop so refined ingot batches stay ahead of building demand.\u3010palwiki-refined-ingot\u2020L1-L6\u3011\u3010segmentnext-refined-ingot\u2020L4-L5\u3011",
+        "underleveled": "Rush level 34, then drop your Improved Furnace on the (191,-36) ridge so you can mine coal and ore without deep desert fights.【segmentnext-refined-ingot†L2-L5】",
+        "overleveled": "Chain multiple Improved Furnaces and maintain a 2:2 ore-to-coal delivery loop so refined ingot batches stay ahead of building demand.【palwiki-refined-ingot†L1-L6】【segmentnext-refined-ingot†L4-L5】",
         "resource_shortages": [
           {
             "item_id": "coal",
-            "solution": "Keep a hauler rota working the ridge at (191,-36) before queueing more furnace batches.\u3010segmentnext-refined-ingot\u2020L5-L5\u3011"
+            "solution": "Keep a hauler rota working the ridge at (191,-36) before queueing more furnace batches.【segmentnext-refined-ingot†L5-L5】"
           },
           {
             "item_id": "refined-ingot",
-            "solution": "Each refined ingot consumes 2 Ore and 2 Coal\u2014rebuild the ratio before resuming hand-ins.\u3010palwiki-refined-ingot\u2020L1-L6\u3011"
+            "solution": "Each refined ingot consumes 2 Ore and 2 Coal—rebuild the ratio before resuming hand-ins.【palwiki-refined-ingot†L1-L6】"
           }
         ],
-        "time_limited": "Smelt in short bursts every time you return to the ridge so the furnace never idles between expeditions.\u3010segmentnext-refined-ingot\u2020L4-L4\u3011",
+        "time_limited": "Smelt in short bursts every time you return to the ridge so the furnace never idles between expeditions.【segmentnext-refined-ingot†L4-L4】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -19355,7 +19355,7 @@
           {
             "signal": "resource_gap:coal_low",
             "condition": "resource_gaps['coal'] <= 20",
-            "adjustment": "Trigger the resource-coal subroute or rotate fresh mining pals before resuming furnace work.\u3010segmentnext-refined-ingot\u2020L5-L5\u3011",
+            "adjustment": "Trigger the resource-coal subroute or rotate fresh mining pals before resuming furnace work.【segmentnext-refined-ingot†L5-L5】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -19409,7 +19409,7 @@
           "step_id": "resource-refined-ingot:001",
           "type": "build",
           "summary": "Unlock and place an Improved Furnace",
-          "detail": "Hit level 34, spend tech points on both Refined Ingot and the Improved Furnace, then blueprint the furnace on the ore/coal ridge. Bring 100 Stone, 30 Cement, and 15 Flame Organs to finish construction.\u3010segmentnext-refined-ingot\u2020L2-L3\u3011",
+          "detail": "Hit level 34, spend tech points on both Refined Ingot and the Improved Furnace, then blueprint the furnace on the ore/coal ridge. Bring 100 Stone, 30 Cement, and 15 Flame Organs to finish construction.【segmentnext-refined-ingot†L2-L3】",
           "targets": [
             {
               "kind": "station",
@@ -19477,7 +19477,7 @@
           "step_id": "resource-refined-ingot:002",
           "type": "gather",
           "summary": "Mine ore and coal from the ridge",
-          "detail": "Cycle mining pals through the (191,-36) plateau so coal nodes and ore boulders refill storage between furnace batches.\u3010segmentnext-refined-ingot\u2020L5-L5\u3011",
+          "detail": "Cycle mining pals through the (191,-36) plateau so coal nodes and ore boulders refill storage between furnace batches.【segmentnext-refined-ingot†L5-L5】",
           "targets": [
             {
               "kind": "item",
@@ -19559,7 +19559,7 @@
           "step_id": "resource-refined-ingot:003",
           "type": "craft",
           "summary": "Smelt refined ingots in batches",
-          "detail": "Queue refined ingots at the Improved Furnace, feeding 2 Ore and 2 Coal per bar so construction stockpiles stay ahead of blueprints.\u3010palwiki-refined-ingot\u2020L1-L6\u3011\u3010segmentnext-refined-ingot\u2020L4-L4\u3011",
+          "detail": "Queue refined ingots at the Improved Furnace, feeding 2 Ore and 2 Coal per bar so construction stockpiles stay ahead of blueprints.【palwiki-refined-ingot†L1-L6】【segmentnext-refined-ingot†L4-L4】",
           "targets": [
             {
               "kind": "item",
@@ -19705,19 +19705,19 @@
         "hardcore": "Hardcore wipes while farming Pal Metal drops risk irreplaceable high-level pals and generator repairs."
       },
       "adaptive_guidance": {
-        "underleveled": "Bank refined ingots and tech points before level 44 so the Electric Furnace and generator frame go up in one trip.\u3010palwiki-electric-furnace\u2020L1-L4\u3011",
-        "overleveled": "Once alloy batches flow, rotate into Astegon or Necromus hunts to add guaranteed Pal Metal drops for legendary queues.\u3010fandom-pal-metal-ingot\u2020L1-L4\u3011",
+        "underleveled": "Bank refined ingots and tech points before level 44 so the Electric Furnace and generator frame go up in one trip.【palwiki-electric-furnace†L1-L4】",
+        "overleveled": "Once alloy batches flow, rotate into Astegon or Necromus hunts to add guaranteed Pal Metal drops for legendary queues.【fandom-pal-metal-ingot†L1-L4】",
         "resource_shortages": [
           {
             "item_id": "paldium-fragment",
-            "solution": "Trigger the resource-paldium subroute or run riverbank loops until you refill at least 80 fragments.\u3010palwiki-paldium\u2020L42-L71\u3011"
+            "solution": "Trigger the resource-paldium subroute or run riverbank loops until you refill at least 80 fragments.【palwiki-paldium†L42-L71】"
           },
           {
             "item_id": "pal-metal-ingot",
-            "solution": "Each bar consumes 4 Ore and 2 Paldium fragments\u2014balance smelts with mining runs before queueing late-game gear.\u3010palwiki-pal-metal-ingot\u2020L1-L3\u3011"
+            "solution": "Each bar consumes 4 Ore and 2 Paldium fragments—balance smelts with mining runs before queueing late-game gear.【palwiki-pal-metal-ingot†L1-L3】"
           }
         ],
-        "time_limited": "Craft Pal Metal Ingots in bursts while the generator is fuelled to avoid power waste between batches.\u3010palwiki-pal-metal-ingot\u2020L1-L3\u3011",
+        "time_limited": "Craft Pal Metal Ingots in bursts while the generator is fuelled to avoid power waste between batches.【palwiki-pal-metal-ingot†L1-L3】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -19735,7 +19735,7 @@
           {
             "signal": "resource_gap:paldium-fragment_low",
             "condition": "resource_gaps['paldium-fragment'] <= 20",
-            "adjustment": "Pause smelting and rerun resource-paldium to rebuild fragments before draining ore stock.\u3010palwiki-paldium\u2020L42-L71\u3011",
+            "adjustment": "Pause smelting and rerun resource-paldium to rebuild fragments before draining ore stock.【palwiki-paldium†L42-L71】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -19789,7 +19789,7 @@
           "step_id": "resource-pal-metal-ingot:001",
           "type": "build",
           "summary": "Construct and power the Electric Furnace",
-          "detail": "Spend level-44 tech points on the Electric Furnace, deliver 50 Refined Ingots, 10 Circuit Boards, 20 Polymer, and 20 Carbon Fiber, then wire it into a Power Generator and assign a high-tier fire Pal to light it.\u3010palwiki-electric-furnace\u2020L1-L4\u3011",
+          "detail": "Spend level-44 tech points on the Electric Furnace, deliver 50 Refined Ingots, 10 Circuit Boards, 20 Polymer, and 20 Carbon Fiber, then wire it into a Power Generator and assign a high-tier fire Pal to light it.【palwiki-electric-furnace†L1-L4】",
           "targets": [
             {
               "kind": "station",
@@ -19852,7 +19852,7 @@
           "step_id": "resource-pal-metal-ingot:002",
           "type": "gather",
           "summary": "Stockpile ore and Paldium fragments",
-          "detail": "Loop the desert ridge for ore while triggering resource-paldium runs so fragment reserves stay ahead of 4 Ore + 2 Paldium alloy batches.\u3010segmentnext-refined-ingot\u2020L5-L5\u3011\u3010palwiki-paldium\u2020L42-L71\u3011\u3010palwiki-pal-metal-ingot\u2020L1-L3\u3011",
+          "detail": "Loop the desert ridge for ore while triggering resource-paldium runs so fragment reserves stay ahead of 4 Ore + 2 Paldium alloy batches.【segmentnext-refined-ingot†L5-L5】【palwiki-paldium†L42-L71】【palwiki-pal-metal-ingot†L1-L3】",
           "targets": [
             {
               "kind": "item",
@@ -19936,7 +19936,7 @@
           "step_id": "resource-pal-metal-ingot:003",
           "type": "craft",
           "summary": "Smelt Pal Metal Ingots",
-          "detail": "Feed 4 Ore and 2 Paldium Fragments into the Electric Furnace per bar, keeping generators powered so late-game armor and weapon blueprints stay supplied.\u3010palwiki-pal-metal-ingot\u2020L1-L3\u3011\u3010fandom-pal-metal-ingot\u2020L1-L4\u3011",
+          "detail": "Feed 4 Ore and 2 Paldium Fragments into the Electric Furnace per bar, keeping generators powered so late-game armor and weapon blueprints stay supplied.【palwiki-pal-metal-ingot†L1-L3】【fandom-pal-metal-ingot†L1-L4】",
           "targets": [
             {
               "kind": "item",
@@ -19998,7 +19998,7 @@
           "step_id": "resource-pal-metal-ingot:004",
           "type": "hunt",
           "summary": "Farm elite Pal Metal drops",
-          "detail": "Rotate Astegon, Necromus, Paladius, and Shadowbeak hunts so guaranteed Pal Metal drops top off alloy storage between furnace cycles.\u3010fandom-pal-metal-ingot\u2020L1-L4\u3011",
+          "detail": "Rotate Astegon, Necromus, Paladius, and Shadowbeak hunts so guaranteed Pal Metal drops top off alloy storage between furnace cycles.【fandom-pal-metal-ingot†L1-L4】",
           "targets": [
             {
               "kind": "pal",
@@ -20151,15 +20151,15 @@
         "hardcore": "Hardcore wipes during ridge mining can strand your coal haulers and stall the entire fiber supply chain."
       },
       "adaptive_guidance": {
-        "underleveled": "Bank the 100 Ingots, 20 Nails, and 10 Cement before hitting level 28 so the line goes up in one construction cycle.\u3010palwiki-production-assembly-line\u2020L8-L45\u3011",
-        "overleveled": "Rotate Jetragon or Shadowbeak hunts between craft batches so their guaranteed drops patch any coal shortages.\u3010palfandom-carbon-fiber\u2020L108-L110\u3011",
+        "underleveled": "Bank the 100 Ingots, 20 Nails, and 10 Cement before hitting level 28 so the line goes up in one construction cycle.【palwiki-production-assembly-line†L8-L45】",
+        "overleveled": "Rotate Jetragon or Shadowbeak hunts between craft batches so their guaranteed drops patch any coal shortages.【palfandom-carbon-fiber†L108-L110】",
         "resource_shortages": [
           {
             "item_id": "carbon-fiber",
-            "solution": "Each craft costs 2 Coal or 5 Charcoal\u2014match queue sizes to your mining throughput before loading the hopper.\u3010palwiki-carbon-fiber\u2020L13-L40\u3011\u3010palfandom-carbon-fiber\u2020L86-L110\u3011"
+            "solution": "Each craft costs 2 Coal or 5 Charcoal—match queue sizes to your mining throughput before loading the hopper.【palwiki-carbon-fiber†L13-L40】【palfandom-carbon-fiber†L86-L110】"
           }
         ],
-        "time_limited": "Burn through a stored Charcoal crate for a 20-piece batch when you only have minutes before a raid.\u3010palwiki-carbon-fiber\u2020L37-L40\u3011\u3010palwiki-charcoal\u2020L22-L31\u3011",
+        "time_limited": "Burn through a stored Charcoal crate for a 20-piece batch when you only have minutes before a raid.【palwiki-carbon-fiber†L37-L40】【palwiki-charcoal†L22-L31】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -20204,7 +20204,7 @@
           "step_id": "resource-carbon-fiber:001",
           "type": "build",
           "summary": "Construct the Production Assembly Line",
-          "detail": "Spend 3 tech points at level 28 to unlock the Production Assembly Line, then deliver 100 Ingots, 50 Wood, 20 Nails, and 10 Cement so three handiwork pals can staff the station without downtime.\u3010palwiki-production-assembly-line\u2020L8-L35\u3011",
+          "detail": "Spend 3 tech points at level 28 to unlock the Production Assembly Line, then deliver 100 Ingots, 50 Wood, 20 Nails, and 10 Cement so three handiwork pals can staff the station without downtime.【palwiki-production-assembly-line†L8-L35】",
           "targets": [
             {
               "kind": "station",
@@ -20254,7 +20254,7 @@
           "step_id": "resource-carbon-fiber:002",
           "type": "gather",
           "summary": "Mine Astral ridge coal and cook backup Charcoal",
-          "detail": "Set Digtoise and Tombat crews on the (191,-36) ridge so ore and coal flow together, then keep furnaces burning Wood at a 2:1 ratio for Charcoal to buffer outages.\u3010segmentnext-refined-ingot\u2020L2-L5\u3011\u3010palwiki-charcoal\u2020L22-L31\u3011",
+          "detail": "Set Digtoise and Tombat crews on the (191,-36) ridge so ore and coal flow together, then keep furnaces burning Wood at a 2:1 ratio for Charcoal to buffer outages.【segmentnext-refined-ingot†L2-L5】【palwiki-charcoal†L22-L31】",
           "targets": [
             {
               "kind": "item",
@@ -20331,7 +20331,7 @@
           "step_id": "resource-carbon-fiber:003",
           "type": "craft",
           "summary": "Queue carbon fiber batches",
-          "detail": "Assign handiwork pals to the Assembly Line, feed it 2 Coal or 5 Charcoal per craft, and backfill with Jetragon or Shadowbeak drops when queues spike for late-game weapons.\u3010palwiki-carbon-fiber\u2020L13-L40\u3011\u3010palfandom-carbon-fiber\u2020L86-L110\u3011",
+          "detail": "Assign handiwork pals to the Assembly Line, feed it 2 Coal or 5 Charcoal per craft, and backfill with Jetragon or Shadowbeak drops when queues spike for late-game weapons.【palwiki-carbon-fiber†L13-L40】【palfandom-carbon-fiber†L86-L110】",
           "targets": [
             {
               "kind": "item",
@@ -20478,15 +20478,15 @@
         "hardcore": "Hardcore wipes drop your early electric pals and any organs you hauled back toward base."
       },
       "adaptive_guidance": {
-        "underleveled": "Glide down from Rayne Syndicate Tower and kite Sparkit toward the bridge while Water pals soak their attacks before committing to longer loops.\u30109565e9\u2020L11-L14\u3011\u3010eec516\u2020L5-L9\u3011",
-        "overleveled": "Rotate a Twilight Dunes sweep between bridge runs so higher-level Sparkit chains keep pace with late-game conductor crafting.\u3010eec516\u2020L5-L7\u3011",
+        "underleveled": "Glide down from Rayne Syndicate Tower and kite Sparkit toward the bridge while Water pals soak their attacks before committing to longer loops.【9565e9†L11-L14】【eec516†L5-L9】",
+        "overleveled": "Rotate a Twilight Dunes sweep between bridge runs so higher-level Sparkit chains keep pace with late-game conductor crafting.【eec516†L5-L7】",
         "resource_shortages": [
           {
             "item_id": "electric-organ",
-            "solution": "Buy the merchant\u2019s 200-gold stock after every hunt to buffer against unlucky Sparkit drops.\u30109565e9\u2020L6-L8\u3011\u3010eec516\u2020L9-L14\u3011"
+            "solution": "Buy the merchant’s 200-gold stock after every hunt to buffer against unlucky Sparkit drops.【9565e9†L6-L8】【eec516†L9-L14】"
           }
         ],
-        "time_limited": "Run a single bridge lap, fast travel home, and bank the organs so you always leave with net profit.\u30109565e9\u2020L11-L14\u3011",
+        "time_limited": "Run a single bridge lap, fast travel home, and bank the organs so you always leave with net profit.【9565e9†L11-L14】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -20547,14 +20547,14 @@
       },
       "failure_recovery": {
         "normal": "Respawn at Rayne Tower, rehydrate, and resume bridge pulls once armor is repaired.",
-        "hardcore": "Withdraw after each loop to deposit organs; don\u2019t risk a Hardcore wipe carrying full stacks."
+        "hardcore": "Withdraw after each loop to deposit organs; don’t risk a Hardcore wipe carrying full stacks."
       },
       "steps": [
         {
           "step_id": "resource-electric-organ:001",
           "type": "travel",
           "summary": "Stage the Rayne tower descent",
-          "detail": "Fast travel to Rayne Syndicate Tower Entrance (~112,-434), glide toward Bridge of the Twin Knights, and flag Sparkit patrol nodes before the farming loop begins.\u30109565e9\u2020L11-L14\u3011\u3010825211382965329\u2020L103-L118\u3011",
+          "detail": "Fast travel to Rayne Syndicate Tower Entrance (~112,-434), glide toward Bridge of the Twin Knights, and flag Sparkit patrol nodes before the farming loop begins.【9565e9†L11-L14】【825211382965329†L103-L118】",
           "targets": [],
           "locations": [
             {
@@ -20597,7 +20597,7 @@
           "step_id": "resource-electric-organ:002",
           "type": "combat",
           "summary": "Loop Sparkit and Jolthog packs",
-          "detail": "Work the bridge ridge, burst Sparkit and Jolthog, fast travel to reset spawns, and repeat until you bank at least a dozen electric organs from guaranteed drops.\u30109565e9\u2020L11-L14\u3011\u30109565e9\u2020L60-L66\u3011\u3010eec516\u2020L5-L7\u3011",
+          "detail": "Work the bridge ridge, burst Sparkit and Jolthog, fast travel to reset spawns, and repeat until you bank at least a dozen electric organs from guaranteed drops.【9565e9†L11-L14】【9565e9†L60-L66】【eec516†L5-L7】",
           "targets": [
             {
               "kind": "item",
@@ -20670,7 +20670,7 @@
           "step_id": "resource-electric-organ:003",
           "type": "trade",
           "summary": "Buy out the Small Settlement vendor",
-          "detail": "Visit the Small Settlement merchant (~73,-485) after each hunt and spend 200 gold per organ to pad reserves while wandering stock lasts.\u30109565e9\u2020L6-L8\u3011\u3010eec516\u2020L9-L14\u3011",
+          "detail": "Visit the Small Settlement merchant (~73,-485) after each hunt and spend 200 gold per organ to pad reserves while wandering stock lasts.【9565e9†L6-L8】【eec516†L9-L14】",
           "targets": [
             {
               "kind": "item",
@@ -20801,20 +20801,20 @@
         "hardcore": "Bridge-of-the-Twin-Knights patrols hit level 20+, so a wipe can cost your entire seed stock and high-level pals."
       },
       "adaptive_guidance": {
-        "underleveled": "Stay on the merchant rotation until you unlock the Wheat Plantation at tech level 15, stocking seeds without provoking the level-20 bridge patrols.\u301046c54c\u2020L9-L21\u3011",
-        "overleveled": "Chain Dinossom's 50% Wheat Seed drop with Flopie loops beyond the bridge to overstock plantations between tech pushes.\u301046c54c\u2020L9-L17\u3011\u3010b1cc9c\u2020L1-L2\u3011",
+        "underleveled": "Stay on the merchant rotation until you unlock the Wheat Plantation at tech level 15, stocking seeds without provoking the level-20 bridge patrols.【46c54c†L9-L21】",
+        "overleveled": "Chain Dinossom's 50% Wheat Seed drop with Flopie loops beyond the bridge to overstock plantations between tech pushes.【46c54c†L9-L17】【b1cc9c†L1-L2】",
         "resource_shortages": [
           {
             "item_id": "wheat-seeds",
-            "solution": "Alternate between Small Settlement purchases and Rayne tower hunts so plantations never stall on reseed stock.\u301046c54c\u2020L12-L17\u3011\u3010a05a80\u2020L1-L13\u3011"
+            "solution": "Alternate between Small Settlement purchases and Rayne tower hunts so plantations never stall on reseed stock.【46c54c†L12-L17】【a05a80†L1-L13】"
           }
         ],
-        "time_limited": "Buy a handful of seeds, drop a plantation, and let automation roll while you focus on other objectives.\u301046c54c\u2020L18-L21\u3011\u301054c140\u2020L1-L9\u3011",
+        "time_limited": "Buy a handful of seeds, drop a plantation, and let automation roll while you focus on other objectives.【46c54c†L18-L21】【54c140†L1-L9】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
             "condition": "mode.coop === true",
-            "adjustment": "Assign one player to escort the merchant haul while the other clears Flopie and Dinossom patrols northeast of Rayne Tower for steady drops.\u301046c54c\u2020L9-L17\u3011",
+            "adjustment": "Assign one player to escort the merchant haul while the other clears Flopie and Dinossom patrols northeast of Rayne Tower for steady drops.【46c54c†L9-L17】",
             "priority": 2,
             "mode_scope": [
               "coop"
@@ -20854,7 +20854,7 @@
           "step_id": "resource-wheat-seeds:001",
           "type": "trade",
           "summary": "Buy Wheat Seeds from the Small Settlement merchant",
-          "detail": "Fast travel to the Small Settlement (~75,-479) and buy at least nine Wheat Seeds from the wandering merchant for 100 gold each whenever they appear, keeping spare stacks for reseeds.\u301046c54c\u2020L12-L16\u3011\u30104d9312\u2020L12-L14\u3011\u3010bda51b\u2020L1-L4\u3011",
+          "detail": "Fast travel to the Small Settlement (~75,-479) and buy at least nine Wheat Seeds from the wandering merchant for 100 gold each whenever they appear, keeping spare stacks for reseeds.【46c54c†L12-L16】【4d9312†L12-L14】【bda51b†L1-L4】",
           "targets": [
             {
               "kind": "item",
@@ -20919,7 +20919,7 @@
           "step_id": "resource-wheat-seeds:002",
           "type": "hunt",
           "summary": "Farm Dinossom and Flopie for field drops",
-          "detail": "Stage at Rayne Syndicate Tower Entrance (~112,-434), sweep the surrounding Windswept Hills for Dinossom's 50% Wheat Seed drops, then glide northeast across the Bridge of the Twin Knights to capture Flopie packs for additional seeds.\u3010ca82d7\u2020L1-L4\u3011\u301046c54c\u2020L9-L17\u3011\u3010b1cc9c\u2020L1-L2\u3011\u3010a05a80\u2020L1-L13\u3011",
+          "detail": "Stage at Rayne Syndicate Tower Entrance (~112,-434), sweep the surrounding Windswept Hills for Dinossom's 50% Wheat Seed drops, then glide northeast across the Bridge of the Twin Knights to capture Flopie packs for additional seeds.【ca82d7†L1-L4】【46c54c†L9-L17】【b1cc9c†L1-L2】【a05a80†L1-L13】",
           "targets": [
             {
               "kind": "item",
@@ -21005,7 +21005,7 @@
           "step_id": "resource-wheat-seeds:003",
           "type": "build",
           "summary": "Construct and staff a Wheat Plantation",
-          "detail": "Spend 3 Wheat Seeds, 35 Wood, and 35 Stone to place a Wheat Plantation, then assign Planting and Watering pals to keep grain flowing into mills.\u301046c54c\u2020L18-L21\u3011\u301054c140\u2020L1-L9\u3011",
+          "detail": "Spend 3 Wheat Seeds, 35 Wood, and 35 Stone to place a Wheat Plantation, then assign Planting and Watering pals to keep grain flowing into mills.【46c54c†L18-L21】【54c140†L1-L9】",
           "targets": [
             {
               "kind": "station",
@@ -21158,15 +21158,15 @@
         "hardcore": "Hardcore wipes can cost your Flambelle rancher and reset organ automation."
       },
       "adaptive_guidance": {
-        "underleveled": "Stick to the Grassy Behemoth Hills and Rayne Tower entrance path where Foxparks are easy kills with basic bows.\u30105531dc\u2020L2-L6\u3011",
-        "overleveled": "Add Mount Obsidian Flambelle sweeps to feed ranch assignments as you scale into mid-game heat tech.\u30105531dc\u2020L7-L8\u3011",
+        "underleveled": "Stick to the Grassy Behemoth Hills and Rayne Tower entrance path where Foxparks are easy kills with basic bows.【5531dc†L2-L6】",
+        "overleveled": "Add Mount Obsidian Flambelle sweeps to feed ranch assignments as you scale into mid-game heat tech.【5531dc†L7-L8】",
         "resource_shortages": [
           {
             "item_id": "flame-organ",
-            "solution": "Cycle Foxparks runs, restock merchants, and keep a Flambelle grazing so you always have backup drops.\u3010cf6c22\u2020L5-L8\u3011"
+            "solution": "Cycle Foxparks runs, restock merchants, and keep a Flambelle grazing so you always have backup drops.【cf6c22†L5-L8】"
           }
         ],
-        "time_limited": "Run the Foxparks ridge once, toss drops into base storage, and resume later without losing progress.\u30105531dc\u2020L5-L6\u3011",
+        "time_limited": "Run the Foxparks ridge once, toss drops into base storage, and resume later without losing progress.【5531dc†L5-L6】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -21235,7 +21235,7 @@
           "step_id": "resource-flame-organ:001",
           "type": "travel",
           "summary": "Sweep the Foxparks ridge",
-          "detail": "Warp to Grassy Behemoth Hills, sprint toward Rayne Syndicate Tower Entrance, and clear Foxparks along the ridge before fast travelling home to reset.\u30105531dc\u2020L2-L6\u3011",
+          "detail": "Warp to Grassy Behemoth Hills, sprint toward Rayne Syndicate Tower Entrance, and clear Foxparks along the ridge before fast travelling home to reset.【5531dc†L2-L6】",
           "targets": [
             {
               "kind": "item",
@@ -21292,7 +21292,7 @@
           "step_id": "resource-flame-organ:002",
           "type": "assign",
           "summary": "Ranch Flambelle for steady supply",
-          "detail": "Capture a Flambelle at roughly (361,-48), drop it into your ranch, and let Magma Tears generate organs while you craft.\u30105531dc\u2020L7-L9\u3011\u3010cf6c22\u2020L8-L8\u3011",
+          "detail": "Capture a Flambelle at roughly (361,-48), drop it into your ranch, and let Magma Tears generate organs while you craft.【5531dc†L7-L9】【cf6c22†L8-L8】",
           "targets": [
             {
               "kind": "item",
@@ -21347,7 +21347,7 @@
           "step_id": "resource-flame-organ:003",
           "type": "trade",
           "summary": "Buy 100-gold organs",
-          "detail": "Swing through the Small Settlement after each run and spend 100 gold per Flame Organ to cushion crafting spikes.\u3010cf6c22\u2020L6-L6\u3011",
+          "detail": "Swing through the Small Settlement after each run and spend 100 gold per Flame Organ to cushion crafting spikes.【cf6c22†L6-L6】",
           "targets": [
             {
               "kind": "item",
@@ -21471,23 +21471,23 @@
       "risk_profile": "medium",
       "failure_penalties": {
         "normal": "Clearing Penking ends the dungeon and forces a respawn timer, wasting the farm run.",
-        "hardcore": "Hardcore wipes inside the arena delete your frost pals\u2014leave once armor degrades."
+        "hardcore": "Hardcore wipes inside the arena delete your frost pals—leave once armor degrades."
       },
       "adaptive_guidance": {
-        "underleveled": "Enter the dungeon, clear Pengullets, and exit before touching Penking so you avoid the hour-long reset timer.\u30104307f5\u2020L9-L11\u3011",
-        "overleveled": "Rotate additional Ice-type drops like Reindrix or Foxcicle between dungeon runs to accelerate legendary saddle crafting.\u30104307f5\u2020L58-L64\u3011",
+        "underleveled": "Enter the dungeon, clear Pengullets, and exit before touching Penking so you avoid the hour-long reset timer.【4307f5†L9-L11】",
+        "overleveled": "Rotate additional Ice-type drops like Reindrix or Foxcicle between dungeon runs to accelerate legendary saddle crafting.【4307f5†L58-L64】",
         "resource_shortages": [
           {
             "item_id": "ice-organ",
-            "solution": "Buy Duneshelter stock for 100 gold whenever you pass through the desert to buffer against slow dungeon respawns.\u30104307f5\u2020L6-L7\u3011\u3010955051\u2020L5-L8\u3011"
+            "solution": "Buy Duneshelter stock for 100 gold whenever you pass through the desert to buffer against slow dungeon respawns.【4307f5†L6-L7】【955051†L5-L8】"
           }
         ],
-        "time_limited": "Run one Pengullet clear, leave the dungeon, and stash organs before the cooldown catches up.\u30104307f5\u2020L9-L11\u3011",
+        "time_limited": "Run one Pengullet clear, leave the dungeon, and stash organs before the cooldown catches up.【4307f5†L9-L11】",
         "dynamic_rules": [
           {
             "signal": "resource_gap:pal-fluids_high",
             "condition": "resource_gaps['pal-fluids'] >= 10",
-            "adjustment": "Stay inside for an extra Pengullet cycle\u2014the arena doubles as a Pal Fluid farm.\u30104307f5\u2020L9-L10\u3011",
+            "adjustment": "Stay inside for an extra Pengullet cycle—the arena doubles as a Pal Fluid farm.【4307f5†L9-L10】",
             "priority": 2,
             "mode_scope": [
               "normal",
@@ -21553,7 +21553,7 @@
           "step_id": "resource-ice-organ:001",
           "type": "travel",
           "summary": "Unlock the Frozen Wings fast travel",
-          "detail": "Activate the Sealed Realm of the Frozen Wings statue and set a camp outside the (113,-351) dungeon door for quick entries.\u30104307f5\u2020L9-L10\u3011",
+          "detail": "Activate the Sealed Realm of the Frozen Wings statue and set a camp outside the (113,-351) dungeon door for quick entries.【4307f5†L9-L10】",
           "targets": [],
           "locations": [
             {
@@ -21594,7 +21594,7 @@
           "step_id": "resource-ice-organ:002",
           "type": "combat",
           "summary": "Farm Pengullets in the arena",
-          "detail": "Clear Pengullets supporting Penking, leave before defeating the boss, then re-enter once the cooldown lifts for another wave of organ drops.\u30104307f5\u2020L9-L11\u3011",
+          "detail": "Clear Pengullets supporting Penking, leave before defeating the boss, then re-enter once the cooldown lifts for another wave of organ drops.【4307f5†L9-L11】",
           "targets": [
             {
               "kind": "item",
@@ -21661,7 +21661,7 @@
           "step_id": "resource-ice-organ:003",
           "type": "trade",
           "summary": "Purchase Duneshelter stock",
-          "detail": "Travel to Duneshelter (358,350) and buy any 100-gold ice organs from the wandering merchants stationed there.\u30100e4eda\u2020L83-L83\u3011\u3010955051\u2020L5-L8\u3011",
+          "detail": "Travel to Duneshelter (358,350) and buy any 100-gold ice organs from the wandering merchants stationed there.【0e4eda†L83-L83】【955051†L5-L8】",
           "targets": [
             {
               "kind": "item",
@@ -21786,10 +21786,10 @@
       "risk_profile": "medium",
       "failure_penalties": {
         "normal": "Night hunts risk wipes from clustered poison projectiles; expect armor durability loss.",
-        "hardcore": "Being downed by Helzephyr barrages ends the save\u2014kite aggressively and disengage below half HP."
+        "hardcore": "Being downed by Helzephyr barrages ends the save—kite aggressively and disengage below half HP."
       },
       "adaptive_guidance": {
-        "underleveled": "If armor is below Metal tier, anchor Step :001 at coordinate cluster C for easy retreat to Plateau fast travel before sunrise.\u3010palnerd-venom-gland\u2020L1-L20\u3011\u3010progameguides-base-triangle\u2020L1-L15\u3011",
+        "underleveled": "If armor is below Metal tier, anchor Step :001 at coordinate cluster C for easy retreat to Plateau fast travel before sunrise.【palnerd-venom-gland†L1-L20】【progameguides-base-triangle†L1-L15】",
         "overleveled": "Players running rocket or shotgun builds can skip Step :002 after tagging 10 glands and move straight to ranch automation.",
         "resource_shortages": [
           {
@@ -21846,7 +21846,7 @@
         ]
       },
       "failure_recovery": {
-        "normal": "If you wipe to poison volleys, rest at the Plateau fast travel, buy five glands from the Small Settlement, and reset the hunt loop.\u3010palnerd-venom-gland\u2020L21-L35\u3011\u3010palwiki-venom-gland\u2020L1-L18\u3011",
+        "normal": "If you wipe to poison volleys, rest at the Plateau fast travel, buy five glands from the Small Settlement, and reset the hunt loop.【palnerd-venom-gland†L21-L35】【palwiki-venom-gland†L1-L18】",
         "hardcore": "Rotate night hunts with a partner in co-op so one player stays at camp to revive if the other is downed."
       },
       "steps": [
@@ -21854,7 +21854,7 @@
           "step_id": "resource-venom-gland:001",
           "type": "travel",
           "summary": "Stage Plateau south ridge camp",
-          "detail": "Fast travel to Plateau of Beginnings, glide to the southern peninsula, and drop a campfire, bed, and storage at roughly (230,-510) so you can reset night loops quickly.\u3010progameguides-base-triangle\u2020L1-L15\u3011",
+          "detail": "Fast travel to Plateau of Beginnings, glide to the southern peninsula, and drop a campfire, bed, and storage at roughly (230,-510) so you can reset night loops quickly.【progameguides-base-triangle†L1-L15】",
           "targets": [],
           "locations": [
             {
@@ -21902,7 +21902,7 @@
           "step_id": "resource-venom-gland:002",
           "type": "combat",
           "summary": "Cull Daedream and Depresso packs",
-          "detail": "Hunt Daedream and Depresso along the southern plateau ridges at night; both species drop Venom Glands when defeated or captured, letting you bank 12-15 glands per cycle before dawn.\u3010palnerd-venom-gland\u2020L5-L23\u3011\u3010palwiki-venom-gland\u2020L1-L18\u3011",
+          "detail": "Hunt Daedream and Depresso along the southern plateau ridges at night; both species drop Venom Glands when defeated or captured, letting you bank 12-15 glands per cycle before dawn.【palnerd-venom-gland†L5-L23】【palwiki-venom-gland†L1-L18】",
           "targets": [
             {
               "kind": "item",
@@ -21975,7 +21975,7 @@
           "step_id": "resource-venom-gland:003",
           "type": "trade",
           "summary": "Buy out Small Settlement stock",
-          "detail": "Visit the Small Settlement merchants around (100,-525) and purchase Venom Glands for 100 gold each to buffer poison ammo crafting before your next hunt cycle.\u3010palnerd-venom-gland\u2020L21-L35\u3011\u3010palwiki-venom-gland\u2020L1-L18\u3011\u3010progameguides-base-triangle\u2020L10-L15\u3011",
+          "detail": "Visit the Small Settlement merchants around (100,-525) and purchase Venom Glands for 100 gold each to buffer poison ammo crafting before your next hunt cycle.【palnerd-venom-gland†L21-L35】【palwiki-venom-gland†L1-L18】【progameguides-base-triangle†L10-L15】",
           "targets": [
             {
               "kind": "item",
@@ -22027,7 +22027,7 @@
           "step_id": "resource-venom-gland:004",
           "type": "build",
           "summary": "Assign Caprity Noct to ranches",
-          "detail": "Capture Caprity Noct from Feybreak spawns and station it on a Ranch so it periodically drops Venom Glands for base logistics while you craft poison arrows.\u3010palnerd-venom-gland\u2020L23-L35\u3011",
+          "detail": "Capture Caprity Noct from Feybreak spawns and station it on a Ranch so it periodically drops Venom Glands for base logistics while you craft poison arrows.【palnerd-venom-gland†L23-L35】",
           "targets": [
             {
               "kind": "pal",
@@ -22146,10 +22146,10 @@
       "risk_profile": "high",
       "failure_penalties": {
         "normal": "Katress claw combos inflict heavy stagger and leather steals; expect potion spend.",
-        "hardcore": "Dark spell barrages can one-shot underleveled teams\u2014retreat if shields break."
+        "hardcore": "Dark spell barrages can one-shot underleveled teams—retreat if shields break."
       },
       "adaptive_guidance": {
-        "underleveled": "Use dragon-type pals like Dinossom to exploit Katress weakness and disengage after two kills before dawn.\u3010gameleap-katress\u2020L7-L20\u3011",
+        "underleveled": "Use dragon-type pals like Dinossom to exploit Katress weakness and disengage after two kills before dawn.【gameleap-katress†L7-L20】",
         "overleveled": "Players above 35 can farm the alpha first, then loop Moonless Shore to minimize travel time.",
         "resource_shortages": [
           {
@@ -22214,7 +22214,7 @@
           "step_id": "resource-katress-hair:001",
           "type": "combat",
           "summary": "Hunt Moonless Shore Katress",
-          "detail": "Circle Moonless Shore and Verdant Brook after dusk; Katress only spawn at night and have about a 50% chance to drop Katress Hair alongside leather.\u3010palnerd-katress-hair\u2020L1-L20\u3011\u3010palwiki-katress-hair\u2020L1-L10\u3011",
+          "detail": "Circle Moonless Shore and Verdant Brook after dusk; Katress only spawn at night and have about a 50% chance to drop Katress Hair alongside leather.【palnerd-katress-hair†L1-L20】【palwiki-katress-hair†L1-L10】",
           "targets": [
             {
               "kind": "item",
@@ -22288,7 +22288,7 @@
           "step_id": "resource-katress-hair:002",
           "type": "combat",
           "summary": "Clear Sealed Realm of the Invincible",
-          "detail": "Tackle the level 23 Katress alpha at the Sealed Realm of the Invincible near (241,-330) to secure high-grade drops and a fast travel anchor.\u3010segmentnext-katress\u2020L7-L24\u3011",
+          "detail": "Tackle the level 23 Katress alpha at the Sealed Realm of the Invincible near (241,-330) to secure high-grade drops and a fast travel anchor.【segmentnext-katress†L7-L24】",
           "targets": [
             {
               "kind": "pal",
@@ -22344,7 +22344,7 @@
           "step_id": "resource-katress-hair:003",
           "type": "build",
           "summary": "Spin up Katress breeding pairs",
-          "detail": "Unlock the Breeding Farm and incubate Large Dark Eggs using combos like Penking + Celaray or Direhowl + Elizabee to replenish Katress without nightly hunts.\u3010gameleap-katress\u2020L20-L32\u3011",
+          "detail": "Unlock the Breeding Farm and incubate Large Dark Eggs using combos like Penking + Celaray or Direhowl + Elizabee to replenish Katress without nightly hunts.【gameleap-katress†L20-L32】",
           "targets": [
             {
               "kind": "item",
@@ -22401,7 +22401,7 @@
           "step_id": "resource-katress-hair:004",
           "type": "craft",
           "summary": "Craft Katress Cap and remedies",
-          "detail": "Spend Katress Hair on the Katress Cap schematic from Duneshelter merchants or convert surplus into Speed Remedy batches for work-speed buffs.\u3010palnerd-katress-hair\u2020L20-L36\u3011\u3010palwiki-katress-hair\u2020L1-L13\u3011",
+          "detail": "Spend Katress Hair on the Katress Cap schematic from Duneshelter merchants or convert surplus into Speed Remedy batches for work-speed buffs.【palnerd-katress-hair†L20-L36】【palwiki-katress-hair†L1-L13】",
           "targets": [
             {
               "kind": "item",
@@ -22525,15 +22525,15 @@
         "hardcore": "Death while hauling souls deletes the stack and risks losing late-game pals needed for Crusher automation."
       },
       "adaptive_guidance": {
-        "underleveled": "Stay near the Bridge of the Twin Knights waypoint and chip Helzephyr with rifles from cliffs instead of chasing into syndicate camps.\u3010palwiki-helzephyr-raw\u2020L68-L116\u3011",
-        "overleveled": "Rotate between Helzephyr ridges and Sakurajima camps every in-game night to keep the Crusher stocked before statue upgrades spike demand.\u3010palwiki-helzephyr-raw\u2020L65-L116\u3011\u3010palwiki-sootseer\u2020L65-L114\u3011",
+        "underleveled": "Stay near the Bridge of the Twin Knights waypoint and chip Helzephyr with rifles from cliffs instead of chasing into syndicate camps.【palwiki-helzephyr-raw†L68-L116】",
+        "overleveled": "Rotate between Helzephyr ridges and Sakurajima camps every in-game night to keep the Crusher stocked before statue upgrades spike demand.【palwiki-helzephyr-raw†L65-L116】【palwiki-sootseer†L65-L114】",
         "resource_shortages": [
           {
             "item_id": "medium-pal-soul",
-            "solution": "Run Crusher conversions each time Small Pal Souls exceed 40 so the statue never stalls.\u3010palwiki-medium-pal-soul-raw\u2020L31-L42\u3011"
+            "solution": "Run Crusher conversions each time Small Pal Souls exceed 40 so the statue never stalls.【palwiki-medium-pal-soul-raw†L31-L42】"
           }
         ],
-        "time_limited": "Fast travel to Duneshelter, sweep the nearest Desiccated Desert chests, then smash spare Small Souls at the Crusher before logging off.\u3010palwiki-medium-pal-soul-raw\u2020L22-L36\u3011\u3010palfandom-medium-pal-soul-raw\u2020L27-L38\u3011",
+        "time_limited": "Fast travel to Duneshelter, sweep the nearest Desiccated Desert chests, then smash spare Small Souls at the Crusher before logging off.【palwiki-medium-pal-soul-raw†L22-L36】【palfandom-medium-pal-soul-raw†L27-L38】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -22590,7 +22590,7 @@
           "step_id": "resource-medium-pal-soul:001",
           "type": "hunt",
           "summary": "Intercept Helzephyr above the twin bridges",
-          "detail": "Glide up from the Bridge of the Twin Knights waypoint (~113,-352) after dusk and tag the Helzephyr flock as it circles the northern mesas. Its Medium Pal Soul drop rate is low, so use chain bolas or rifles to secure repeated captures and harvest rare souls along with Venom Glands.\u3010palwiki-helzephyr-raw\u2020L65-L116\u3011",
+          "detail": "Glide up from the Bridge of the Twin Knights waypoint (~113,-352) after dusk and tag the Helzephyr flock as it circles the northern mesas. Its Medium Pal Soul drop rate is low, so use chain bolas or rifles to secure repeated captures and harvest rare souls along with Venom Glands.【palwiki-helzephyr-raw†L65-L116】",
           "targets": [
             {
               "kind": "item",
@@ -22616,7 +22616,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Anchor a Grappling Gun or flying mount before engaging so a fall from the mesas doesn\u2019t end the run.",
+              "tactics": "Anchor a Grappling Gun or flying mount before engaging so a fall from the mesas doesn’t end the run.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -22664,7 +22664,7 @@
           "step_id": "resource-medium-pal-soul:002",
           "type": "hunt",
           "summary": "Purge Sakurajima Sootseer camps",
-          "detail": "Swoop into Sakurajima\u2019s crater camps after midnight, luring Sootseer pairs out of the purple flame pits. Every takedown yields guaranteed Medium Pal Souls plus Bones and Crude Oil\u2014kite them through open lava channels to avoid getting cornered.\u3010palwiki-sootseer\u2020L65-L114\u3011",
+          "detail": "Swoop into Sakurajima’s crater camps after midnight, luring Sootseer pairs out of the purple flame pits. Every takedown yields guaranteed Medium Pal Souls plus Bones and Crude Oil—kite them through open lava channels to avoid getting cornered.【palwiki-sootseer†L65-L114】",
           "targets": [
             {
               "kind": "item",
@@ -22737,7 +22737,7 @@
           "step_id": "resource-medium-pal-soul:003",
           "type": "explore",
           "summary": "Sweep Desiccated Desert treasure chains",
-          "detail": "Teleport to Duneshelter (357,347) and circuit the nearby wrecked convoys and cliff ruins; Medium Pal Souls frequently spawn loose or in chests throughout the desert, so clear each lap before raids reset.\u3010palwiki-medium-pal-soul-raw\u2020L22-L29\u3011\u3010palfandom-medium-pal-soul-raw\u2020L27-L30\u3011\u3010palwiki-duneshelter\u2020L506-L516\u3011",
+          "detail": "Teleport to Duneshelter (357,347) and circuit the nearby wrecked convoys and cliff ruins; Medium Pal Souls frequently spawn loose or in chests throughout the desert, so clear each lap before raids reset.【palwiki-medium-pal-soul-raw†L22-L29】【palfandom-medium-pal-soul-raw†L27-L30】【palwiki-duneshelter†L506-L516】",
           "targets": [
             {
               "kind": "item",
@@ -22794,7 +22794,7 @@
           "step_id": "resource-medium-pal-soul:004",
           "type": "craft",
           "summary": "Convert souls at the Crusher",
-          "detail": "Feed surplus Small Pal Souls into the Crusher for Medium conversions and down-convert spare Large souls when raids oversupply them, keeping the statue queue flush before raid prep sessions.\u3010palwiki-medium-pal-soul-raw\u2020L31-L42\u3011",
+          "detail": "Feed surplus Small Pal Souls into the Crusher for Medium conversions and down-convert spare Large souls when raids oversupply them, keeping the statue queue flush before raid prep sessions.【palwiki-medium-pal-soul-raw†L31-L42】",
           "targets": [
             {
               "kind": "item",
@@ -22917,18 +22917,18 @@
       "risk_profile": "high",
       "failure_penalties": {
         "normal": "Being downed by level 50+ elites forces a corpse run through PIDF patrols and chews through high-tier gear durability.",
-        "hardcore": "Hardcore wipes against Anubis or Executioner raids delete endgame kits\u2014disengage if shields and potions run dry."
+        "hardcore": "Hardcore wipes against Anubis or Executioner raids delete endgame kits—disengage if shields and potions run dry."
       },
       "adaptive_guidance": {
-        "underleveled": "Rotate Step :002 at night with traps and dark pals so Anubis stays staggered while you build Crusher stockpiles before challenging Executioner raids.\u3010game8-large-pal-soul\u2020L113-L136\u3011",
-        "overleveled": "Chain Steps :002 and :004 in a single loop\u2014clear Anubis, fast travel to the sanctuary, then intercept raids to bank 4+ souls per lap.\u3010palwiki-large-pal-soul\u2020L125-L160\u3011",
+        "underleveled": "Rotate Step :002 at night with traps and dark pals so Anubis stays staggered while you build Crusher stockpiles before challenging Executioner raids.【game8-large-pal-soul†L113-L136】",
+        "overleveled": "Chain Steps :002 and :004 in a single loop—clear Anubis, fast travel to the sanctuary, then intercept raids to bank 4+ souls per lap.【palwiki-large-pal-soul†L125-L160】",
         "resource_shortages": [
           {
             "item_id": "large-pal-soul",
-            "solution": "Run Step :003 to convert two Medium Pal Souls or split one Giant Pal Soul into two Large souls whenever drops lag behind Statue demands.\u3010game8-large-pal-soul\u2020L117-L156\u3011\u3010palwiki-crusher\u2020L159-L179\u3011"
+            "solution": "Run Step :003 to convert two Medium Pal Souls or split one Giant Pal Soul into two Large souls whenever drops lag behind Statue demands.【game8-large-pal-soul†L117-L156】【palwiki-crusher†L159-L179】"
           }
         ],
-        "time_limited": "Prioritise Steps :001 and :003 so Crusher conversions keep Statue projects moving even if you skip hunt rotations this session.\u3010game8-large-pal-soul\u2020L117-L156\u3011",
+        "time_limited": "Prioritise Steps :001 and :003 so Crusher conversions keep Statue projects moving even if you skip hunt rotations this session.【game8-large-pal-soul†L117-L156】",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -23005,15 +23005,15 @@
         ]
       },
       "failure_recovery": {
-        "normal": "If Anubis wipes you, rest at the Twilight Dunes statue and return with fresh traps once patrols reset\u2014the alpha respawns at (-134,-95).\u3010palfandom-anubis\u2020L294-L303\u3011",
-        "hardcore": "Hardcore saves should lean on Step :003 conversions from banked Medium or Giant souls instead of repeating risky alpha fights.\u3010game8-large-pal-soul\u2020L117-L156\u3011\u3010palwiki-crusher\u2020L159-L179\u3011"
+        "normal": "If Anubis wipes you, rest at the Twilight Dunes statue and return with fresh traps once patrols reset—the alpha respawns at (-134,-95).【palfandom-anubis†L294-L303】",
+        "hardcore": "Hardcore saves should lean on Step :003 conversions from banked Medium or Giant souls instead of repeating risky alpha fights.【game8-large-pal-soul†L117-L156】【palwiki-crusher†L159-L179】"
       },
       "steps": [
         {
           "step_id": "resource-large-pal-soul:001",
           "type": "build",
           "summary": "Install Statue of Power and Crusher",
-          "detail": "Spend tech points to unlock both the Statue of Power and Crusher, then place them near storage so Large Pal Souls can immediately feed upgrades and conversions.\u3010palwiki-statue-of-power\u2020L160-L186\u3011\u3010palwiki-crusher\u2020L159-L179\u3011",
+          "detail": "Spend tech points to unlock both the Statue of Power and Crusher, then place them near storage so Large Pal Souls can immediately feed upgrades and conversions.【palwiki-statue-of-power†L160-L186】【palwiki-crusher†L159-L179】",
           "targets": [
             {
               "kind": "tech",
@@ -23087,7 +23087,7 @@
           "step_id": "resource-large-pal-soul:002",
           "type": "combat",
           "summary": "Defeat Anubis in Twilight Dunes",
-          "detail": "Fast travel to Twilight Dunes and clear the level 47 Anubis alpha at (-134,-95); every kill drops a Large Pal Soul alongside Bones, making it the fastest repeatable source.\u3010palfandom-anubis\u2020L294-L303\u3011\u3010game8-large-pal-soul\u2020L113-L120\u3011\u3010palwiki-large-pal-soul\u2020L125-L132\u3011",
+          "detail": "Fast travel to Twilight Dunes and clear the level 47 Anubis alpha at (-134,-95); every kill drops a Large Pal Soul alongside Bones, making it the fastest repeatable source.【palfandom-anubis†L294-L303】【game8-large-pal-soul†L113-L120】【palwiki-large-pal-soul†L125-L132】",
           "targets": [
             {
               "kind": "pal",
@@ -23173,7 +23173,7 @@
           "step_id": "resource-large-pal-soul:003",
           "type": "craft",
           "summary": "Convert souls at the Crusher",
-          "detail": "Feed two Medium Pal Souls or one Giant Pal Soul into the Crusher to mint Large Pal Souls whenever Statue projects demand more than hunts provide.\u3010game8-large-pal-soul\u2020L117-L156\u3011\u3010palwiki-crusher\u2020L159-L179\u3011",
+          "detail": "Feed two Medium Pal Souls or one Giant Pal Soul into the Crusher to mint Large Pal Souls whenever Statue projects demand more than hunts provide.【game8-large-pal-soul†L117-L156】【palwiki-crusher†L159-L179】",
           "targets": [
             {
               "kind": "item",
@@ -23238,7 +23238,7 @@
           "step_id": "resource-large-pal-soul:004",
           "type": "gather",
           "summary": "Sweep sanctuaries and raids",
-          "detail": "After each hunt, glide through No. 2 Wildlife Sanctuary (-675,-113) and intercept Pal Genetic Research Unit raids\u2014both zones leave Large Pal Souls on the ground after skirmishes.\u3010palwiki-large-pal-soul\u2020L116-L160\u3011\u3010palwiki-wildlife-sanctuary-2\u2020L1-L15\u3011",
+          "detail": "After each hunt, glide through No. 2 Wildlife Sanctuary (-675,-113) and intercept Pal Genetic Research Unit raids—both zones leave Large Pal Souls on the ground after skirmishes.【palwiki-large-pal-soul†L116-L160】【palwiki-wildlife-sanctuary-2†L1-L15】",
           "targets": [
             {
               "kind": "item",
@@ -23259,7 +23259,7 @@
           ],
           "mode_adjustments": {
             "hardcore": {
-              "tactics": "Avoid chaining kills once PIDF reinforcements spawn\u2014grab souls and extract immediately.",
+              "tactics": "Avoid chaining kills once PIDF reinforcements spawn—grab souls and extract immediately.",
               "mode_scope": [
                 "hardcore"
               ]
@@ -23400,10 +23400,10 @@
         "resource_shortages": [
           {
             "item_id": "cotton_candy",
-            "solution": "Assign each Woolipop to the ranch\u2014Candy Pop guarantees 1\u20132 cotton candy per cycle and stock never spoils, so fill a chest before logging off."
+            "solution": "Assign each Woolipop to the ranch—Candy Pop guarantees 1–2 cotton candy per cycle and stock never spoils, so fill a chest before logging off."
           }
         ],
-        "time_limited": "Queue cakes ahead of time and let Woolipop work the ranch overnight\u2014the candy never expires, making it ideal for weekend prep.",
+        "time_limited": "Queue cakes ahead of time and let Woolipop work the ranch overnight—the candy never expires, making it ideal for weekend prep.",
         "dynamic_rules": [
           {
             "signal": "mode:coop",
@@ -23498,7 +23498,7 @@
             }
           ],
           "citations": [
-            "palwiki-breeding-render\u2020L1-L3"
+            "palwiki-breeding-render†L1-L3"
           ]
         },
         {
@@ -23569,15 +23569,15 @@
             }
           ],
           "citations": [
-            "palwiki-woolipop-breeding\u2020L2-L9",
-            "palwiki-breeding-render\u2020L1-L3"
+            "palwiki-woolipop-breeding†L2-L9",
+            "palwiki-breeding-render†L1-L3"
           ]
         },
         {
           "step_id": "resource-cotton-candy:003",
           "type": "assign",
           "summary": "Staff Woolipop on the Ranch for cotton candy",
-          "detail": "Drop Woolipop onto the ranch: Candy Pop guarantees 1\u20132 cotton candy plus High Quality Pal Oil per cycle, and the sweets never spoil, so funnel output into chests for long-term buffs.",
+          "detail": "Drop Woolipop onto the ranch: Candy Pop guarantees 1–2 cotton candy plus High Quality Pal Oil per cycle, and the sweets never spoil, so funnel output into chests for long-term buffs.",
           "targets": [
             {
               "kind": "item",
@@ -23631,8 +23631,8 @@
             }
           ],
           "citations": [
-            "palwiki-woolipop\u2020L12-L100",
-            "palwiki-cotton-candy\u2020L4-L24"
+            "palwiki-woolipop†L12-L100",
+            "palwiki-cotton-candy†L4-L24"
           ]
         }
       ],
@@ -23658,6 +23658,306 @@
         {
           "route_id": "resource-high-quality-pal-oil",
           "reason": "Woolipop ranching doubles as a High Quality Pal Oil drip once your candy reserve is stable."
+        }
+      ]
+    },
+    {
+      "route_id": "resource-broncherry-meat",
+      "title": "Broncherry Meat Caravan Loop",
+      "category": "resources",
+      "tags": [
+        "resource-farm",
+        "broncherry-meat",
+        "alpha-hunt",
+        "cooking"
+      ],
+      "progression_role": "support",
+      "recommended_level": {
+        "min": 22,
+        "max": 34
+      },
+      "modes": {
+        "normal": true,
+        "hardcore": true,
+        "solo": true,
+        "coop": true
+      },
+      "prerequisites": {
+        "routes": [],
+        "tech": [
+          "meat-cleaver"
+        ],
+        "items": [],
+        "pals": []
+      },
+      "objectives": [
+        "Unlock the Meat Cleaver and stage capture gear for the level 23 alpha",
+        "Clear or capture the Verdant Brook Alpha Broncherry each in-game day",
+        "Butcher banked Broncherry to stockpile meat and seed drops"
+      ],
+      "estimated_time_minutes": {
+        "solo": 32,
+        "coop": 24
+      },
+      "estimated_xp_gain": {
+        "min": 420,
+        "max": 640
+      },
+      "risk_profile": "medium",
+      "failure_penalties": {
+        "normal": "Missing the alpha rotation forfeits the daily guaranteed meat bundle until the next in-game day respawn.",
+        "hardcore": "Hardcore wipes can cost your butchery kit and captured pals if PIDF patrols finish you during the hunt."
+      },
+      "adaptive_guidance": {
+        "underleveled": "If you cannot safely duel the alpha, throw Mega or Hyper Spheres to capture Broncherry at (-222,-669) and butcher it back at camp—the Meat Cleaver guarantees the same drops without a protracted fight.",
+        "overleveled": "Run a daily kill plus a spare capture so you bank four Broncherry Meat and bonus Tomato Seeds for rib roasts and salads each loop.",
+        "resource_shortages": [
+          {
+            "item_id": "broncherry_meat",
+            "solution": "Fast travel in, burst down the alpha for two guaranteed cuts, then butcher any captured spares to double the haul before logging off."
+          }
+        ],
+        "time_limited": "Alpha Broncherry respawns every in-game day; sprint in for a single clear, grab the two cuts, and reset by sleeping if you only have a few minutes.",
+        "dynamic_rules": [
+          {
+            "signal": "mode:coop",
+            "condition": "mode.coop === true",
+            "adjustment": "Assign one player to kite Broncherry while the partner nets captures and drags them home for butchery so the loop finishes before PIDF reinforcements arrive.",
+            "priority": 2,
+            "mode_scope": [
+              "coop"
+            ],
+            "related_steps": [
+              "resource-broncherry-meat:002",
+              "resource-broncherry-meat:003"
+            ]
+          }
+        ]
+      },
+      "checkpoints": [
+        {
+          "id": "resource-broncherry-meat:checkpoint-cleaver",
+          "summary": "Butchery kit unlocked",
+          "benefits": [
+            "Meat Cleaver crafted",
+            "Hotbar slot configured"
+          ],
+          "related_steps": [
+            "resource-broncherry-meat:001"
+          ]
+        },
+        {
+          "id": "resource-broncherry-meat:checkpoint-alpha",
+          "summary": "Alpha cleared",
+          "benefits": [
+            "Daily respawn on cooldown",
+            "Guaranteed cuts secured"
+          ],
+          "related_steps": [
+            "resource-broncherry-meat:002"
+          ]
+        },
+        {
+          "id": "resource-broncherry-meat:checkpoint-storage",
+          "summary": "Meat banked",
+          "benefits": [
+            "Chest restocked",
+            "Seeds catalogued"
+          ],
+          "related_steps": [
+            "resource-broncherry-meat:003"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "step_id": "resource-broncherry-meat:001",
+          "type": "prepare",
+          "summary": "Unlock Meat Cleaver and stage your kit",
+          "detail": "Spend 2 Technology Points at level 12 to unlock the Meat Cleaver, craft it at a Primitive Workbench, and keep it equipped so the Butcher command replaces Pet when you interact with captured pals.",
+          "targets": [],
+          "locations": [
+            {
+              "region_id": "palpagos-overworld",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {},
+          "recommended_loadout": {
+            "gear": [
+              "meat-cleaver"
+            ],
+            "pals": [],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 0,
+            "max": 0
+          },
+          "outputs": {
+            "items": [],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [],
+          "citations": [
+            "palwiki-meat-cleaver"
+          ]
+        },
+        {
+          "step_id": "resource-broncherry-meat:002",
+          "type": "hunt",
+          "summary": "Sweep the Alpha Broncherry ridge",
+          "detail": "Fast travel to the nearby statue network and clear or capture Broncherry at (-222,-669); the level 23 alpha drops two Broncherry Meat every run and has a 50% chance to hand over Tomato Seeds.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "broncherry_meat",
+              "qty": 2
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "palpagos-overworld",
+              "coords": [
+                -222,
+                -669
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "hardcore": {
+              "tactics": "Bring a tanky mount and disengage if PIDF patrols arrive; you can return after sleeping to reset the daily respawn.",
+              "mode_scope": [
+                "hardcore"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [
+              "hyper-sphere",
+              "mega-sphere"
+            ],
+            "pals": [
+              "anubis"
+            ],
+            "consumables": [
+              "medical-supplies"
+            ]
+          },
+          "xp_award_estimate": {
+            "min": 300,
+            "max": 420
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "broncherry_meat",
+                "qty": 2
+              }
+            ],
+            "pals": [
+              "broncherry"
+            ],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-precious-dragon-stone"
+            }
+          ],
+          "citations": [
+            "palwiki-alpha-pals",
+            "palwiki-broncherry-raw"
+          ]
+        },
+        {
+          "step_id": "resource-broncherry-meat:003",
+          "type": "base",
+          "summary": "Butcher and bank the haul",
+          "detail": "Back at base, equip the Meat Cleaver and butcher captured Broncherry to duplicate the two guaranteed meat drops and stash any Tomato Seeds for plantations before the next respawn.",
+          "targets": [
+            {
+              "kind": "item",
+              "id": "broncherry_meat",
+              "qty": 6
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "palpagos-overworld",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {},
+          "recommended_loadout": {
+            "gear": [
+              "meat-cleaver"
+            ],
+            "pals": [],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 120,
+            "max": 220
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "broncherry_meat",
+                "qty": 6
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-tomato-seeds"
+            }
+          ],
+          "citations": [
+            "palwiki-broncherry-raw",
+            "palwiki-meat-cleaver"
+          ]
+        }
+      ],
+      "completion_criteria": [
+        {
+          "type": "have-item",
+          "item_id": "broncherry_meat",
+          "qty": 10
+        }
+      ],
+      "yields": {
+        "levels_estimate": "+0 to +1",
+        "key_unlocks": []
+      },
+      "metrics": {
+        "progress_segments": 3,
+        "boss_targets": 1,
+        "quest_nodes": 0
+      },
+      "next_routes": [
+        {
+          "route_id": "resource-precious-dragon-stone",
+          "reason": "Share the alpha circuit to stack Precious Dragon Stones alongside Broncherry Meat each day."
+        },
+        {
+          "route_id": "resource-tomato-seeds",
+          "reason": "Broncherry's Tomato Seed drops feed plantations that support Rib Roast and salad dishes."
         }
       ]
     },
@@ -23861,7 +24161,7 @@
           "step_id": "resource-small-pal-soul:002",
           "type": "craft",
           "summary": "Convert medium souls at the Crusher",
-          "detail": "Load the Crusher with Medium Pal Souls before dawn\u2014each crush outputs two Small Pal Souls, letting you stretch sanctuary hauls or dungeon clears into twice the offerings needed for statue upgrades.",
+          "detail": "Load the Crusher with Medium Pal Souls before dawn—each crush outputs two Small Pal Souls, letting you stretch sanctuary hauls or dungeon clears into twice the offerings needed for statue upgrades.",
           "targets": [
             {
               "kind": "item",
@@ -24312,8 +24612,8 @@
       "quest_node_value": 320,
       "description": "Route-level metrics reflect adaptive momentum: progress segments reward checklist depth, boss clears add large boosts, and quest nodes track story completions."
     },
-    "estimation_method": "\n1. For each completed step, take the median of its XP estimate range (or the per-step range if no estimate is provided).  Sum these medians to compute the base XP.\n2. Add adaptive bonuses: progress_segments \u00d7 progress_segment_value, boss_targets \u00d7 boss_clear_value, and quest_nodes \u00d7 quest_node_value.\n3. Add +500 XP for each boss clear marked directly on a step and +10% for finishing the route deathless in Hardcore.  In Co-Op, divide XP evenly among players.\n4. Convert cumulative XP to a player level by finding the highest level where cumulative_xp \u2264 total XP in the xp_thresholds array.\n5. Compute confidence as the fraction of steps with explicit XP estimates plus 0.1 if route metrics are provided (cap at 1.0).",
-    "example": "Suppose a player completed the Starter Base route in solo normal mode.  The median XP for its steps sums to ~370 XP.  No bonuses apply.  According to the XP table, 370 XP corresponds to level\u00a05.  Because all steps have explicit XP estimates, the confidence score is 1.0."
+    "estimation_method": "\n1. For each completed step, take the median of its XP estimate range (or the per-step range if no estimate is provided).  Sum these medians to compute the base XP.\n2. Add adaptive bonuses: progress_segments × progress_segment_value, boss_targets × boss_clear_value, and quest_nodes × quest_node_value.\n3. Add +500 XP for each boss clear marked directly on a step and +10% for finishing the route deathless in Hardcore.  In Co-Op, divide XP evenly among players.\n4. Convert cumulative XP to a player level by finding the highest level where cumulative_xp ≤ total XP in the xp_thresholds array.\n5. Compute confidence as the fraction of steps with explicit XP estimates plus 0.1 if route metrics are provided (cap at 1.0).",
+    "example": "Suppose a player completed the Starter Base route in solo normal mode.  The median XP for its steps sums to ~370 XP.  No bonuses apply.  According to the XP table, 370 XP corresponds to level 5.  Because all steps have explicit XP estimates, the confidence score is 1.0."
   },
   "recommender": {
     "input_context_shape": {
@@ -24370,7 +24670,7 @@
       "Filter out routes with unmet prerequisites or missing adaptive_guidance entries for requested goals",
       "Boost support routes when resource_gaps overlap with their outputs",
       "Prefer routes whose metrics meet or exceed normalization targets when available_time_minutes is low",
-      "Award dynamic_alignment when player context satisfies a route\u2019s adaptive_guidance.dynamic_rules"
+      "Award dynamic_alignment when player context satisfies a route’s adaptive_guidance.dynamic_rules"
     ],
     "tie_breakers": [
       "lowest_consumable_cost",
@@ -24397,7 +24697,7 @@
   },
   "guideCatalog": {
     "path": "data/guide_catalog.json",
-    "guide_count": 198,
+    "guide_count": 199,
     "fields": [
       "id",
       "title",
@@ -24431,9 +24731,9 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "**Locate a Great Eagle Statue** in the region you\u2019re exploring.  These large statues emit a faint glow.",
+              "instruction": "**Locate a Great Eagle Statue** in the region you’re exploring.  These large statues emit a faint glow.",
               "citations": [
-                "354485449518951\u2020L124-L131"
+                "354485449518951†L124-L131"
               ]
             },
             {
@@ -24465,7 +24765,7 @@
               "order": 1,
               "instruction": "Explore the starting area and **collect fallen branches or strike trees** to gather wood.",
               "citations": [
-                "354485449518951\u2020L166-L169"
+                "354485449518951†L166-L169"
               ]
             },
             {
@@ -24502,7 +24802,7 @@
               "order": 2,
               "instruction": "**Place the workbench** near your Palbox or base location.",
               "citations": [
-                "354485449518951\u2020L188-L191"
+                "354485449518951†L188-L191"
               ]
             },
             {
@@ -24528,7 +24828,7 @@
               "order": 1,
               "instruction": "**Earn technology points** by leveling up, completing missions and meeting any level requirements.",
               "citations": [
-                "354485449518951\u2020L207-L209"
+                "354485449518951†L207-L209"
               ]
             },
             {
@@ -24560,7 +24860,7 @@
               "order": 1,
               "instruction": "Unlock the **Capturing Device (Pal Sphere) blueprint** in the tech tree if you have not already.",
               "citations": [
-                "354485449518951\u2020L225-L231"
+                "354485449518951†L225-L231"
               ]
             },
             {
@@ -24572,7 +24872,7 @@
               "order": 3,
               "instruction": "At a workbench, **combine Paldium fragments with wood and stone** to craft Pal Spheres; stockpile extras for captures.",
               "citations": [
-                "354485449518951\u2020L224-L252"
+                "354485449518951†L224-L252"
               ]
             }
           ]
@@ -24598,7 +24898,7 @@
               "order": 2,
               "instruction": "**Weaken a wild Pal** by reducing its HP with non-fatal attacks.",
               "citations": [
-                "354485449518951\u2020L272-L274"
+                "354485449518951†L272-L274"
               ]
             },
             {
@@ -24630,7 +24930,7 @@
               "order": 2,
               "instruction": "**Unlock the Palbox technology** in the tech tree and gather Paldium fragments, wood and stone.",
               "citations": [
-                "354485449518951\u2020L310-L314"
+                "354485449518951†L310-L314"
               ]
             },
             {
@@ -24640,7 +24940,7 @@
             },
             {
               "order": 4,
-              "instruction": "Immediately **build core stations**\u2014Primitive Workbench, campfire, storage chest and a bed\u2014for crafting, cooking and rest.",
+              "instruction": "Immediately **build core stations**—Primitive Workbench, campfire, storage chest and a bed—for crafting, cooking and rest.",
               "citations": []
             },
             {
@@ -24667,7 +24967,7 @@
               "order": 1,
               "instruction": "**Open the Palbox management menu** at your base to view available workers.",
               "citations": [
-                "354485449518951\u2020L329-L332"
+                "354485449518951†L329-L332"
               ]
             },
             {
@@ -24709,7 +25009,7 @@
               "order": 2,
               "instruction": "**Harvest berries** by pressing the interact key.",
               "citations": [
-                "354485449518951\u2020L347-L349"
+                "354485449518951†L347-L349"
               ]
             },
             {
@@ -24741,7 +25041,7 @@
               "order": 2,
               "instruction": "**Collect materials** such as fiber, wool and leather from Pals or plants.",
               "citations": [
-                "354485449518951\u2020L367-L370"
+                "354485449518951†L367-L370"
               ]
             },
             {
@@ -24772,7 +25072,7 @@
               "order": 2,
               "instruction": "When you level up, open your **inventory/stats screen**.",
               "citations": [
-                "354485449518951\u2020L382-L386"
+                "354485449518951†L382-L386"
               ]
             },
             {
@@ -24804,7 +25104,7 @@
               "order": 2,
               "instruction": "**Wear weather-appropriate armor** to avoid cold or heat damage.",
               "citations": [
-                "354485449518951\u2020L367-L370"
+                "354485449518951†L367-L370"
               ]
             },
             {
@@ -24838,7 +25138,7 @@
             },
             {
               "order": 3,
-              "instruction": "Use your Pal\u2019s partner skill and **swap Pals** to exploit elemental weaknesses.",
+              "instruction": "Use your Pal’s partner skill and **swap Pals** to exploit elemental weaknesses.",
               "citations": []
             }
           ]
@@ -24859,7 +25159,7 @@
               "order": 1,
               "instruction": "Travel to coordinates **(264, -548)** on the southern coast.",
               "citations": [
-                "633260338298658\u2020L112-L118"
+                "633260338298658†L112-L118"
               ]
             },
             {
@@ -24890,7 +25190,7 @@
               "order": 1,
               "instruction": "Fast-travel to **Small Settlement** coordinates (8, -528).",
               "citations": [
-                "633260338298658\u2020L120-L126"
+                "633260338298658†L120-L126"
               ]
             },
             {
@@ -24921,7 +25221,7 @@
               "order": 1,
               "instruction": "Journey to **-77, -310** and head south into Cinnamoth Forest.",
               "citations": [
-                "633260338298658\u2020L128-L134"
+                "633260338298658†L128-L134"
               ]
             },
             {
@@ -24952,7 +25252,7 @@
               "order": 1,
               "instruction": "Travel to **180, -39**.",
               "citations": [
-                "633260338298658\u2020L136-L141"
+                "633260338298658†L136-L141"
               ]
             },
             {
@@ -24983,7 +25283,7 @@
               "order": 1,
               "instruction": "Reach **-646, 270** on Sakurajima Island.",
               "citations": [
-                "633260338298658\u2020L143-L149"
+                "633260338298658†L143-L149"
               ]
             },
             {
@@ -25101,7 +25401,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Monitor each Pal\u2019s **SAN meter**; high workloads reduce morale.",
+              "instruction": "Monitor each Pal’s **SAN meter**; high workloads reduce morale.",
               "citations": []
             },
             {
@@ -25133,7 +25433,7 @@
               "order": 1,
               "instruction": "Capture Pals with **Transporting** or **Kindling** suitability (e.g., Wumpo, Jormuntide Ignis).",
               "citations": [
-                "633260338298658\u2020L161-L166"
+                "633260338298658†L161-L166"
               ]
             },
             {
@@ -25164,7 +25464,7 @@
               "order": 1,
               "instruction": "Obtain Pals like **Anubis** or **Astegon** for handiwork/mining.",
               "citations": [
-                "633260338298658\u2020L166-L172"
+                "633260338298658†L166-L172"
               ]
             },
             {
@@ -25195,7 +25495,7 @@
               "order": 1,
               "instruction": "Capture Pals such as **Jormuntide**, **Broncherry Aqua** or **Wumpo Botan** for watering or lumbering.",
               "citations": [
-                "633260338298658\u2020L161-L169"
+                "633260338298658†L161-L169"
               ]
             },
             {
@@ -25226,7 +25526,7 @@
               "order": 1,
               "instruction": "Use Pals with **Medicine Production** or **Planting** suitability (e.g., **Bellanoir**, **Lyleen**).",
               "citations": [
-                "633260338298658\u2020L174-L177"
+                "633260338298658†L174-L177"
               ]
             },
             {
@@ -25442,7 +25742,7 @@
               "order": 3,
               "instruction": "Travel to coal-rich regions (e.g., Sealed Realm) and mine coal for advanced tech.",
               "citations": [
-                "633260338298658\u2020L136-L141"
+                "633260338298658†L136-L141"
               ]
             }
           ]
@@ -25463,7 +25763,7 @@
               "order": 1,
               "instruction": "Find sulfur deposits near volcanoes or **Cinnamoth Forest**.",
               "citations": [
-                "633260338298658\u2020L128-L134"
+                "633260338298658†L128-L134"
               ]
             },
             {
@@ -25494,7 +25794,7 @@
               "order": 1,
               "instruction": "Travel to **Sakurajima Island** to find crude oil nodes.",
               "citations": [
-                "633260338298658\u2020L143-L149"
+                "633260338298658†L143-L149"
               ]
             },
             {
@@ -25554,7 +25854,7 @@
               "order": 1,
               "instruction": "Search near water for glowing blue rocks (Paldium).",
               "citations": [
-                "354485449518951\u2020L225-L231"
+                "354485449518951†L225-L231"
               ]
             },
             {
@@ -25586,7 +25886,7 @@
               "order": 1,
               "instruction": "Hunt fluffy Pals (e.g., Lamball) for **wool and leather**.",
               "citations": [
-                "354485449518951\u2020L367-L370"
+                "354485449518951†L367-L370"
               ]
             },
             {
@@ -25733,7 +26033,7 @@
               "order": 1,
               "instruction": "Visit desert regions at night when **Nightstar Sand** glows.",
               "citations": [
-                "92541297987896\u2020L117-L118"
+                "92541297987896†L117-L118"
               ]
             },
             {
@@ -26003,7 +26303,7 @@
               "order": 2,
               "instruction": "Gather Pal Metal Ingots, Paldium Fragments and Nails.",
               "citations": [
-                "285876925291367\u2020L189-L203"
+                "285876925291367†L189-L203"
               ]
             },
             {
@@ -26244,7 +26544,7 @@
               "order": 3,
               "instruction": "Build the incubator and place eggs inside to cut hatching time in half.",
               "citations": [
-                "612653128208765\u2020L79-L83"
+                "612653128208765†L79-L83"
               ]
             }
           ]
@@ -26381,7 +26681,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Learn each Pal\u2019s **element type** (Fire, Water, Grass, Electric, etc.).",
+              "instruction": "Learn each Pal’s **element type** (Fire, Water, Grass, Electric, etc.).",
               "citations": []
             },
             {
@@ -26508,7 +26808,7 @@
             },
             {
               "order": 3,
-              "instruction": "Focus on Grizzbolt\u2019s weak points, dodge its attacks and use Water-type moves to win.",
+              "instruction": "Focus on Grizzbolt’s weak points, dodge its attacks and use Water-type moves to win.",
               "citations": []
             }
           ]
@@ -26538,7 +26838,7 @@
             },
             {
               "order": 3,
-              "instruction": "Burn down Lyleen\u2019s plant-type minions and stagger the boss to defeat it.",
+              "instruction": "Burn down Lyleen’s plant-type minions and stagger the boss to defeat it.",
               "citations": []
             }
           ]
@@ -26558,17 +26858,17 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Capture Ice or Grass Pals to counter Orserk\u2019s Dragon/Electric typing.",
+              "instruction": "Capture Ice or Grass Pals to counter Orserk’s Dragon/Electric typing.",
               "citations": []
             },
             {
               "order": 2,
-              "instruction": "Dodge Axel\u2019s long-range attacks and close the distance quickly.",
+              "instruction": "Dodge Axel’s long-range attacks and close the distance quickly.",
               "citations": []
             },
             {
               "order": 3,
-              "instruction": "Focus your Pals\u2019 partner skills and heal frequently.",
+              "instruction": "Focus your Pals’ partner skills and heal frequently.",
               "citations": []
             }
           ]
@@ -26593,7 +26893,7 @@
             },
             {
               "order": 2,
-              "instruction": "Avoid Victor\u2019s high-damage projectiles and stay mobile.",
+              "instruction": "Avoid Victor’s high-damage projectiles and stay mobile.",
               "citations": []
             },
             {
@@ -26652,12 +26952,12 @@
             },
             {
               "order": 2,
-              "instruction": "Break Bellanoir\u2019s shields by focusing your attacks.",
+              "instruction": "Break Bellanoir’s shields by focusing your attacks.",
               "citations": []
             },
             {
               "order": 3,
-              "instruction": "Avoid the Libero variant\u2019s rapid strikes and maintain healing.",
+              "instruction": "Avoid the Libero variant’s rapid strikes and maintain healing.",
               "citations": []
             }
           ]
@@ -26682,7 +26982,7 @@
             },
             {
               "order": 2,
-              "instruction": "Dodge Bjorn\u2019s area attacks; avoid standing in burning pools.",
+              "instruction": "Dodge Bjorn’s area attacks; avoid standing in burning pools.",
               "citations": []
             },
             {
@@ -26740,7 +27040,7 @@
             },
             {
               "order": 2,
-              "instruction": "Target the Moon Lord\u2019s hands and core; destroy each part in sequence.",
+              "instruction": "Target the Moon Lord’s hands and core; destroy each part in sequence.",
               "citations": []
             },
             {
@@ -26854,7 +27154,7 @@
               "order": 1,
               "instruction": "Refer to the Best Pals Tier List; top combat Pals include **Jormuntide Ignis**, **Jetragon** and **Frostallion**.",
               "citations": [
-                "213589709604736\u2020L156-L160"
+                "213589709604736†L156-L160"
               ]
             },
             {
@@ -27033,7 +27333,7 @@
             },
             {
               "order": 2,
-              "instruction": "Reduce the Pal\u2019s health without defeating it.",
+              "instruction": "Reduce the Pal’s health without defeating it.",
               "citations": []
             },
             {
@@ -27173,7 +27473,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Consult the interactive map or Palpedia for each Pal\u2019s coordinates.",
+              "instruction": "Consult the interactive map or Palpedia for each Pal’s coordinates.",
               "citations": []
             },
             {
@@ -27232,7 +27532,7 @@
               "order": 1,
               "instruction": "Identify Pals with **Transporting** or **Kindling** work suitability.",
               "citations": [
-                "633260338298658\u2020L161-L166"
+                "633260338298658†L161-L166"
               ]
             },
             {
@@ -27263,7 +27563,7 @@
               "order": 1,
               "instruction": "Capture Pals like **Anubis** or **Lunaris** that excel at handiwork.",
               "citations": [
-                "633260338298658\u2020L166-L167"
+                "633260338298658†L166-L167"
               ]
             },
             {
@@ -27294,7 +27594,7 @@
               "order": 1,
               "instruction": "Capture Pals such as **Blazamut**, **Astegon** or **Reptyro**.",
               "citations": [
-                "633260338298658\u2020L170-L172"
+                "633260338298658†L170-L172"
               ]
             },
             {
@@ -27325,7 +27625,7 @@
               "order": 1,
               "instruction": "Acquire Pals with **Planting** suitability (e.g., **Lyleen**).",
               "citations": [
-                "633260338298658\u2020L174-L177"
+                "633260338298658†L174-L177"
               ]
             },
             {
@@ -27356,7 +27656,7 @@
               "order": 1,
               "instruction": "Capture **Frostallion**, **Cryolinx** or **Reptyro Cyst** for cooling duties.",
               "citations": [
-                "633260338298658\u2020L178-L179"
+                "633260338298658†L178-L179"
               ]
             },
             {
@@ -27387,7 +27687,7 @@
               "order": 1,
               "instruction": "Capture **Orserk**, **Relaxaurus Lux** or **Grizzbolt**.",
               "citations": [
-                "633260338298658\u2020L168-L169"
+                "633260338298658†L168-L169"
               ]
             },
             {
@@ -27450,7 +27750,7 @@
             },
             {
               "order": 2,
-              "instruction": "**Partner skills** are triggered when Pals accompany you in the overworld (e.g., Jetragon\u2019s fast flight).",
+              "instruction": "**Partner skills** are triggered when Pals accompany you in the overworld (e.g., Jetragon’s fast flight).",
               "citations": []
             },
             {
@@ -27503,7 +27803,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Monitor each Pal\u2019s SAN bar; low SAN results in reduced efficiency or refusal to work.",
+              "instruction": "Monitor each Pal’s SAN bar; low SAN results in reduced efficiency or refusal to work.",
               "citations": []
             },
             {
@@ -27537,12 +27837,12 @@
             },
             {
               "order": 2,
-              "instruction": "Access your Pal\u2019s **appearance menu** via the Palbox or inventory.",
+              "instruction": "Access your Pal’s **appearance menu** via the Palbox or inventory.",
               "citations": []
             },
             {
               "order": 3,
-              "instruction": "Apply the skin to change your Pal\u2019s appearance.",
+              "instruction": "Apply the skin to change your Pal’s appearance.",
               "citations": []
             }
           ]
@@ -27629,7 +27929,7 @@
             },
             {
               "order": 3,
-              "instruction": "While Palworld does not have Pok\u00e9mon-style evolutions, some Pals have **subspecies** accessible via breeding.",
+              "instruction": "While Palworld does not have Pokémon-style evolutions, some Pals have **subspecies** accessible via breeding.",
               "citations": []
             }
           ]
@@ -27708,7 +28008,7 @@
               "order": 1,
               "instruction": "Reach **technology level 19** and unlock the Breeding Farm.",
               "citations": [
-                "612653128208765\u2020L51-L55"
+                "612653128208765†L51-L55"
               ]
             },
             {
@@ -27739,7 +28039,7 @@
               "order": 1,
               "instruction": "Gather **flour, berries, milk, eggs and honey**.",
               "citations": [
-                "612653128208765\u2020L53-L55"
+                "612653128208765†L53-L55"
               ]
             },
             {
@@ -27749,7 +28049,7 @@
             },
             {
               "order": 3,
-              "instruction": "Place cake in the Breeding Farm\u2019s inventory to encourage Pals to mate.",
+              "instruction": "Place cake in the Breeding Farm’s inventory to encourage Pals to mate.",
               "citations": []
             }
           ]
@@ -27770,7 +28070,7 @@
               "order": 1,
               "instruction": "Place one **male** and one **female** Pal in the Breeding Farm.",
               "citations": [
-                "612653128208765\u2020L53-L55"
+                "612653128208765†L53-L55"
               ]
             },
             {
@@ -27782,7 +28082,7 @@
               "order": 3,
               "instruction": "Eggs inherit the average breeding power of the parents.",
               "citations": [
-                "612653128208765\u2020L56-L58"
+                "612653128208765†L56-L58"
               ]
             }
           ]
@@ -27830,9 +28130,9 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Use recommended combinations like **Relaxaurus + Sparkit \u2192 Relaxaurus Lux** or **Lyleen + Menasting \u2192 Lyleen Noct**.",
+              "instruction": "Use recommended combinations like **Relaxaurus + Sparkit → Relaxaurus Lux** or **Lyleen + Menasting → Lyleen Noct**.",
               "citations": [
-                "612653128208765\u2020L64-L77"
+                "612653128208765†L64-L77"
               ]
             },
             {
@@ -27863,21 +28163,21 @@
               "order": 1,
               "instruction": "Combine **Penking + Bushi** to produce **Anubis** for early DPS.",
               "citations": [
-                "612653128208765\u2020L87-L100"
+                "612653128208765†L87-L100"
               ]
             },
             {
               "order": 2,
               "instruction": "Use **Rushoar + Surfent** or **Swee + Sweepa** to get **Digtoise**.",
               "citations": [
-                "612653128208765\u2020L87-L105"
+                "612653128208765†L87-L105"
               ]
             },
             {
               "order": 3,
               "instruction": "Breed **Nitewing + Cinnamoth** to obtain **Sibelyx**.",
               "citations": [
-                "612653128208765\u2020L87-L111"
+                "612653128208765†L87-L111"
               ]
             }
           ]
@@ -27898,14 +28198,14 @@
               "order": 1,
               "instruction": "Breed **Penking + Penking** for Penking with the **Artisan** passive.",
               "citations": [
-                "612653128208765\u2020L120-L124"
+                "612653128208765†L120-L124"
               ]
             },
             {
               "order": 2,
               "instruction": "Breed **Penking + Wumpo Botan** for random work passives.",
               "citations": [
-                "612653128208765\u2020L120-L127"
+                "612653128208765†L120-L127"
               ]
             },
             {
@@ -27931,21 +28231,21 @@
               "order": 1,
               "instruction": "Breed **Relaxaurus + Sparkit** for **Relaxaurus Lux**.",
               "citations": [
-                "612653128208765\u2020L132-L134"
+                "612653128208765†L132-L134"
               ]
             },
             {
               "order": 2,
               "instruction": "Breed **Incineram + Maraith** for **Incineram Noct**.",
               "citations": [
-                "612653128208765\u2020L132-L135"
+                "612653128208765†L132-L135"
               ]
             },
             {
               "order": 3,
               "instruction": "Breed **Frostallion + Anubis** for **Bastigor**.",
               "citations": [
-                "612653128208765\u2020L132-L136"
+                "612653128208765†L132-L136"
               ]
             }
           ]
@@ -27966,21 +28266,21 @@
               "order": 1,
               "instruction": "Combine **Lamball + Fielfox** to create **Digtoise Terra**.",
               "citations": [
-                "612653128208765\u2020L141-L144"
+                "612653128208765†L141-L144"
               ]
             },
             {
               "order": 2,
               "instruction": "Breed **Mammorest + Wumpo** for **Mammorest Cryst**.",
               "citations": [
-                "612653128208765\u2020L141-L145"
+                "612653128208765†L141-L145"
               ]
             },
             {
               "order": 3,
               "instruction": "Pair **Lyleen + Menasting** for **Lyleen Noct** as a healer-tank hybrid.",
               "citations": [
-                "612653128208765\u2020L141-L146"
+                "612653128208765†L141-L146"
               ]
             }
           ]
@@ -28001,21 +28301,21 @@
               "order": 1,
               "instruction": "Breed **Elphidran + Surfent Aqua** for **Elphidran Aqua** (flying water mount).",
               "citations": [
-                "612653128208765\u2020L149-L154"
+                "612653128208765†L149-L154"
               ]
             },
             {
               "order": 2,
               "instruction": "Pair **Eikthyrdeer + Hangyu** for **Eikthyrdeer Terra**.",
               "citations": [
-                "612653128208765\u2020L151-L154"
+                "612653128208765†L151-L154"
               ]
             },
             {
               "order": 3,
               "instruction": "Combine **Surfent + Dumud** for **Surfent Terra**.",
               "citations": [
-                "612653128208765\u2020L149-L154"
+                "612653128208765†L149-L154"
               ]
             }
           ]
@@ -28036,21 +28336,21 @@
               "order": 1,
               "instruction": "Breed **Lyleen + Menasting** again for **Lyleen Noct** (healer/support).",
               "citations": [
-                "612653128208765\u2020L160-L166"
+                "612653128208765†L160-L166"
               ]
             },
             {
               "order": 2,
               "instruction": "Pair **Mau + Pengullet** for **Mau Cryst** (budget healer).",
               "citations": [
-                "612653128208765\u2020L160-L166"
+                "612653128208765†L160-L166"
               ]
             },
             {
               "order": 3,
               "instruction": "Breed **Dinossom + Rayhound** for **Dinossom Lux** (speed buff support).",
               "citations": [
-                "612653128208765\u2020L160-L166"
+                "612653128208765†L160-L166"
               ]
             }
           ]
@@ -28076,7 +28376,7 @@
               "order": 2,
               "instruction": "Place them in a standard incubator or **Electric Incubator** to reduce hatching time.",
               "citations": [
-                "612653128208765\u2020L79-L83"
+                "612653128208765†L79-L83"
               ]
             },
             {
@@ -28102,7 +28402,7 @@
               "order": 1,
               "instruction": "Breed high-level Pals; there is about a **5 % chance** to produce a Huge/Alpha Egg.",
               "citations": [
-                "612653128208765\u2020L60-L62"
+                "612653128208765†L60-L62"
               ]
             },
             {
@@ -28162,7 +28462,7 @@
               "order": 1,
               "instruction": "Understand that 40 % of offspring get one passive, 30 % get two, 20 % get three and 10 % get four.",
               "citations": [
-                "612653128208765\u2020L56-L59"
+                "612653128208765†L56-L59"
               ]
             },
             {
@@ -28191,9 +28491,9 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Use **Electric Incubators** to reduce wait time by 1.5\u00d7.",
+              "instruction": "Use **Electric Incubators** to reduce wait time by 1.5×.",
               "citations": [
-                "612653128208765\u2020L79-L83"
+                "612653128208765†L79-L83"
               ]
             },
             {
@@ -28638,7 +28938,7 @@
             },
             {
               "order": 3,
-              "instruction": "Adjust your base\u2019s position or use Pals to mitigate weather effects.",
+              "instruction": "Adjust your base’s position or use Pals to mitigate weather effects.",
               "citations": []
             }
           ]
@@ -28784,7 +29084,7 @@
             },
             {
               "order": 3,
-              "instruction": "Read entries in your log to learn more about Palworld\u2019s story.",
+              "instruction": "Read entries in your log to learn more about Palworld’s story.",
               "citations": []
             }
           ]
@@ -28795,7 +29095,7 @@
           "source_heading": "Tides of Terraria Content Overview",
           "category": "Update",
           "category_group": "Special Updates & Events",
-          "trigger": "Player asks what\u2019s included in the Terraria collaboration",
+          "trigger": "Player asks what’s included in the Terraria collaboration",
           "keywords": [
             "Terraria update",
             "new island"
@@ -28977,7 +29277,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Travel to the oil rig\u2019s coordinates.",
+              "instruction": "Travel to the oil rig’s coordinates.",
               "citations": []
             },
             {
@@ -29095,7 +29395,7 @@
               "order": 1,
               "instruction": "Read the patch notes to understand new features: PVP arena, Lockpicking Tool v3, dog coins and more.",
               "citations": [
-                "285876925291367\u2020L181-L184"
+                "285876925291367†L181-L184"
               ]
             },
             {
@@ -29126,7 +29426,7 @@
               "order": 1,
               "instruction": "Travel to the PVP arena on Sakurajima island.",
               "citations": [
-                "675291985780246\u2020L470-L474"
+                "675291985780246†L470-L474"
               ]
             },
             {
@@ -29513,7 +29813,7 @@
             },
             {
               "order": 3,
-              "instruction": "Join each other\u2019s games by inputting the provided codes.",
+              "instruction": "Join each other’s games by inputting the provided codes.",
               "citations": []
             }
           ]
@@ -29542,7 +29842,7 @@
             },
             {
               "order": 3,
-              "instruction": "Respect other players\u2019 privacy and follow community guidelines.",
+              "instruction": "Respect other players’ privacy and follow community guidelines.",
               "citations": []
             }
           ]
@@ -29593,7 +29893,7 @@
               "order": 1,
               "instruction": "Work Speed influences how quickly a Pal completes assigned tasks.",
               "citations": [
-                "633260338298658\u2020L160-L170"
+                "633260338298658†L160-L170"
               ]
             },
             {
@@ -29614,7 +29914,7 @@
           "source_heading": "Stamina & Weight Systems",
           "category": "Mechanics",
           "category_group": "Stats & Mechanics",
-          "trigger": "Player asks why they can\u2019t run or carry more",
+          "trigger": "Player asks why they can’t run or carry more",
           "keywords": [
             "stamina",
             "weight"
@@ -29807,7 +30107,7 @@
             },
             {
               "order": 3,
-              "instruction": "Equip gear that reduces damage from the enemy\u2019s dominant element.",
+              "instruction": "Equip gear that reduces damage from the enemy’s dominant element.",
               "citations": []
             }
           ]
@@ -30116,7 +30416,7 @@
           "steps": [
             {
               "order": 1,
-              "instruction": "Check the game\u2019s terms of service to ensure modding is allowed.",
+              "instruction": "Check the game’s terms of service to ensure modding is allowed.",
               "citations": []
             },
             {
@@ -30271,7 +30571,7 @@
             },
             {
               "order": 3,
-              "instruction": "Monitor younger players\u2019 interactions and ensure they play in safe environments.",
+              "instruction": "Monitor younger players’ interactions and ensure they play in safe environments.",
               "citations": []
             }
           ]
@@ -30293,22 +30593,22 @@
               "order": 1,
               "instruction": "Farm Flambelle near the Mossanda Forest lava ravine for guaranteed oil drops.",
               "citations": [
-                "9cc14d\u2020L17-L21",
-                "c3b8c9\u2020L23-L37"
+                "9cc14d†L17-L21",
+                "c3b8c9†L23-L37"
               ]
             },
             {
               "order": 2,
               "instruction": "Buy extra oil from the Small Settlement wandering merchant when available.",
               "citations": [
-                "9cc14d\u2020L19-L24"
+                "9cc14d†L19-L24"
               ]
             },
             {
               "order": 3,
               "instruction": "Assign Dumud to a ranch to produce oil passively.",
               "citations": [
-                "9e983e\u2020L1-L26"
+                "9e983e†L1-L26"
               ]
             }
           ]
@@ -30338,7 +30638,7 @@
             },
             {
               "order": 2,
-              "instruction": "Raid **Sakurajima Sootseer camps at night**\u2014each kill guarantees Medium Pal Souls plus Bones and Crude Oil for statue stockpiles.",
+              "instruction": "Raid **Sakurajima Sootseer camps at night**—each kill guarantees Medium Pal Souls plus Bones and Crude Oil for statue stockpiles.",
               "citations": [
                 "palwiki-sootseer"
               ]
@@ -30351,6 +30651,86 @@
                 "palwiki-medium-pal-soul-raw",
                 "palfandom-medium-pal-soul-raw",
                 "palwiki-crusher-pal-soul-conversion"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-broncherry-meat",
+          "title": "Broncherry Meat Caravan Loop",
+          "source_heading": "Broncherry Meat Caravan Loop",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player needs Broncherry Meat for high-tier dishes and lacks a repeatable drop loop.",
+          "keywords": [
+            "broncherry meat",
+            "alpha pal",
+            "meat cleaver",
+            "tomato seeds"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Unlock the Meat Cleaver at level 12 for 2 Tech Points and craft it so you can butcher captured pals back at base.",
+              "citations": [
+                "palwiki-meat-cleaver"
+              ],
+              "links": [
+                {
+                  "type": "item",
+                  "id": "meat-cleaver",
+                  "name": "Meat Cleaver"
+                },
+                {
+                  "type": "structure",
+                  "id": "primitive-workbench",
+                  "name": "Primitive Workbench"
+                }
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Clear or capture the level 23 Alpha Broncherry at (-222,-669) each in-game day for guaranteed meat drops.",
+              "citations": [
+                "palwiki-alpha-pals",
+                "palwiki-broncherry-raw"
+              ],
+              "links": [
+                {
+                  "type": "pal",
+                  "id": "broncherry",
+                  "slug": "broncherry",
+                  "name": "Broncherry"
+                },
+                {
+                  "type": "location",
+                  "id": "broncherry-alpha",
+                  "name": "Broncherry Alpha Ridge",
+                  "region": "Palpagos Overworld"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Butcher spare captures at camp to double the Broncherry Meat haul and stash any Tomato Seeds for plantations.",
+              "citations": [
+                "palwiki-broncherry-raw",
+                "palwiki-meat-cleaver"
+              ],
+              "links": [
+                {
+                  "type": "item",
+                  "id": "broncherry_meat",
+                  "slug": "broncherry-meat",
+                  "name": "Broncherry Meat"
+                },
+                {
+                  "type": "item",
+                  "id": "tomato_seeds",
+                  "slug": "tomato-seeds",
+                  "name": "Tomato Seeds"
+                }
               ]
             }
           ]
@@ -30401,7 +30781,7 @@
           "resistances": [
             "neutral"
           ],
-          "breeding_notes": "Combines with Lifmunk to produce Vixy\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Combines with Lifmunk to produce Vixy【506019502892519†screenshot】."
         },
         {
           "id": "cattiva",
@@ -30435,7 +30815,7 @@
           "resistances": [
             "neutral"
           ],
-          "breeding_notes": "Combines with Mau\u00a0Cryst to produce Vixy\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Combines with Mau Cryst to produce Vixy【506019502892519†screenshot】."
         },
         {
           "id": "chikipi",
@@ -30476,7 +30856,7 @@
           "resistances": [
             "neutral"
           ],
-          "breeding_notes": "Combines with Foxparks to produce Vixy\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Combines with Foxparks to produce Vixy【506019502892519†screenshot】."
         },
         {
           "id": "lifmunk",
@@ -30517,7 +30897,7 @@
           "resistances": [
             "water"
           ],
-          "breeding_notes": "Combines with Lamball to produce Vixy\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Combines with Lamball to produce Vixy【506019502892519†screenshot】."
         },
         {
           "id": "foxparks",
@@ -30543,7 +30923,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Huggy Fire \u2013 can be equipped to the player to act as a flamethrower\u3010513843636763139\u2020L117-L170\u3011.",
+          "partner_skill": "Huggy Fire – can be equipped to the player to act as a flamethrower【513843636763139†L117-L170】.",
           "work_suitability": [
             {
               "type": "kindling",
@@ -30563,7 +30943,7 @@
           "resistances": [
             "fire"
           ],
-          "breeding_notes": "Combines with Chikipi to produce Vixy\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Combines with Chikipi to produce Vixy【506019502892519†screenshot】."
         },
         {
           "id": "fuack",
@@ -30584,7 +30964,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Watering \u2013 assists with watering crops.",
+          "partner_skill": "Watering – assists with watering crops.",
           "work_suitability": [
             {
               "type": "watering",
@@ -30625,7 +31005,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Rush Attack \u2013 charges at enemies when commanded.",
+          "partner_skill": "Rush Attack – charges at enemies when commanded.",
           "work_suitability": [
             {
               "type": "mining",
@@ -30670,7 +31050,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Dig Here! \u2013 produces items when assigned to a Ranch\u3010761280216223901\u2020screenshot\u3011.",
+          "partner_skill": "Dig Here! – produces items when assigned to a Ranch【761280216223901†screenshot】.",
           "work_suitability": [
             {
               "type": "gathering",
@@ -30694,7 +31074,7 @@
           "resistances": [
             "neutral"
           ],
-          "breeding_notes": "Can be bred by combining Lamball with Lifmunk, Lamball with Hangyu\u00a0Cryst, Cattiva with Mau\u00a0Cryst, Chikipi with Foxparks, Sparkit with Teafant, Teafant with Flambelle, or Cremis with Mau\u00a0Cryst\u3010506019502892519\u2020screenshot\u3011."
+          "breeding_notes": "Can be bred by combining Lamball with Lifmunk, Lamball with Hangyu Cryst, Cattiva with Mau Cryst, Chikipi with Foxparks, Sparkit with Teafant, Teafant with Flambelle, or Cremis with Mau Cryst【506019502892519†screenshot】."
         },
         {
           "id": "melpaca",
@@ -30715,7 +31095,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Mount \u2013 allows player to ride slowly and carry items.",
+          "partner_skill": "Mount – allows player to ride slowly and carry items.",
           "work_suitability": [
             {
               "type": "transporting",
@@ -30766,7 +31146,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Guardian of the Forest \u2013 can be ridden, enables a double jump and increases tree\u2011cutting efficiency\u3010142053078936299\u2020L123-L142\u3011.",
+          "partner_skill": "Guardian of the Forest – can be ridden, enables a double jump and increases tree‑cutting efficiency【142053078936299†L123-L142】.",
           "work_suitability": [
             {
               "type": "logging",
@@ -30807,7 +31187,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Mount \u2013 allows the player to ride quickly.",
+          "partner_skill": "Mount – allows the player to ride quickly.",
           "work_suitability": [
             {
               "type": "transporting",
@@ -30848,7 +31228,7 @@
               "drop_rate": 1.0
             }
           ],
-          "partner_skill": "Travel Companion \u2013 can be ridden to fly at high speed\u3010468454281657786\u2020screenshot\u3011.",
+          "partner_skill": "Travel Companion – can be ridden to fly at high speed【468454281657786†screenshot】.",
           "work_suitability": [
             {
               "type": "transporting",
@@ -31442,7 +31822,7 @@
           "level_hint_min": 1,
           "level_hint_max": 15,
           "climate": "temperate",
-          "hazards": "low\u2011level Pals",
+          "hazards": "low‑level Pals",
           "coordinates_bbox": [
             -500,
             -600,
@@ -31493,7 +31873,7 @@
           "level_hint_min": 20,
           "level_hint_max": 30,
           "climate": "lush valley",
-          "hazards": "mid\u2011level predators",
+          "hazards": "mid‑level predators",
           "coordinates_bbox": [
             -300,
             200,
@@ -31915,383 +32295,383 @@
               "alt_parent_pal_id": "mau-cryst"
             }
           ],
-          "notes": "Each pair produces a Vixy egg when bred at the breeding station\u3010506019502892519\u2020screenshot\u3011."
+          "notes": "Each pair produces a Vixy egg when bred at the breeding station【506019502892519†screenshot】."
         }
       ]
     },
     {
       "sources": {
         "paldb-primitive-workbench": {
-          "title": "Primitive Workbench \u2013 PalDB",
+          "title": "Primitive Workbench – PalDB",
           "url": "https://paldb.cc/station/primitive-workbench",
           "access_date": "2025-09-30",
-          "notes": "Shows that the Primitive Workbench requires 2 Wood to build\u3010907636800064548\u2020screenshot\u3011."
+          "notes": "Shows that the Primitive Workbench requires 2 Wood to build【907636800064548†screenshot】."
         },
         "thegamer-foxparks-spawn": {
           "title": "Palworld: How To Find And Capture Foxparks",
           "url": "https://www.thegamer.com/palworld-foxparks-location-guide/",
           "access_date": "2025-09-30",
-          "notes": "Provides spawn coordinates for Foxparks and notes they are kindling Pals\u3010956200907149478\u2020L146-L169\u3011."
+          "notes": "Provides spawn coordinates for Foxparks and notes they are kindling Pals【956200907149478†L146-L169】."
         },
         "namehero-xp-capture": {
           "title": "Palworld Leveling Guide",
           "url": "https://www.namehero.com/game-guides/palworld-leveling-guide/",
           "access_date": "2025-09-30",
-          "notes": "Highlights that capturing Pals yields more XP than defeating them\u3010116860197722081\u2020L96-L128\u3011."
+          "notes": "Highlights that capturing Pals yields more XP than defeating them【116860197722081†L96-L128】."
         },
         "shockbyte-leather-sources": {
           "title": "Palworld: How To Get Leather",
           "url": "https://shockbyte.com/blog/how-to-get-leather-in-palworld",
           "access_date": "2025-09-30",
-          "notes": "Lists Pals that drop Leather and notes the Sea\u00a0Breeze Archipelago Church and Bridge of the Twin Knights as farming locations\u3010840767909995613\u2020L78-L100\u3011\u3010840767909995613\u2020L106-L135\u3011."
+          "notes": "Lists Pals that drop Leather and notes the Sea Breeze Archipelago Church and Bridge of the Twin Knights as farming locations【840767909995613†L78-L100】【840767909995613†L106-L135】."
         },
         "shockbyte-leather-merchant": {
           "title": "Palworld: How To Get Leather",
           "url": "https://shockbyte.com/blog/how-to-get-leather-in-palworld",
           "access_date": "2025-09-30",
-          "notes": "Notes that Wandering Merchants sell Leather for about 150\u00a0gold each\u3010840767909995613\u2020L78-L100\u3011."
+          "notes": "Notes that Wandering Merchants sell Leather for about 150 gold each【840767909995613†L78-L100】."
         },
         "gameclubz-foxparks-harness": {
-          "title": "Palworld \u2013 How to Unlock and Use Foxparks Harness",
+          "title": "Palworld – How to Unlock and Use Foxparks Harness",
           "url": "https://gameclubz.com/palworld/foxparks-harness-guide",
           "access_date": "2025-09-30",
-          "notes": "Provides the Foxparks Harness recipe (3\u00a0Leather, 5\u00a0Flame Organs, 5\u00a0Paldium Fragments) and explains unlocking at level\u00a06 after catching Foxparks\u3010353245298505537\u2020L150-L180\u3011."
+          "notes": "Provides the Foxparks Harness recipe (3 Leather, 5 Flame Organs, 5 Paldium Fragments) and explains unlocking at level 6 after catching Foxparks【353245298505537†L150-L180】."
         },
         "gameclubz-eikthyrdeer-saddle": {
-          "title": "Palworld \u2013 Eikthyrdeer Saddle Guide",
+          "title": "Palworld – Eikthyrdeer Saddle Guide",
           "url": "https://gameclubz.com/palworld/eikthyrdeer-saddle-guide",
           "access_date": "2025-09-30",
-          "notes": "States that the Eikthyrdeer Saddle unlocks at level\u00a012 with 2\u00a0tech points and lists required materials (5\u00a0Leather, 20\u00a0Fiber, 10\u00a0Ingots, 3\u00a0Horns, 15\u00a0Paldium Fragments)\u3010963225160620124\u2020L160-L167\u3011."
+          "notes": "States that the Eikthyrdeer Saddle unlocks at level 12 with 2 tech points and lists required materials (5 Leather, 20 Fiber, 10 Ingots, 3 Horns, 15 Paldium Fragments)【963225160620124†L160-L167】."
         },
         "eikthyrdeer-drops": {
-          "title": "Eikthyrdeer \u2013 Palworld Wiki",
+          "title": "Eikthyrdeer – Palworld Wiki",
           "url": "https://palworld.fandom.com/wiki/Eikthyrdeer",
           "access_date": "2025-09-30",
-          "notes": "Lists Eikthyrdeer drops: 2\u00a0Venison, 2\u20133\u00a0Leather and 2\u00a0Horns at 100\u00a0% drop rate\u3010142053078936299\u2020L295-L311\u3011."
+          "notes": "Lists Eikthyrdeer drops: 2 Venison, 2–3 Leather and 2 Horns at 100 % drop rate【142053078936299†L295-L311】."
         },
         "eikthyrdeer-partner-skill": {
-          "title": "Eikthyrdeer \u2013 Palworld Wiki",
+          "title": "Eikthyrdeer – Palworld Wiki",
           "url": "https://palworld.fandom.com/wiki/Eikthyrdeer",
           "access_date": "2025-09-30",
-          "notes": "Describes the partner skill \u2018Guardian of the Forest\u2019 \u2013 the Pal can be ridden, enables double jump and increases tree\u2011cutting efficiency\u3010142053078936299\u2020L123-L142\u3011."
+          "notes": "Describes the partner skill ‘Guardian of the Forest’ – the Pal can be ridden, enables double jump and increases tree‑cutting efficiency【142053078936299†L123-L142】."
         },
         "paldb-foxparks-partner": {
-          "title": "Foxparks \u2013 PalDB",
+          "title": "Foxparks – PalDB",
           "url": "https://paldb.cc/pal/foxparks",
           "access_date": "2025-09-30",
-          "notes": "Mentions the partner skill \u2018Huggy Fire\u2019 which equips Foxparks as a flamethrower and its work suitability (Kindling Lv1)\u3010513843636763139\u2020L117-L170\u3011."
+          "notes": "Mentions the partner skill ‘Huggy Fire’ which equips Foxparks as a flamethrower and its work suitability (Kindling Lv1)【513843636763139†L117-L170】."
         },
         "palwiki-direhowl-recipe": {
-          "title": "Direhowl Saddled Harness \u2013 Palworld Wiki",
+          "title": "Direhowl Saddled Harness – Palworld Wiki",
           "url": "https://palworld.fandom.com/wiki/Direhowl_Saddled_Harness",
           "access_date": "2025-09-30",
-          "notes": "Provides the Direhowl harness recipe (10\u00a0Leather, 20\u00a0Wood, 15\u00a0Fiber, 10\u00a0Paldium Fragments) and states it unlocks at level\u00a09 with 1\u00a0tech point\u3010197143349627535\u2020L151-L156\u3011."
+          "notes": "Provides the Direhowl harness recipe (10 Leather, 20 Wood, 15 Fiber, 10 Paldium Fragments) and states it unlocks at level 9 with 1 tech point【197143349627535†L151-L156】."
         },
         "palwiki-nitewing-saddle": {
-          "title": "Nitewing Saddled Harness \u2013 Palworld Wiki",
+          "title": "Nitewing Saddled Harness – Palworld Wiki",
           "url": "https://palworld.fandom.com/wiki/Nitewing_Saddle",
           "access_date": "2025-09-30",
-          "notes": "Lists the Nitewing saddle recipe (20\u00a0Leather, 10\u00a0Cloth, 15\u00a0Ingots, 20\u00a0Fiber, 20\u00a0Paldium Fragments) and level requirements\u3010524512399342633\u2020L151-L156\u3011."
+          "notes": "Lists the Nitewing saddle recipe (20 Leather, 10 Cloth, 15 Ingots, 20 Fiber, 20 Paldium Fragments) and level requirements【524512399342633†L151-L156】."
         },
         "updatecrazy-patch-067": {
           "title": "Palworld Update v0.6.7 Patch Notes",
           "url": "https://updatecrazy.com/palworld-update-v0-6-7-patch-notes",
           "access_date": "2025-09-30",
-          "notes": "Confirms game version 1.079.736 released on Sept\u00a029\u00a02025 and fixes relating to dungeon crashes\u3010353708512100491\u2020L31-L56\u3011."
+          "notes": "Confirms game version 1.079.736 released on Sept 29 2025 and fixes relating to dungeon crashes【353708512100491†L31-L56】."
         },
         "goleap-region-levels": {
           "title": "Palworld Map Level Zones",
           "url": "https://www.gameleap.com/palworld-map-level-zones",
           "access_date": "2025-09-30",
-          "notes": "Provides level ranges for each region (e.g. Windswept Hills 1\u201315, Sea\u00a0Breeze Archipelago 1\u201310)\u3010950757978743332\u2020L131-L147\u3011."
+          "notes": "Provides level ranges for each region (e.g. Windswept Hills 1–15, Sea Breeze Archipelago 1–10)【950757978743332†L131-L147】."
         },
         "gosunoob-vixy-breeding": {
-          "title": "Palworld \u2013 Vixy Breeding Combinations",
+          "title": "Palworld – Vixy Breeding Combinations",
           "url": "https://www.gosunoob.com/palworld/vixy-breeding/",
           "access_date": "2025-09-30",
-          "notes": "Lists combos that produce Vixy and notes its work suitability and drops\u3010506019502892519\u2020screenshot\u3011\u3010761280216223901\u2020screenshot\u3011."
+          "notes": "Lists combos that produce Vixy and notes its work suitability and drops【506019502892519†screenshot】【761280216223901†screenshot】."
         },
         "pcgamesn-bosses": {
           "title": "All Palworld bosses in order and how to beat them",
           "url": "https://www.pcgamesn.com/palworld/bosses",
           "access_date": "2025-09-30",
-          "notes": "Provides details on tower bosses including Zoe & Grizzbolt, coordinates (112,\u00a0-434), challenge damage (30K), recommended ground Pals and tactics\u3010825211382965329\u2020L103-L118\u3011; also lists Nitewing as an Alpha Pal at Ice Wind Island (level\u00a018)\u3010825211382965329\u2020L294-L302\u3011 and Jetragon at Mount Obsidian (level\u00a050)\u3010825211382965329\u2020L337-L339\u3011."
+          "notes": "Provides details on tower bosses including Zoe & Grizzbolt, coordinates (112, -434), challenge damage (30K), recommended ground Pals and tactics【825211382965329†L103-L118】; also lists Nitewing as an Alpha Pal at Ice Wind Island (level 18)【825211382965329†L294-L302】 and Jetragon at Mount Obsidian (level 50)【825211382965329†L337-L339】."
         },
         "pcgamer-grappling-gun": {
           "title": "Palworld grappling gun guide",
           "url": "https://www.pcgamer.com/palworld-grappling-gun-crafting/",
           "access_date": "2025-09-30",
-          "notes": "Explains that the Grappling Gun unlocks at level\u00a012 and costs 1\u00a0Ancient Technology Point; crafting requires 10\u00a0Paldium Fragments, 10\u00a0Ingots, 30\u00a0Fiber and 1\u00a0Ancient Civilization Part\u3010312162085103617\u2020L180-L205\u3011."
+          "notes": "Explains that the Grappling Gun unlocks at level 12 and costs 1 Ancient Technology Point; crafting requires 10 Paldium Fragments, 10 Ingots, 30 Fiber and 1 Ancient Civilization Part【312162085103617†L180-L205】."
         },
         "pcgamesn-jetragon": {
-          "title": "All Palworld bosses in order and how to beat them \u2013 Jetragon entry",
+          "title": "All Palworld bosses in order and how to beat them – Jetragon entry",
           "url": "https://www.pcgamesn.com/palworld/bosses",
           "access_date": "2025-09-30",
-          "notes": "States that Jetragon is a level\u00a050 Legendary Celestial Dragon found at Mount Obsidian\u3010825211382965329\u2020L337-L339\u3011."
+          "notes": "States that Jetragon is a level 50 Legendary Celestial Dragon found at Mount Obsidian【825211382965329†L337-L339】."
         },
         "palwiki-humans": {
-          "title": "Humans \u2013 Palworld Wiki",
+          "title": "Humans – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Humans",
           "access_date": "2025-09-30",
-          "notes": "Explains that non-leader humans can be captured with Pal Spheres, have lower catch rates needing higher-grade spheres, cannot use their weapons, and merchants stationed at bases provide permanent shop access despite only rank\u00a01 work suitability.\u3010529f5c\u2020L67-L90\u3011\u301094455f\u2020L13-L18\u3011"
+          "notes": "Explains that non-leader humans can be captured with Pal Spheres, have lower catch rates needing higher-grade spheres, cannot use their weapons, and merchants stationed at bases provide permanent shop access despite only rank 1 work suitability.【529f5c†L67-L90】【94455f†L13-L18】"
         },
         "palwiki-small-settlement": {
-          "title": "Small Settlement \u2013 Palworld Wiki",
+          "title": "Small Settlement – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Small_Settlement",
           "access_date": "2025-10-18",
-          "notes": "Provides the Small Settlement coordinates (75,-479) and lists resident merchants for early-game trade routes.\u3010palwiki-small-settlement\u2020L3-L15\u3011"
+          "notes": "Provides the Small Settlement coordinates (75,-479) and lists resident merchants for early-game trade routes.【palwiki-small-settlement†L3-L15】"
         },
         "palwiki-paldium": {
-          "title": "Paldium Fragment \u2013 Palworld Wiki",
+          "title": "Paldium Fragment – Palworld Wiki",
           "url": "https://palworld.fandom.com/wiki/Paldium_Fragment",
           "access_date": "2025-09-30",
-          "notes": "Lists river, cliff and smelting sources for Paldium Fragments including respawn timers and conversion tips\u3010palwiki-paldium\u2020L42-L71\u3011\u3010palwiki-paldium\u2020L86-L115\u3011\u3010palwiki-paldium\u2020L118-L140\u3011."
+          "notes": "Lists river, cliff and smelting sources for Paldium Fragments including respawn timers and conversion tips【palwiki-paldium†L42-L71】【palwiki-paldium†L86-L115】【palwiki-paldium†L118-L140】."
         },
         "palwiki-charcoal": {
-          "title": "Charcoal \u2013 Palworld Wiki (Fandom)",
+          "title": "Charcoal – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Charcoal",
           "access_date": "2025-10-05",
-          "notes": "States charcoal is crafted at any furnace, weighs 2, and costs 2 Wood per batch for gunpowder prep\u301018fa49\u2020L1-L1\u3011\u3010ac044b\u2020L1-L7\u3011."
+          "notes": "States charcoal is crafted at any furnace, weighs 2, and costs 2 Wood per batch for gunpowder prep【18fa49†L1-L1】【ac044b†L1-L7】."
         },
         "palwiki-gunpowder": {
-          "title": "Gunpowder \u2013 Palworld Wiki (Fandom)",
+          "title": "Gunpowder – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Gunpowder",
           "access_date": "2025-10-05",
-          "notes": "Confirms gunpowder is a tier 21 tech crafted at a High Quality Workbench or better using 2 Charcoal and 1 Sulfur for ammunition\u301031b0ff\u2020L1-L1\u3011\u30104c6362\u2020L1-L1\u3011."
+          "notes": "Confirms gunpowder is a tier 21 tech crafted at a High Quality Workbench or better using 2 Charcoal and 1 Sulfur for ammunition【31b0ff†L1-L1】【4c6362†L1-L1】."
         },
         "pcgamesn-beautiful-flower": {
           "title": "Palworld beautiful flower locations",
           "url": "https://www.pcgamesn.com/palworld/beautiful-flower",
           "access_date": "2025-10-07",
-          "notes": "Lists Ribbunny, Petallia, Wumpo, and Lyleen as flower drops and explains Strange Juice usage at the Medieval Medicine Workbench.\u3010ba24e5\u2020L18-L37\u3011\u30100ed4ae\u2020L1-L12\u3011"
+          "notes": "Lists Ribbunny, Petallia, Wumpo, and Lyleen as flower drops and explains Strange Juice usage at the Medieval Medicine Workbench.【ba24e5†L18-L37】【0ed4ae†L1-L12】"
         },
         "palwiki-wildlife-sanctuary": {
-          "title": "Wildlife Sanctuary \u2013 Palworld Wiki",
+          "title": "Wildlife Sanctuary – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Wildlife_Sanctuary",
           "access_date": "2025-10-07",
-          "notes": "Explains trespassing penalties and that Sanctuary No.1 hosts level 20-25 pals while No.2 and No.3 feature level 50 threats.\u3010f574c5\u2020L5-L24\u3011"
+          "notes": "Explains trespassing penalties and that Sanctuary No.1 hosts level 20-25 pals while No.2 and No.3 feature level 50 threats.【f574c5†L5-L24】"
         },
         "palwiki-wildlife-sanctuary-1": {
-          "title": "No. 1 Wildlife Sanctuary \u2013 Palworld Wiki",
+          "title": "No. 1 Wildlife Sanctuary – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/No._1_Wildlife_Sanctuary",
           "access_date": "2025-10-07",
-          "notes": "Gives the island\u2019s coordinates (90,-735), highlights Petallia and other residents, and confirms Beautiful Flower gathering there.\u3010fe9924\u2020L1-L20\u3011"
+          "notes": "Gives the island’s coordinates (90,-735), highlights Petallia and other residents, and confirms Beautiful Flower gathering there.【fe9924†L1-L20】"
         },
         "palwiki-wildlife-sanctuary-2": {
-          "title": "No. 2 Wildlife Sanctuary \u2013 Palworld Wiki",
+          "title": "No. 2 Wildlife Sanctuary – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/No._2_Wildlife_Sanctuary",
           "access_date": "2025-10-07",
-          "notes": "Provides coordinates (-675,-113) and lists high-level pals plus Beautiful Flower, Sulfur, and Ore spawns.\u301015adf0\u2020L1-L22\u3011"
+          "notes": "Provides coordinates (-675,-113) and lists high-level pals plus Beautiful Flower, Sulfur, and Ore spawns.【15adf0†L1-L22】"
         },
         "palwiki-wildlife-sanctuary-3": {
-          "title": "No. 3 Wildlife Sanctuary \u2013 Palworld Wiki",
+          "title": "No. 3 Wildlife Sanctuary – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/No._3_Wildlife_Sanctuary",
           "access_date": "2025-10-07",
-          "notes": "Locates the island at (669,640) and details late-game pals like Lyleen and Shadowbeak along with Beautiful Flower spawns.\u3010c5acbe\u2020L1-L19\u3011"
+          "notes": "Locates the island at (669,640) and details late-game pals like Lyleen and Shadowbeak along with Beautiful Flower spawns.【c5acbe†L1-L19】"
         },
         "palwiki-ribbuny": {
-          "title": "Ribbuny \u2013 Palworld Wiki",
+          "title": "Ribbuny – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Ribbuny",
           "access_date": "2025-10-07",
-          "notes": "Drop table shows Beautiful Flower as a rare drop alongside leather, plus behavior info.\u30109be50c\u2020L31-L59\u3011"
+          "notes": "Drop table shows Beautiful Flower as a rare drop alongside leather, plus behavior info.【9be50c†L31-L59】"
         },
         "palwiki-petallia": {
-          "title": "Petallia \u2013 Palworld Wiki",
+          "title": "Petallia – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Petallia",
           "access_date": "2025-10-07",
-          "notes": "Confirms Petallia guarantees 2-3 Beautiful Flowers and is exclusive to Sanctuary No.1 with work proficiencies.\u30109f35a4\u2020L31-L52\u3011"
+          "notes": "Confirms Petallia guarantees 2-3 Beautiful Flowers and is exclusive to Sanctuary No.1 with work proficiencies.【9f35a4†L31-L52】"
         },
         "palwiki-beautiful-flower": {
-          "title": "Beautiful Flower \u2013 Palworld Wiki",
+          "title": "Beautiful Flower – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Beautiful_Flower",
           "access_date": "2025-10-07",
-          "notes": "States the item is harvested across all Wildlife Sanctuaries and used for Strange Juice crafting.\u301021cd8a\u2020L1-L28\u3011"
+          "notes": "States the item is harvested across all Wildlife Sanctuaries and used for Strange Juice crafting.【21cd8a†L1-L28】"
         },
         "pcgamesn-carbon-fiber": {
           "title": "How to get Palworld Carbon Fiber",
           "url": "https://www.pcgamesn.com/palworld/carbon-fiber",
           "access_date": "2025-10-07",
-          "notes": "Explains unlocking the Production Assembly Line at level 28, coal/charcoal crafting inputs, and legendary drop alternatives from Jetragon or Shadowbeak.\u30102b82ab\u2020L138-L145\u3011"
+          "notes": "Explains unlocking the Production Assembly Line at level 28, coal/charcoal crafting inputs, and legendary drop alternatives from Jetragon or Shadowbeak.【2b82ab†L138-L145】"
         },
         "palwiki-carbon-fiber": {
-          "title": "Carbon Fiber \u2013 Palworld Wiki",
+          "title": "Carbon Fiber – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Carbon_Fiber",
           "access_date": "2025-10-07",
-          "notes": "Lists crafting recipes converting Coal or Charcoal into Carbon Fiber at the Production Assembly Line.\u3010f7ee05\u2020L1-L28\u3011"
+          "notes": "Lists crafting recipes converting Coal or Charcoal into Carbon Fiber at the Production Assembly Line.【f7ee05†L1-L28】"
         },
         "palwiki-production-assembly-line": {
-          "title": "Production Assembly Line \u2013 Palworld Wiki",
+          "title": "Production Assembly Line – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Production_Assembly_Line",
           "access_date": "2025-10-07",
-          "notes": "Details unlock level 28, required materials (100 Ingots, 50 Wood, 20 Nails, 10 Cement), and power requirements for the station.\u30105d3253\u2020L1-L35\u3011"
+          "notes": "Details unlock level 28, required materials (100 Ingots, 50 Wood, 20 Nails, 10 Cement), and power requirements for the station.【5d3253†L1-L35】"
         },
         "palwiki-jetragon": {
-          "title": "Jetragon \u2013 Palworld Wiki",
+          "title": "Jetragon – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Jetragon",
           "access_date": "2025-10-07",
-          "notes": "Drop table shows Carbon Fiber, Polymer, and Pure Quartz rewards from the legendary mount near Mount Obsidian.\u3010278868\u2020L31-L60\u3011"
+          "notes": "Drop table shows Carbon Fiber, Polymer, and Pure Quartz rewards from the legendary mount near Mount Obsidian.【278868†L31-L60】"
         },
         "palwiki-shadowbeak": {
-          "title": "Shadowbeak \u2013 Palworld Wiki",
+          "title": "Shadowbeak – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Shadowbeak",
           "access_date": "2025-10-07",
-          "notes": "Lists Carbon Fiber and Pal Metal Ingot drops plus its habitat in Sanctuary No.3.\u3010eac1d9\u2020L33-L62\u3011"
+          "notes": "Lists Carbon Fiber and Pal Metal Ingot drops plus its habitat in Sanctuary No.3.【eac1d9†L33-L62】"
         },
         "game8-ore-farming": {
-          "title": "How to Farm Ore and Best Locations | Palworld\u3010Game8\u3011",
+          "title": "How to Farm Ore and Best Locations | Palworld【Game8】",
           "url": "https://game8.co/games/Palworld/archives/440245",
           "access_date": "2025-10-15",
-          "notes": "Lists Fort Ruins, Desolate Church, Small Settlement, and Icy Weasel Hill ore coordinates with base layout and automation guidance for mining pals.\u301040f7a9\u2020L1-L80\u3011\u3010d070f4\u2020L1-L24\u3011"
+          "notes": "Lists Fort Ruins, Desolate Church, Small Settlement, and Icy Weasel Hill ore coordinates with base layout and automation guidance for mining pals.【40f7a9†L1-L80】【d070f4†L1-L24】"
         },
         "palwiki-ore": {
-          "title": "Ore \u2013 Palworld Wiki",
+          "title": "Ore – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Ore",
           "access_date": "2025-10-15",
-          "notes": "Explains ore nodes are gray with red streaks, cites Ore Mining Site variants, and lists mining pal drop tables for ore.\u3010047054\u2020L18-L24\u3011"
+          "notes": "Explains ore nodes are gray with red streaks, cites Ore Mining Site variants, and lists mining pal drop tables for ore.【047054†L18-L24】"
         },
         "palwiki-ingot": {
-          "title": "Ingot \u2013 Palworld Wiki",
+          "title": "Ingot – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Ingot",
           "access_date": "2025-10-15",
-          "notes": "Describes crafting Ingots by smelting two ore in a Primitive Furnace and highlights their role in mid-game equipment.\u3010951c6f\u2020L6-L16\u3011"
+          "notes": "Describes crafting Ingots by smelting two ore in a Primitive Furnace and highlights their role in mid-game equipment.【951c6f†L6-L16】"
         },
         "game8-large-pal-soul": {
-          "title": "How to Get Large Pal Soul: All Recipes and Effects  | Palworld\u3010Game8\u3011",
+          "title": "How to Get Large Pal Soul: All Recipes and Effects  | Palworld【Game8】",
           "url": "https://game8.co/games/Palworld/archives/440127",
           "access_date": "2025-10-17",
-          "notes": "Lists Large Pal Soul drop sources (Anubis, Frostallion Noct, Necromus) and shows Crusher conversions between Medium, Large, and Giant souls plus Statue usage.\u3010game8-large-pal-soul\u2020L113-L158\u3011"
+          "notes": "Lists Large Pal Soul drop sources (Anubis, Frostallion Noct, Necromus) and shows Crusher conversions between Medium, Large, and Giant souls plus Statue usage.【game8-large-pal-soul†L113-L158】"
         },
         "palwiki-large-pal-soul": {
-          "title": "Large Pal Soul \u2013 Palworld Wiki",
+          "title": "Large Pal Soul – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Large_Pal_Soul",
           "access_date": "2025-10-17",
-          "notes": "Confirms Large Pal Souls spawn on the ground and drop from Anubis, Frostallion Noct, Necromus, Neptilius, and Pal Genetic Research Unit Executioners.\u3010palwiki-large-pal-soul\u2020L116-L160\u3011"
+          "notes": "Confirms Large Pal Souls spawn on the ground and drop from Anubis, Frostallion Noct, Necromus, Neptilius, and Pal Genetic Research Unit Executioners.【palwiki-large-pal-soul†L116-L160】"
         },
         "palwiki-statue-of-power": {
-          "title": "Statue of Power \u2013 Palworld Wiki",
+          "title": "Statue of Power – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Statue_of_Power",
           "access_date": "2025-10-17",
-          "notes": "Explains Statue of Power interaction flow and that Pal enhancement consumes Small, Medium, Large, and Giant Pal Souls.\u3010palwiki-statue-of-power\u2020L160-L186\u3011"
+          "notes": "Explains Statue of Power interaction flow and that Pal enhancement consumes Small, Medium, Large, and Giant Pal Souls.【palwiki-statue-of-power†L160-L186】"
         },
         "palwiki-crusher": {
-          "title": "Crusher \u2013 Palworld Wiki",
+          "title": "Crusher – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Crusher",
           "access_date": "2025-10-17",
-          "notes": "Lists Crusher recipes converting Small to Medium, Medium to Large, and Giant to Large Pal Souls.\u3010palwiki-crusher\u2020L159-L179\u3011"
+          "notes": "Lists Crusher recipes converting Small to Medium, Medium to Large, and Giant to Large Pal Souls.【palwiki-crusher†L159-L179】"
         },
         "palfandom-anubis": {
-          "title": "Anubis \u2013 Palworld Wiki (Fandom)",
+          "title": "Anubis – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Anubis",
           "access_date": "2025-10-17",
-          "notes": "States Anubis spawns as an Alpha at Twilight Dunes (-134,-95).\u301028a64e\u2020L300-L303\u3011"
+          "notes": "States Anubis spawns as an Alpha at Twilight Dunes (-134,-95).【28a64e†L300-L303】"
         },
         "palwiki-bone": {
-          "title": "Bone \u2013 Palworld Wiki",
+          "title": "Bone – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Bone",
           "access_date": "2025-10-18",
-          "notes": "Lists Wandering Merchant pricing, notes Sootseer and Vixy produce bones at the ranch, and summarizes bone crafting uses.\u3010palwiki-bone\u2020L1-L37\u3011"
+          "notes": "Lists Wandering Merchant pricing, notes Sootseer and Vixy produce bones at the ranch, and summarizes bone crafting uses.【palwiki-bone†L1-L37】"
         },
         "palfandom-bone": {
-          "title": "Bone \u2013 Palworld Wiki (Fandom)",
+          "title": "Bone – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Bone",
           "access_date": "2025-10-18",
-          "notes": "Provides the full drop list, confirms ranch production from Sootseer and Vixy, and reiterates the 100G merchant price.\u3010palfandom-bone\u2020L1-L55\u3011"
+          "notes": "Provides the full drop list, confirms ranch production from Sootseer and Vixy, and reiterates the 100G merchant price.【palfandom-bone†L1-L55】"
         },
         "palwiki-sootseer": {
-          "title": "Sootseer \u2013 Palworld Wiki",
+          "title": "Sootseer – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Sootseer",
           "access_date": "2025-10-18",
-          "notes": "Documents the Grave Robber partner skill digging bones at the ranch, guaranteed bone drops, and night spawns across Sakurajima.\u3010palwiki-sootseer\u2020L12-L116\u3011"
+          "notes": "Documents the Grave Robber partner skill digging bones at the ranch, guaranteed bone drops, and night spawns across Sakurajima.【palwiki-sootseer†L12-L116】"
         },
         "palwiki-rushoar": {
-          "title": "Rushoar \u2013 Palworld Wiki",
+          "title": "Rushoar – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Rushoar",
           "access_date": "2025-10-18",
-          "notes": "Confirms Rushoar drops Bone alongside Pork and Leather and describes its aggressive hill patrol behaviour.\u3010palwiki-rushoar\u2020L65-L116\u3011"
+          "notes": "Confirms Rushoar drops Bone alongside Pork and Leather and describes its aggressive hill patrol behaviour.【palwiki-rushoar†L65-L116】"
         },
         "palwiki-windswept-hills": {
-          "title": "Windswept Hills \u2013 Palworld Wiki",
+          "title": "Windswept Hills – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Windswept_Hills",
           "access_date": "2025-10-18",
-          "notes": "Explains the region is the starting zone with low-level pals and lists the Small Settlement as a key point of interest.\u3010palwiki-windswept-hills\u2020L7-L22\u3011"
+          "notes": "Explains the region is the starting zone with low-level pals and lists the Small Settlement as a key point of interest.【palwiki-windswept-hills†L7-L22】"
         },
         "palwiki-vixy": {
-          "title": "Vixy \u2013 Palworld Wiki",
+          "title": "Vixy – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Vixy",
           "access_date": "2025-10-18",
-          "notes": "Shows Dig Here! produces items at the ranch and that Vixy drops Bone and Leather at 100% rates.\u3010palwiki-vixy\u2020L9-L49\u3011"
+          "notes": "Shows Dig Here! produces items at the ranch and that Vixy drops Bone and Leather at 100% rates.【palwiki-vixy†L9-L49】"
         },
         "palwiki-mau-raw": {
-          "title": "Mau \u2013 Palworld Wiki",
+          "title": "Mau – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Mau",
           "access_date": "2025-10-21",
-          "notes": "Confirms Mau\u2019s Gold Digger partner skill digs coins, lists coin drop amounts, and notes it spawns in Windswept Hills dungeons or faction camps.\u3010palwiki-mau-raw\u2020L11-L115\u3011"
+          "notes": "Confirms Mau’s Gold Digger partner skill digs coins, lists coin drop amounts, and notes it spawns in Windswept Hills dungeons or faction camps.【palwiki-mau-raw†L11-L115】"
         },
         "palwiki-mozzarina-raw": {
-          "title": "Mozzarina \u2013 Palworld Wiki (raw)",
+          "title": "Mozzarina – Palworld Wiki (raw)",
           "url": "https://palworld.wiki.gg/index.php?title=Mozzarina&action=raw",
           "access_date": "2025-10-27",
-          "notes": "Shows Mozzarina Meat dropping in 2\u20133 piece bundles at 100% alongside guaranteed milk for both normal and alpha variants.\u3010palwiki-mozzarina-raw\u2020L65-L105\u3011"
+          "notes": "Shows Mozzarina Meat dropping in 2–3 piece bundles at 100% alongside guaranteed milk for both normal and alpha variants.【palwiki-mozzarina-raw†L65-L105】"
         },
         "palwiki-cooler-box-raw": {
-          "title": "Cooler Box \u2013 Palworld Wiki (raw)",
+          "title": "Cooler Box – Palworld Wiki (raw)",
           "url": "https://palworld.wiki.gg/index.php?title=Cooler_Box&action=raw",
           "access_date": "2025-10-27",
-          "notes": "Explains the Cooler Box unlock at technology level 13, its 20 Ingot/20 Stone/5 Ice Organ recipe, and that Cooling pals prevent stored food from spoiling.\u3010palwiki-cooler-box-raw\u2020L1-L24\u3011"
+          "notes": "Explains the Cooler Box unlock at technology level 13, its 20 Ingot/20 Stone/5 Ice Organ recipe, and that Cooling pals prevent stored food from spoiling.【palwiki-cooler-box-raw†L1-L24】"
         },
         "palwiki-gold-coin-raw": {
-          "title": "Gold Coin \u2013 Palworld Wiki",
+          "title": "Gold Coin – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Gold_Coin",
           "access_date": "2025-10-21",
-          "notes": "States Gold Coins are traded currency and can be earned by selling items or pals, defeating human mobs, opening chests, or ranching Mau, Mau Cryst, and Vixy.\u3010palwiki-gold-coin-raw\u2020L3-L28\u3011"
+          "notes": "States Gold Coins are traded currency and can be earned by selling items or pals, defeating human mobs, opening chests, or ranching Mau, Mau Cryst, and Vixy.【palwiki-gold-coin-raw†L3-L28】"
         },
         "palwiki-gold-coin": {
-          "title": "Gold Coin \u2013 Palworld Wiki (Fandom)",
+          "title": "Gold Coin – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Gold_Coin",
           "access_date": "2025-10-21",
-          "notes": "Lists merchant sales, Syndicate drops, and ranch producers (Mau, Mau Cryst, Vixy) for Gold Coins.\u3010palwiki-gold-coin\u2020L28-L44\u3011"
+          "notes": "Lists merchant sales, Syndicate drops, and ranch producers (Mau, Mau Cryst, Vixy) for Gold Coins.【palwiki-gold-coin†L28-L44】"
         },
         "palwiki-nail": {
-          "title": "Nail \u2013 Palworld Wiki",
+          "title": "Nail – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Nail",
           "access_date": "2025-10-18",
-          "notes": "Details the level 10 tech unlock, Primitive Workbench crafting requirement, and 1 Ingot to 2 Nail recipe.\u3010palwiki-nail\u2020L3-L33\u3011"
+          "notes": "Details the level 10 tech unlock, Primitive Workbench crafting requirement, and 1 Ingot to 2 Nail recipe.【palwiki-nail†L3-L33】"
         },
         "game8-nail": {
-          "title": "How to Get Nail: All Recipes and Effects  | Palworld\u3010Game8\u3011",
+          "title": "How to Get Nail: All Recipes and Effects  | Palworld【Game8】",
           "url": "https://game8.co/games/Palworld/archives/440158",
           "access_date": "2025-10-18",
-          "notes": "Explains reaching level 10 to unlock Nail tech, crafting nails from ingots at workbenches and assembly lines, and the need for a Primitive Furnace to feed the recipe.\u3010game8-nail\u2020L100-L124\u3011"
+          "notes": "Explains reaching level 10 to unlock Nail tech, crafting nails from ingots at workbenches and assembly lines, and the need for a Primitive Furnace to feed the recipe.【game8-nail†L100-L124】"
         },
         "palwiki-refined-ingot": {
-          "title": "Refined Ingot \u2013 Palworld Wiki",
+          "title": "Refined Ingot – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Refined_Ingot",
           "access_date": "2025-10-20",
-          "notes": "Confirms refined ingots are crafted from 2 Ore and 2 Coal at an Improved Furnace unlocked at tech level 34.\u3010palwiki-refined-ingot\u2020L1-L5\u3011"
+          "notes": "Confirms refined ingots are crafted from 2 Ore and 2 Coal at an Improved Furnace unlocked at tech level 34.【palwiki-refined-ingot†L1-L5】"
         },
         "segmentnext-refined-ingot": {
           "title": "How To Get Refined Ingots In Palworld",
           "url": "https://segmentnext.com/palworld-refined-ingot/",
           "access_date": "2025-10-20",
-          "notes": "Describes unlocking refined ingots and the Improved Furnace at level 34, notes each bar costs Ore \u00d72 and Coal \u00d72, and recommends the (191,-36) mining outpost with Digtoise/Tombat automation.\u3010segmentnext-refined-ingot\u2020L1-L5\u3011"
+          "notes": "Describes unlocking refined ingots and the Improved Furnace at level 34, notes each bar costs Ore ×2 and Coal ×2, and recommends the (191,-36) mining outpost with Digtoise/Tombat automation.【segmentnext-refined-ingot†L1-L5】"
         },
         "palwiki-electric-furnace": {
-          "title": "Electric Furnace \u2013 Palworld Wiki",
+          "title": "Electric Furnace – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Electric_Furnace",
           "access_date": "2025-10-20",
-          "notes": "Shows the Electric Furnace unlocks at level 44, costs 50 Refined Ingots, 10 Circuit Boards, 20 Polymer, 20 Carbon Fiber, and still needs electricity plus a fire Pal to operate.\u3010palwiki-electric-furnace\u2020L1-L4\u3011"
+          "notes": "Shows the Electric Furnace unlocks at level 44, costs 50 Refined Ingots, 10 Circuit Boards, 20 Polymer, 20 Carbon Fiber, and still needs electricity plus a fire Pal to operate.【palwiki-electric-furnace†L1-L4】"
         },
         "palwiki-pal-metal-ingot": {
-          "title": "Pal Metal Ingot \u2013 Palworld Wiki",
+          "title": "Pal Metal Ingot – Palworld Wiki",
           "url": "https://palworld.wiki.gg/wiki/Pal_Metal_Ingot",
           "access_date": "2025-10-20",
-          "notes": "States Pal Metal Ingots are crafted at the Electric Furnace with a 4 Ore + 2 Paldium Fragment recipe and notes their late-game usage and drops.\u3010palwiki-pal-metal-ingot\u2020L1-L3\u3011"
+          "notes": "States Pal Metal Ingots are crafted at the Electric Furnace with a 4 Ore + 2 Paldium Fragment recipe and notes their late-game usage and drops.【palwiki-pal-metal-ingot†L1-L3】"
         },
         "fandom-pal-metal-ingot": {
-          "title": "Pal Metal Ingot \u2013 Palworld Wiki (Fandom)",
+          "title": "Pal Metal Ingot – Palworld Wiki (Fandom)",
           "url": "https://palworld.fandom.com/wiki/Pal_Metal_Ingot",
           "access_date": "2025-10-20",
-          "notes": "Provides the Electric Furnace recipe, reiterates 4 Ore + 2 Paldium Fragment cost, and lists Astegon, Necromus, Paladius, and Shadowbeak as drop sources.\u3010fandom-pal-metal-ingot\u2020L1-L4\u3011"
+          "notes": "Provides the Electric Furnace recipe, reiterates 4 Ore + 2 Paldium Fragment cost, and lists Astegon, Necromus, Paladius, and Shadowbeak as drop sources.【fandom-pal-metal-ingot†L1-L4】"
         }
       }
     }

--- a/guides.md
+++ b/guides.md
@@ -24765,6 +24765,313 @@ Cotton Candy Woolipop Confection Loop uses breeding-farm automation to hatch a s
 }
 ```
 
+### Route: Broncherry Meat Caravan Loop
+
+Broncherry Meat Caravan Loop rides the overworld Alpha Broncherry at (-222,-669) and Meat Cleaver butchery so every daily respawn delivers guaranteed meat cuts plus tomato seed byproducts for late-game kitchens.【palwiki-alpha-pals†L1-L104】【palwiki-broncherry-raw†L66-L98】【palwiki-meat-cleaver†L2-L38】
+
+```json
+{
+  "route_id": "resource-broncherry-meat",
+  "title": "Broncherry Meat Caravan Loop",
+  "category": "resources",
+  "tags": [
+    "resource-farm",
+    "broncherry-meat",
+    "alpha-hunt",
+    "cooking"
+  ],
+  "progression_role": "support",
+  "recommended_level": {
+    "min": 22,
+    "max": 34
+  },
+  "modes": {
+    "normal": true,
+    "hardcore": true,
+    "solo": true,
+    "coop": true
+  },
+  "prerequisites": {
+    "routes": [],
+    "tech": [
+      "meat-cleaver"
+    ],
+    "items": [],
+    "pals": []
+  },
+  "objectives": [
+    "Unlock the Meat Cleaver and stage capture gear for the level 23 alpha",
+    "Clear or capture the Verdant Brook Alpha Broncherry each in-game day",
+    "Butcher banked Broncherry to stockpile meat and seed drops"
+  ],
+  "estimated_time_minutes": {
+    "solo": 32,
+    "coop": 24
+  },
+  "estimated_xp_gain": {
+    "min": 420,
+    "max": 640
+  },
+  "risk_profile": "medium",
+  "failure_penalties": {
+    "normal": "Missing the alpha rotation forfeits the daily guaranteed meat bundle until the next in-game day respawn.",
+    "hardcore": "Hardcore wipes can cost your butchery kit and captured pals if PIDF patrols finish you during the hunt."
+  },
+  "adaptive_guidance": {
+    "underleveled": "If you cannot safely duel the alpha, throw Mega or Hyper Spheres to capture Broncherry at (-222,-669) and butcher it back at camp—the Meat Cleaver guarantees the same drops without a protracted fight.【palwiki-alpha-pals†L8-L104】【palwiki-meat-cleaver†L2-L38】",
+    "overleveled": "Run a daily kill plus a spare capture so you bank four Broncherry Meat and bonus Tomato Seeds for rib roasts and salads each loop.【palwiki-alpha-pals†L8-L104】【palwiki-broncherry-raw†L66-L98】",
+    "resource_shortages": [
+      {
+        "item_id": "broncherry_meat",
+        "solution": "Fast travel in, burst down the alpha for two guaranteed cuts, then butcher any captured spares to double the haul before logging off.【palwiki-alpha-pals†L8-L104】【palwiki-broncherry-raw†L66-L98】【palwiki-meat-cleaver†L2-L38】"
+      }
+    ],
+    "time_limited": "Alpha Broncherry respawns every in-game day; sprint in for a single clear, grab the two cuts, and reset by sleeping if you only have a few minutes.【palwiki-alpha-pals†L1-L12】【palwiki-broncherry-raw†L66-L98】",
+    "dynamic_rules": [
+      {
+        "signal": "mode:coop",
+        "condition": "mode.coop === true",
+        "adjustment": "Assign one player to kite Broncherry while the partner nets captures and drags them home for butchery so the loop finishes before PIDF reinforcements arrive.",
+        "priority": 2,
+        "mode_scope": [
+          "coop"
+        ],
+        "related_steps": [
+          "resource-broncherry-meat:002",
+          "resource-broncherry-meat:003"
+        ]
+      }
+    ]
+  },
+  "checkpoints": [
+    {
+      "id": "resource-broncherry-meat:checkpoint-cleaver",
+      "summary": "Butchery kit unlocked",
+      "benefits": [
+        "Meat Cleaver crafted",
+        "Hotbar slot configured"
+      ],
+      "related_steps": [
+        "resource-broncherry-meat:001"
+      ]
+    },
+    {
+      "id": "resource-broncherry-meat:checkpoint-alpha",
+      "summary": "Alpha cleared",
+      "benefits": [
+        "Daily respawn on cooldown",
+        "Guaranteed cuts secured"
+      ],
+      "related_steps": [
+        "resource-broncherry-meat:002"
+      ]
+    },
+    {
+      "id": "resource-broncherry-meat:checkpoint-storage",
+      "summary": "Meat banked",
+      "benefits": [
+        "Chest restocked",
+        "Seeds catalogued"
+      ],
+      "related_steps": [
+        "resource-broncherry-meat:003"
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "step_id": "resource-broncherry-meat:001",
+      "type": "prepare",
+      "summary": "Unlock Meat Cleaver and stage your kit",
+      "detail": "Spend 2 Technology Points at level 12 to unlock the Meat Cleaver, craft it at a Primitive Workbench, and keep it equipped so the Butcher command replaces Pet when you interact with captured pals.【palwiki-meat-cleaver†L2-L38】",
+      "targets": [],
+      "locations": [
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {},
+      "recommended_loadout": {
+        "gear": [
+          "meat-cleaver"
+        ],
+        "pals": [],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 0,
+        "max": 0
+      },
+      "outputs": {
+        "items": [],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [],
+      "citations": [
+        "palwiki-meat-cleaver†L2-L38"
+      ]
+    },
+    {
+      "step_id": "resource-broncherry-meat:002",
+      "type": "hunt",
+      "summary": "Sweep the Alpha Broncherry ridge",
+      "detail": "Fast travel to the nearby statue network and clear or capture Broncherry at (-222,-669); the level 23 alpha drops two Broncherry Meat every run and has a 50% chance to hand over Tomato Seeds.【palwiki-alpha-pals†L31-L104】【palwiki-broncherry-raw†L66-L98】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "broncherry_meat",
+          "qty": 2
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            -222,
+            -669
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "hardcore": {
+          "tactics": "Bring a tanky mount and disengage if PIDF patrols arrive; you can return after sleeping to reset the daily respawn.",
+          "mode_scope": [
+            "hardcore"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [
+          "hyper-sphere",
+          "mega-sphere"
+        ],
+        "pals": [
+          "anubis"
+        ],
+        "consumables": [
+          "medical-supplies"
+        ]
+      },
+      "xp_award_estimate": {
+        "min": 300,
+        "max": 420
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "broncherry_meat",
+            "qty": 2
+          }
+        ],
+        "pals": [
+          "broncherry"
+        ],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-precious-dragon-stone"
+        }
+      ],
+      "citations": [
+        "palwiki-alpha-pals†L31-L104",
+        "palwiki-broncherry-raw†L66-L98"
+      ]
+    },
+    {
+      "step_id": "resource-broncherry-meat:003",
+      "type": "base",
+      "summary": "Butcher and bank the haul",
+      "detail": "Back at base, equip the Meat Cleaver and butcher captured Broncherry to duplicate the two guaranteed meat drops and stash any Tomato Seeds for plantations before the next respawn.【palwiki-broncherry-raw†L66-L98】【palwiki-meat-cleaver†L2-L38】",
+      "targets": [
+        {
+          "kind": "item",
+          "id": "broncherry_meat",
+          "qty": 6
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {},
+      "recommended_loadout": {
+        "gear": [
+          "meat-cleaver"
+        ],
+        "pals": [],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 120,
+        "max": 220
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "broncherry_meat",
+            "qty": 6
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-tomato-seeds"
+        }
+      ],
+      "citations": [
+        "palwiki-broncherry-raw†L66-L98",
+        "palwiki-meat-cleaver†L2-L38"
+      ]
+    }
+  ],
+  "completion_criteria": [
+    {
+      "type": "have-item",
+      "item_id": "broncherry_meat",
+      "qty": 10
+    }
+  ],
+  "yields": {
+    "levels_estimate": "+0 to +1",
+    "key_unlocks": []
+  },
+  "metrics": {
+    "progress_segments": 3,
+    "boss_targets": 1,
+    "quest_nodes": 0
+  },
+  "next_routes": [
+    {
+      "route_id": "resource-precious-dragon-stone",
+      "reason": "Share the alpha circuit to stack Precious Dragon Stones alongside Broncherry Meat each day."
+    },
+    {
+      "route_id": "resource-tomato-seeds",
+      "reason": "Broncherry’s Tomato Seed drops feed plantations that support Rib Roast and salad dishes."
+    }
+  ]
+}
+```
+
 ### Route: Small Pal Soul Night Hunts & Crusher Loop
 
 Small Pal Soul Night Hunts & Crusher Loop combines nocturnal Daedream and Nox sweeps near the Small Settlement with Crusher
@@ -25824,6 +26131,12 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/index.php?title=Braloha&action=raw",
       "access_date": "2025-10-17",
       "notes": "States Braloha spawns exclusively on Oasis Isle east of the Desiccated Desert peninsula.【palwiki-braloha-raw†L121-L125】"
+    },
+    "palwiki-broncherry-raw": {
+      "title": "Broncherry \u2013 palworld.wiki.gg (raw wikitext)",
+      "url": "https://palworld.wiki.gg/index.php?title=Broncherry&action=raw",
+      "access_date": "2025-11-13",
+      "notes": "Shows Broncherry guarantees two Broncherry Meat per drop, 50% Tomato Seed byproducts, and the alpha reward table for Winds of Spring.【palwiki-broncherry-raw†L66-L103】"
     },
     "palwiki-wumpo-botan-raw": {
       "title": "Wumpo Botan \u2013 Palworld Wiki (raw)",

--- a/sources/palwiki-broncherry-raw.txt
+++ b/sources/palwiki-broncherry-raw.txt
@@ -1,0 +1,151 @@
+{{Pal Prev/Next | prevPal = Relaxaurus Lux | prevNo = 085b | nextPal =  Broncherry Aqua | nextNo = 086b}}
+{{Pal
+
+|name                   ={{PAGENAME}}
+|no                     =086
+|title                  =Winds of Spring
+
+|ele1                   =Grass
+|ele2                   =
+
+|partnerskill           =Overaffectionate
+|partnerskill_desc      =Can be [[ridden]].
+While in team, Broncherry helps carry supplies, increasing the [[player]]'s max [[carrying capacity]].
+|partnerskill_icon      =Mount
+
+| hp                     = 120
+| attack                 = 90
+| attack_melee           = 80
+| defense                = 100
+| support                = 120
+
+| slow_walk_speed        = 50
+| walk_speed             = 75
+| run_speed              = 350
+| ride_sprint_speed      = 500
+| transport_speed        = 200
+| stamina                = 100
+| work_speed             = 100
+
+| price                  = 2920
+| receive_damage_rate    = 1
+| receive_damage_rate_a  = 0.24
+| capture_rate_correct   = 1
+| capture_rate_correct_a = 0.7
+| breeding_rank          = 860
+
+| passiveskill1          =
+| passiveskill2          = 
+| passiveskill3          = 
+| passiveskill4          = 
+
+| activeskill1           = Wind Cutter
+| activeskill7           = Sand Blast
+| activeskill15          = Muscle Slam
+| activeskill22          = Seed Mine
+| activeskill30          = Grass Tornado
+| activeskill40          = Spine Vine
+| activeskill50          = Solar Blast
+
+|kindling               =
+|watering               =
+|planting               =3
+|generating_electricity =
+|handiwork              =
+|gathering              =
+|lumbering              =
+|mining                 =
+|medicine_production    =
+|cooling                =
+|transport              =
+|farming                =
+
+| food                  = 7
+| nocturnal             = No
+
+|drop1=Broncherry Meat 
+|drop1_min=2
+|drop1_max=2
+|drop1_chance=100
+|drop2=Tomato Seeds 
+|drop2_min=1
+|drop2_max=2
+|drop2_chance=50
+|drop3                  = Potato Seeds
+|drop3_min              = 1
+|drop3_max              = 1
+|drop3_chance           = 50
+|drop4                  = 
+|drop4_min              = 
+|drop4_max              = 
+|drop4_chance           = 
+|drop5                  = 
+|drop5_min              = 
+|drop5_max              = 
+|drop5_chance           = 
+
+|alphadrop1=Ancient Civilization Parts 
+|alphadrop1_min=1
+|alphadrop1_max=3
+|alphadrop1_chance=100
+|alphadrop2=Broncherry Meat
+|alphadrop2_min=2
+|alphadrop2_max=2
+|alphadrop2_chance=100
+|alphadrop3=Tomato Seeds 
+|alphadrop3_min=1
+|alphadrop3_max=2
+|alphadrop3_chance=50
+|alphadrop4=Precious Dragon Stone
+|alphadrop4_min=1
+|alphadrop4_max=3
+|alphadrop4_chance=100
+|alphadrop5=Ring of Grass Resistance +1
+|alphadrop5_min=1
+|alphadrop5_max=1
+|alphadrop5_chance=3
+
+}}{{paldeck|Its scent drastically changes before and after pairing. It exudes a pleasing aroma after finding a partner, which is called the "scent of first love."}}
+'''Broncherry''' (Japanese: '''ラブラドン''' ''Loveladon'') is a {{i|Grass}} [[Elements|element]] [[Pals|Pal]]. It has an {{i|Water}} [[Elements|element]] [[Breeding|variation]], [[Broncherry Aqua]].
+
+== Appearance ==
+Broncherry is a large sauropod Pal whose body primarily consists of greens, with a pink flower-like structure around the base of the neck and petal-like structures going up it.
+
+== Behavior and habitat==
+Broncherry are usually calm and only become aggressive when attacked. 
+[[File:Broncherry_Day_Habitat.webp|thumb|Daytime Broncherry Spawns]]
+[[File:Broncherry_Night_Habitat.webp|thumb|Nightime Broncherry Spawns]]
+
+== Utility ==
+Broncherry has a base Stamina of 100 and a Mount Speed of 500, making it the slowest Mount in the game, on par with [[Sweepa]] and [[Broncherry Aqua]]. 
+
+Its [[Partner Skill]], Overaffectionate, offers two benefits. The passive benefit, which requires the Broncherry Saddle, increases the player’s Carrying capacity by +100/+110/+120/+130/+140, depending on the Partner Skill Level. This bonus is cumulative with other Pals in the party, providing a significant boost.
+
+This passive bonus is the second highest in the game, matched by [[Broncherry Aqua]], [[Kingpaca]], and [[Kingpaca Cryst]], and only surpassed by [[Wumpo]] and [[Wumpo Botan]].
+
+== History ==
+* [[0.2.4.0]]
+** Increased the Alpha Received Damage Rate from 0.2 to 0.24.
+* [[0.1.2.0]]
+** Introduced.
+
+== Variant(s) ==
+* [[Broncherry Aqua]]
+
+== Trivia ==
+* Broncherry’s name might be a blend of “brontosaurus” and “cherry.” Interestingly, it also resembles the French phrase “Mon Chéri” (my dear), which is used to show affection, fitting the love theme of this Pal.
+* The Japanese name might originate from ラブラブ “raburabu” (a Wasei-eigo term meaning “love-love”), which describes being affectionate or infatuated. It likely also includes the suffix “-odon,” commonly found in the scientific names of large animals.
+* Despite its English name, Broncherry more closely resembles an ''[https://en.wikipedia.org/wiki/Amargasaurus Amargasaurus]'', namely due to the petal-like structures its head and neck being similar to the spines seen on the skeleton.
+*This Pal is #048 in Paldeck  on PocketPair [https://x.com/Palworld_EN/status/1738167508719271951 X].
+
+== Media ==
+{{#ev:youtube|yYsc3bmKu80|410|inline|Paldeck No.048 BRONCHERRY - Palworld Gameplay Pocketpair||autoplay=false}}
+<gallery widths="150">
+File:Broncherry wild.png|A wild Broncherry being captured.
+File:Broncherry bis.png
+</gallery>
+
+{{Navbox Pals}}
+[[Category:Pals]]
+[[Category:Rideable Pals]]
+[[Category:Pals with exclusive Skills]]


### PR DESCRIPTION
## Summary
- add a Broncherry Meat caravan route with alpha hunt and Meat Cleaver butchery guidance, plus supporting source data
- sync guides bundle metadata and guide catalog so the shortage menu surfaces the new resource entry
- update agent log/backlog with the new coverage and follow-up work items

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03b4c8e6c83318fadfa1e7e971831