### PR TITLE
Add Crusher automation coverage for medium pal souls

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -77,7 +77,7 @@ Key confirmations from the review:
 
 ### Backlog (Confirm Against `routeGuideData.resourceGuideGaps` Before Starting)
 
-* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **High Quality Pal Oil**, **Small Pal Soul**, **Medium Pal Soul follow-ups (Crusher automation variants)**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
+* High-priority shortages still missing guides: **Caprity Meat**, **Galeclaw Poultry**, **High Quality Pal Oil**, **Small Pal Soul**, **Sanctuary-exclusive drops (e.g., Lyleen Noct hair, Sibelyx Ignis cloth)**, **Merchant restock timing references**.
 * Secondary targets once two independent citations are secured: **Milk auxiliary spawns**, **Seed restock timers (Tomato/Lettuce/Berry)**, **Elite alpha respawn timers for gemstone loops**, **Automation throughput benchmarks for Assembly Line/Power Grid resources**.
 
 Update this backlog whenever a guide ships or when a data source becomes available, and archive stale TODOs with reasoning if a resource becomes obsolete or its shortages are resolved by upstream patches.
@@ -174,3 +174,14 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Secure a second independent citation for non-alpha Broncherry spawns (interactive map export or reputable guide) so future revisions can offer alternative hunt loops beyond the daily alpha kill.
 2. Capture quantitative butcher throughput (meat per hour, raid timers) once playtest data is available to tighten the estimated XP/output ranges in both the route JSON and shortage card.
 3. Audit downstream recipe routes (e.g., Rib Roast, hearty meals) to ensure they now reference the Broncherry Meat loop and surface dependencies appropriately once production bundles rebuild.
+
+### 2025-11-15 Medium Pal Soul automation handoff
+
+* Expanded `resource-medium-pal-soul` with a Crusher automation checkpoint, Watering-pal guidance, and a new `crusher-automation` key unlock so shortages surface base wiring steps alongside hunt loops.
+* Updated `data/guide_catalog.json` and the bundle catalog entry to add a fourth shortage step that highlights wiring storage between the Crusher and Statue of Power with supporting citations.
+
+**Continuation notes:**
+
+1. Capture empirical conversion throughput (Medium souls per minute) for common Watering pals to validate the new automation estimates before publishing dashboard copy.
+2. Monitor shortage cards after the next bundle rebuild to confirm the new automation step renders correctly and references the added `crusher-automation` unlock.
+3. Evaluate linking the automation step directly into `resource-large-pal-soul` once cooperative loadout benchmarks for Watering and Transporting pals are sourced.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8762,6 +8762,27 @@
             "palfandom-medium-pal-soul-raw",
             "palwiki-crusher-pal-soul-conversion"
           ]
+        },
+        {
+          "order": 4,
+          "instruction": "Stage a **Crusher and Statue of Power loop** at base, keep Watering pals on the Crusher, and shuttle Small or Large souls into Medium stock before each upgrade batch.",
+          "citations": [
+            "palwiki-crusher-raw",
+            "palwiki-statue-of-power",
+            "palwiki-small-pal-soul"
+          ],
+          "links": [
+            {
+              "type": "structure",
+              "id": "crusher",
+              "name": "Crusher"
+            },
+            {
+              "type": "structure",
+              "id": "statue-of-power",
+              "name": "Statue of Power"
+            }
+          ]
         }
       ]
     },

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -22509,11 +22509,12 @@
         "Ambush Helzephyr patrols for rare Medium Pal Soul drops",
         "Clear Sakurajima Sootseer camps for guaranteed Medium Pal Souls",
         "Loot Desiccated Desert treasure chests for loose Medium Pal Souls",
-        "Convert excess Small or Large souls in the Crusher to balance demand"
+        "Convert excess Small or Large souls in the Crusher to balance demand",
+        "Automate Crusher conversions so Statue of Power queues stay buffered"
       ],
       "estimated_time_minutes": {
-        "solo": 45,
-        "coop": 32
+        "solo": 50,
+        "coop": 36
       },
       "estimated_xp_gain": {
         "min": 480,
@@ -22582,6 +22583,17 @@
           ],
           "related_steps": [
             "resource-medium-pal-soul:004"
+          ]
+        },
+        {
+          "id": "resource-medium-pal-soul:checkpoint-automation",
+          "summary": "Crusher automation tuned",
+          "benefits": [
+            "Watering pals assigned",
+            "Small-to-medium cycle stabilized"
+          ],
+          "related_steps": [
+            "resource-medium-pal-soul:005"
           ]
         }
       ],
