### PR TITLE
Add resource coverage diff tool and document next steps

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -196,3 +196,13 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Secure at least one overworld spawn citation with coordinates for repeatable Caprity hunts (interactive map export or atlas scrape) so the route can anchor a farming loop instead of relying on anecdotal positions.
 2. Cross-check sanctuary and ranch outputs for Caprity Noct to confirm whether nocturnal variants deliver meat alongside venom so the route can branch into automation once location data lands.
 3. Once coordinates are sourced, draft the `resource-caprity-meat` route with early capture, alpha clears, and ranch processing before wiring it into `data/guides.bundle.json` and `data/guide_catalog.json`.
+
+### 2025-11-17 Coverage diagnostics automation
+
+* Added `scripts/resource_coverage_report.py` to diff resource routes in `guides.md` against `data/guide_catalog.json`, producing a concise list of catalog entries that still lack JSON coverage (or vice versa). Running the tool shows the catalog is complete but highlights four existing resource routes (`resource-leather-early`, `resource-paldium`, `resource-honey`, `resource-coal`) that never received shortage cards, so shortages UI still treats them as gaps.【scripts/resource_coverage_report.py†L1-L109】【2890e0†L1-L9】
+
+**Continuation notes:**
+
+1. Backfill catalog records for the four orphaned resource routes so the shortages drawer can surface them; ensure `shortage_menu: true` where appropriate and re-export bundles.
+2. Extend the script to optionally emit CSV/markdown output so progress snapshots can drop directly into PR descriptions and Ops dashboards.
+3. Expand the detector with citation linting (e.g., flag resource routes missing at least two independent sources) once coordinate exports for Caprity/Galeclaw land, so future backlog passes can validate evidence alongside coverage.

--- a/scripts/resource_coverage_report.py
+++ b/scripts/resource_coverage_report.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate a coverage report for shortage resource guides.
+
+The script inspects guides.md for resource routes, loads the guide
+catalog metadata, and compares the two lists. It surfaces resources
+missing full route JSON, catalog entries, or both so the agent can
+prioritise new work quickly.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Set
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUIDES_PATH = REPO_ROOT / "guides.md"
+CATALOG_PATH = REPO_ROOT / "data" / "guide_catalog.json"
+
+ROUTE_BLOCK_PATTERN = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ResourceRoute:
+    route_id: str
+    title: str
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    entry_id: str
+    title: str
+    shortage_menu: bool
+
+
+def parse_resource_routes(markdown: str) -> List[ResourceRoute]:
+    routes: List[ResourceRoute] = []
+    for match in ROUTE_BLOCK_PATTERN.finditer(markdown):
+        block = match.group(1)
+        try:
+            payload = json.loads(block)
+        except json.JSONDecodeError:
+            # Skip malformed blocks but continue scanning remaining content.
+            continue
+        route_id = payload.get("route_id")
+        if isinstance(route_id, str) and route_id.startswith("resource-"):
+            title = payload.get("title", "")
+            routes.append(ResourceRoute(route_id=route_id, title=title))
+    return routes
+
+
+def load_catalog_entries() -> List[CatalogEntry]:
+    catalog = json.loads(CATALOG_PATH.read_text())
+    entries: List[CatalogEntry] = []
+    for section in catalog.get("sections", []):
+        for item in section.get("entries", []):
+            entry_id = item.get("id")
+            if not isinstance(entry_id, str):
+                continue
+            if not entry_id.startswith("resource-"):
+                continue
+            entries.append(
+                CatalogEntry(
+                    entry_id=entry_id,
+                    title=item.get("title", ""),
+                    shortage_menu=bool(item.get("shortage_menu", False)),
+                )
+            )
+    return entries
+
+
+def format_report(missing_routes: Iterable[CatalogEntry], missing_catalog: Iterable[ResourceRoute]) -> str:
+    lines = ["Resource Coverage Report"]
+    lines.append("========================\n")
+
+    missing_route_list = list(missing_routes)
+    if missing_route_list:
+        lines.append("Catalog entries without matching routes:")
+        for entry in missing_route_list:
+            status = "shortage-menu" if entry.shortage_menu else "catalog-only"
+            lines.append(f"  - {entry.entry_id} ({entry.title or 'untitled'}) [{status}]")
+    else:
+        lines.append("All catalogued resources have matching routes.")
+
+    lines.append("")
+
+    missing_catalog_list = list(missing_catalog)
+    if missing_catalog_list:
+        lines.append("Routes missing catalog entries:")
+        for route in missing_catalog_list:
+            lines.append(f"  - {route.route_id} ({route.title or 'untitled'})")
+    else:
+        lines.append("All resource routes are present in the catalog.")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    markdown = GUIDES_PATH.read_text(encoding="utf-8")
+    routes = parse_resource_routes(markdown)
+    entries = load_catalog_entries()
+
+    route_ids: Set[str] = {route.route_id for route in routes}
+    catalog_ids: Set[str] = {entry.entry_id for entry in entries}
+
+    missing_routes = [entry for entry in entries if entry.entry_id not in route_ids]
+    missing_catalog = [route for route in routes if route.route_id not in catalog_ids]
+
+    report = format_report(missing_routes, missing_catalog)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `resource_coverage_report.py` to compare resource routes in `guides.md` against shortage catalog entries
- log the diagnostic results and follow-up actions in `agent.md` to guide coverage work

## Testing
- scripts/resource_coverage_report.py


------
https://chatgpt.com/codex/tasks/task_e_68e056b46c7c833192d1201bbae787a5