@@ -22794,7 +22806,7 @@
           "step_id": "resource-medium-pal-soul:004",
           "type": "craft",
           "summary": "Convert souls at the Crusher",
-          "detail": "Feed surplus Small Pal Souls into the Crusher for Medium conversions and down-convert spare Large souls when raids oversupply them, keeping the statue queue flush before raid prep sessions.【palwiki-medium-pal-soul-raw†L31-L42】",
+          "detail": "Assign at least two Watering pals to the Crusher so it continually swaps 2 Small Pal Souls into 1 Medium and breaks down Large souls when raids overflow, letting you balance supply without leaving base.【palwiki-crusher-raw†L15-L48】【palwiki-medium-pal-soul-raw†L33-L42】",
           "targets": [
             {
               "kind": "item",
@@ -22837,9 +22849,78 @@
               "statue-upgrades": true
             }
           },
-          "branching": [],
+          "branching": [
+            {
+              "subroute_ref": "resource-small-pal-soul"
+            }
+          ],
           "citations": [
+            "palwiki-crusher-raw",
             "palwiki-medium-pal-soul-raw"
+          ]
+        },
+        {
+          "step_id": "resource-medium-pal-soul:005",
+          "type": "build",
+          "summary": "Wire Crusher automation into the Statue loop",
+          "detail": "Stage storage beside the Crusher and Statue of Power, keep Watering pals working the Crusher, and task a Transporting pal to ferry Small and Large souls so every four Small souls cycle into two Medium before upgrade sessions.【palwiki-crusher-raw†L15-L48】【palwiki-statue-of-power†L3-L12】【palwiki-small-pal-soul†L3-L6】",
+          "targets": [
+            {
+              "kind": "structure",
+              "id": "crusher"
+            },
+            {
+              "kind": "structure",
+              "id": "statue-of-power"
+            }
+          ],
+          "locations": [
+            {
+              "region_id": "base",
+              "coords": [
+                0,
+                0
+              ],
+              "time": "any",
+              "weather": "any"
+            }
+          ],
+          "mode_adjustments": {
+            "coop": {
+              "tactics": "Have one player babysit Crusher queues while the other runs deliveries, then swap duties when statue offerings refill.",
+              "mode_scope": [
+                "coop"
+              ]
+            }
+          },
+          "recommended_loadout": {
+            "gear": [],
+            "pals": [],
+            "consumables": []
+          },
+          "xp_award_estimate": {
+            "min": 40,
+            "max": 80
+          },
+          "outputs": {
+            "items": [
+              {
+                "item_id": "medium-pal-soul",
+                "qty": 8
+              }
+            ],
+            "pals": [],
+            "unlocks": {}
+          },
+          "branching": [
+            {
+              "subroute_ref": "resource-small-pal-soul"
+            }
+          ],
+          "citations": [
+            "palwiki-crusher-raw",
+            "palwiki-statue-of-power",
+            "palwiki-small-pal-soul"
           ]
         }
       ],
@@ -22854,11 +22935,12 @@
         "levels_estimate": "+1 to +2",
         "key_unlocks": [
           "medium-pal-soul-buffer",
-          "statue-upgrade-pipeline"
+          "statue-upgrade-pipeline",
+          "crusher-automation"
         ]
       },
       "metrics": {
-        "progress_segments": 4,
+        "progress_segments": 5,
         "boss_targets": 0,
         "quest_nodes": 0
       },
@@ -30651,6 +30733,27 @@
                 "palwiki-medium-pal-soul-raw",
                 "palfandom-medium-pal-soul-raw",
                 "palwiki-crusher-pal-soul-conversion"
+              ]
+            },
+            {
+              "order": 4,
+              "instruction": "Stage a **Crusher and Statue of Power loop** at base, keep Watering pals on the Crusher, and shuttle Small or Large souls into Medium stock before each upgrade batch.",
+              "citations": [
+                "palwiki-crusher-raw",
+                "palwiki-statue-of-power",
+                "palwiki-small-pal-soul"
+              ],
+              "links": [
+                {
+                  "type": "structure",
+                  "id": "crusher",
+                  "name": "Crusher"
+                },
+                {
+                  "type": "structure",
+                  "id": "statue-of-power",
+                  "name": "Statue of Power"
+                }
               ]
             }
           ]

--- a/guides.md
+++ b/guides.md
@@ -14829,11 +14829,12 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
     "Ambush Helzephyr patrols for rare Medium Pal Soul drops",
     "Clear Sakurajima Sootseer camps for guaranteed Medium Pal Souls",
     "Loot Desiccated Desert treasure chests for loose Medium Pal Souls",
-    "Convert excess Small or Large souls in the Crusher to balance demand"
+    "Convert excess Small or Large souls in the Crusher to balance demand",
+    "Automate Crusher conversions so Statue of Power queues stay buffered"
   ],
   "estimated_time_minutes": {
-    "solo": 45,
-    "coop": 32
+    "solo": 50,
+    "coop": 36
   },
   "estimated_xp_gain": {
     "min": 480,
@@ -14902,6 +14903,17 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
       ],
       "related_steps": [
         "resource-medium-pal-soul:004"
+      ]
+    },
+    {
+      "id": "resource-medium-pal-soul:checkpoint-automation",
+      "summary": "Crusher automation tuned",
+      "benefits": [
+        "Watering pals assigned",
+        "Small-to-medium cycle stabilized"
+      ],
+      "related_steps": [
+        "resource-medium-pal-soul:005"
       ]
     }
   ],
@@ -15114,7 +15126,7 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
       "step_id": "resource-medium-pal-soul:004",
       "type": "craft",
       "summary": "Convert souls at the Crusher",
-      "detail": "Feed surplus Small Pal Souls into the Crusher for Medium conversions and down-convert spare Large souls when raids oversupply them, keeping the statue queue flush before raid prep sessions.【palwiki-medium-pal-soul-raw†L31-L42】",
+      "detail": "Assign at least two Watering pals to the Crusher so it continually swaps 2 Small Pal Souls into 1 Medium and breaks down Large souls when raids overflow, letting you balance supply without leaving base.【palwiki-crusher-raw†L15-L48】【palwiki-medium-pal-soul-raw†L33-L42】",
       "targets": [
         {
           "kind": "item",
@@ -15157,9 +15169,78 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
           "statue-upgrades": true
         }
       },
-      "branching": [],
+      "branching": [
+        {
+          "subroute_ref": "resource-small-pal-soul"
+        }
+      ],
       "citations": [
+        "palwiki-crusher-raw",
         "palwiki-medium-pal-soul-raw"
+      ]
+    },
+    {
+      "step_id": "resource-medium-pal-soul:005",
+      "type": "build",
+      "summary": "Wire Crusher automation into the Statue loop",
+      "detail": "Stage storage beside the Crusher and Statue of Power, keep Watering pals working the Crusher, and task a Transporting pal to ferry Small and Large souls so every four Small souls cycle into two Medium before upgrade sessions.【palwiki-crusher-raw†L15-L48】【palwiki-statue-of-power†L3-L12】【palwiki-small-pal-soul†L3-L6】",
+      "targets": [
+        {
+          "kind": "structure",
+          "id": "crusher"
+        },
+        {
+          "kind": "structure",
+          "id": "statue-of-power"
+        }
+      ],
+      "locations": [
+        {
+          "region_id": "base",
+          "coords": [
+            0,
+            0
+          ],
+          "time": "any",
+          "weather": "any"
+        }
+      ],
+      "mode_adjustments": {
+        "coop": {
+          "tactics": "Have one player babysit Crusher queues while the other runs deliveries, then swap duties when statue offerings refill.",
+          "mode_scope": [
+            "coop"
+          ]
+        }
+      },
+      "recommended_loadout": {
+        "gear": [],
+        "pals": [],
+        "consumables": []
+      },
+      "xp_award_estimate": {
+        "min": 40,
+        "max": 80
+      },
+      "outputs": {
+        "items": [
+          {
+            "item_id": "medium-pal-soul",
+            "qty": 8
+          }
+        ],
+        "pals": [],
+        "unlocks": {}
+      },
+      "branching": [
+        {
+          "subroute_ref": "resource-small-pal-soul"
+        }
+      ],
+      "citations": [
+        "palwiki-crusher-raw",
+        "palwiki-statue-of-power",
+        "palwiki-small-pal-soul"
       ]
     }
   ],
@@ -15174,11 +15255,12 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
     "levels_estimate": "+1 to +2",
     "key_unlocks": [
       "medium-pal-soul-buffer",
-      "statue-upgrade-pipeline"
+      "statue-upgrade-pipeline",
+      "crusher-automation"
     ]
   },
   "metrics": {
-    "progress_segments": 4,
+    "progress_segments": 5,
     "boss_targets": 0,
     "quest_nodes": 0
   },
@@ -26089,6 +26171,12 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/wiki/Crusher",
       "access_date": "2025-10-17",
       "notes": "Lists Crusher recipes converting Small to Medium, Medium to Large, and Giant to Large Pal Souls.\u3010palwiki-crusher\u2020L159-L179\u3011"
+    },
+    "palwiki-crusher-raw": {
+      "title": "Crusher \u2013 Palworld Wiki (Fandom)",
+      "url": "https://palworld.fandom.com/wiki/Crusher?action=raw",
+      "access_date": "2025-11-15",
+      "notes": "Raw article confirms Crusher requires Watering pals and details Pal Soul conversions such as 2 Small to 1 Medium and 1 Large to 2 Medium souls.【palwiki-crusher-raw†L15-L48】"
     },
     "palwiki-crusher-pal-soul-conversion": {
       "title": "Crusher \u2013 Palworld Wiki (rendered)",

--- a/sources/palwiki-crusher-raw.txt
+++ b/sources/palwiki-crusher-raw.txt
@@ -1,0 +1,80 @@
+{{Infobox_Item
+|image = Crusher.png
+|type = Production
+|rarity = 
+|source = build
+|points_cost = 2
+|materials = 50 {{i|Wood}}<br/>20 {{i|Stone}}<br/>10 {{i|Paldium Fragment}}
+|tech_type = tech
+|tech_tier = 8}}
+'''Crusher''' is a structure in {{PW}}.
+
+It can be unlocked at level 8 for 2 [[Technology]] points.
+
+==Usage==
+It requires pals with the {{i|Watering}} trait to work. It processes various materials into certain others, such as converting Wood and Stone to [[Fiber]] and [[Paldium Fragment|Paldium Fragments]] respectively.
+{| class="fandom-table"
+!Input
+!Output 
+|-
+|1 {{i|Wood}}
+|2 {{I|Fiber}}
+|-
+|5 {{i|Stone}}
+|1 {{i|Paldium Fragment}}
+|-
+|1 {{I|Meteorite Fragment}}
+|3 {{I|Paldium Fragment}}
+|-
+|2 {{I|Ore}}
+|1 {{I|Paldium Fragment}}
+|-
+|1 {{i|Medium Pal Soul}}
+|2 {{i|Small Pal Soul}}
+|-
+|2 {{i|Small Pal Soul}}
+|1 {{i|Medium Pal Soul}}
+|-
+|1 {{i|Large Pal Soul}}
+|2 {{i|Medium Pal Soul}}
+|-
+|2 {{i|Medium Pal Soul}}
+|1 {{i|Large Pal Soul}}
+|-
+|2 {{I|Large Pal Soul}}
+|1 {{I|Giant Pal Soul}}
+|-
+|1 {{I|Giant Pal Soul}}
+|2 {{I|Large Pal Soul}}
+|-
+|1 {{I|Pal Sphere}}
+|1 {{I|Paldium Fragment}}
+|-
+|1 {{I|Mega Sphere}}
+|1 {{I|Paldium Fragment}}
+|-
+|1 {{I|Giga Sphere}}
+|2 {{I|Paldium Fragment}}
+|-
+|1 {{I|Hyper Sphere}}
+|3 {{I|Paldium Fragment}}
+|-
+|1 {{I|Ultra Sphere}}
+|5 {{I|Paldium Fragment}}
+|-
+|1 {{I|Legendary Sphere}}
+|10 {{I|Paldium Fragment}}
+|-
+|1 {{I|Ultimate Sphere}}
+|20 {{I|Paldium Fragment}}
+|-
+|1 {{I|Exotic Sphere}}
+|30 {{I|Paldium Fragment}}
+|}
+
+== Update History==
+* [[Early Access 0.2.0.6]]
+** You can now crush {{i|Small Pal Soul}}, {{i|Medium Pal Soul}} and {{i|Large Pal Soul}}.
+*[[Early Access 0.1.2.0]]
+**Introduced.
+[[Category:Structures]]


### PR DESCRIPTION
## Summary
- expand the `resource-medium-pal-soul` route with a Crusher automation objective, checkpoint, and base-wiring step plus a new `crusher-automation` key unlock
- update the shortage catalog entry to add a fourth step covering the Crusher/Statue loop and cite the new Crusher raw source
- register the supporting Crusher raw citation file and document the automation handoff in `agent.md`

## Testing
- jq empty data/guides.bundle.json
- jq empty data/guide_catalog.json

------
https://chatgpt.com/codex/tasks/task_e_68e048898bfc83318c0b7738020948ae