### PR TITLE
Add shortage catalog entries and align coverage report

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -206,3 +206,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Backfill catalog records for the four orphaned resource routes so the shortages drawer can surface them; ensure `shortage_menu: true` where appropriate and re-export bundles.
 2. Extend the script to optionally emit CSV/markdown output so progress snapshots can drop directly into PR descriptions and Ops dashboards.
 3. Expand the detector with citation linting (e.g., flag resource routes missing at least two independent sources) once coordinate exports for Caprity/Galeclaw land, so future backlog passes can validate evidence alongside coverage.
+
+### 2025-11-18 Resource shortage catalog backfill
+
+* Inserted shortage catalog entries for `resource-leather-early`, `resource-paldium`, `resource-honey`, and `resource-coal` inside `data/guide_catalog.json` and the mirrored bundle payload so the shortages UI can surface the early-game leather loop, Paldium fragment circuit, Honey ranch automation, and Coal smelter prep alongside newer additions.  Entries preserve the same spawn, merchant, and processing citations used in the full routes so cross-links stay authoritative.【data/guide_catalog.json†L8597-L8884】【data/guides.bundle.json†L24782-L25131】
+* Updated the bundle metadata `verified_at_utc` to `2025-11-18T00:00:00Z` and bumped the catalog `guide_count` to 203 to reflect the expanded coverage snapshot.【data/guides.bundle.json†L2-L9】【data/guides.bundle.json†L24780-L24788】
+* Hardened `scripts/resource_coverage_report.py` so it recognises both the legacy `sections[].entries[]` structure and the current flat `guides[]` layout, preventing false positives now that the shortage catalog omits the old section wrapper.【scripts/resource_coverage_report.py†L1-L118】
+
+**Continuation notes:**
+
+1. Use the refreshed coverage report to prioritise the remaining backlog of resource routes lacking catalog cards (e.g., wool, egg, refined ingot).  Draft catalog entries in batches so the shortages UI gains broad early/mid-game parity.
+2. Extend `resource_coverage_report.py` with optional CSV or Markdown exports to drop straight into Ops status threads once the remaining catalog debt shrinks.
+3. After the next bundle deployment, spot-check the production shortages drawer to confirm Leather, Paldium Fragments, Honey, and Coal disappear from `resourceGuideGaps`; if they linger, audit downstream ingestion for case-sensitivity or bundle cache issues.

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -8598,6 +8598,288 @@
       ]
     },
     {
+      "id": "resource-coal",
+      "title": "Coal Run & Smelter Prep",
+      "source_heading": "Coal Run & Smelter Prep",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player can’t craft Refined Ingots, gunpowder, or ammo because Coal reserves are empty.",
+      "keywords": [
+        "coal",
+        "hillside cavern",
+        "desiccated desert",
+        "refined ingot"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Clear **Hillside Cavern (147,-397)** northeast of the Rayne Syndicate Tower, mining every Coal vein before exiting to reset the nodes.",
+          "citations": [
+            "pcgamesn-coal"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "hillside-cavern",
+              "name": "Hillside Cavern",
+              "region": "Windswept Hills"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Rotate through the **Desiccated Desert** ridges and **Astral Mountain** foothills for faster-respawning Coal veins once you have higher-level gear.",
+          "citations": [
+            "pcgamesn-coal"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "desiccated-desert",
+              "name": "Desiccated Desert",
+              "region": "Desiccated Desert"
+            },
+            {
+              "type": "location",
+              "id": "astral-mountain",
+              "name": "Astral Mountain",
+              "region": "Astral Mountain"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Feed the haul into the **Improved Furnace or Crusher** at base to turn Coal and Ore into Refined Ingots before the next combat push.",
+          "citations": [
+            "palwiki-coal"
+          ],
+          "links": [
+            {
+              "type": "structure",
+              "id": "improved-furnace",
+              "name": "Improved Furnace"
+            },
+            {
+              "type": "structure",
+              "id": "crusher",
+              "name": "Crusher"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "resource-honey",
+      "title": "Honey Harvest Network",
+      "source_heading": "Honey Harvest Network",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player needs Honey for Cake, Strange Juice, or other cooking lines and lacks a steady stock.",
+      "keywords": [
+        "honey",
+        "cinnamoth",
+        "beegarde",
+        "ranch"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Teleport to **Cinnamoth Forest (-74,-279)** and capture the roaming Cinnamoth packs so each catch drops 6–8 Honey.",
+          "citations": [
+            "pcgamesn-honey"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "cinnamoth-forest",
+              "name": "Cinnamoth Forest",
+              "region": "Sea Breeze Archipelago"
+            },
+            {
+              "type": "pal",
+              "id": "cinnamoth",
+              "name": "Cinnamoth"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Push into **Mossanda Forest (234,-118)** to capture or defeat Beegarde squads and bank another dozen Honey plus workers for automation.",
+          "citations": [
+            "pcgamesn-honey"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "mossanda-forest",
+              "name": "Mossanda Forest",
+              "region": "Forest of Oblivion"
+            },
+            {
+              "type": "pal",
+              "id": "beegarde",
+              "name": "Beegarde"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Assign captured **Beegarde** to a Ranch so Honey trickles in passively between breeding batches and cake crafts.",
+          "citations": [
+            "pcgamesn-honey",
+            "palwiki-honey"
+          ],
+          "links": [
+            {
+              "type": "structure",
+              "id": "ranch",
+              "name": "Ranch"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "resource-leather-early",
+      "title": "Leather Farming Loop (Early)",
+      "source_heading": "Leather Farming Loop (Early)",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player needs Leather for early armor, saddles, or crafting upgrades and wants a fast refill loop.",
+      "keywords": [
+        "leather",
+        "foxparks",
+        "rushoar",
+        "merchant"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Fast travel to the **Sea Breeze Archipelago Church** or the **Bridge of the Twin Knights** and clear the dense Foxparks, Rushoar, and Fuack spawns for quick Leather drops.",
+          "citations": [
+            "shockbyte-leather-sources"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "sea-breeze-archipelago-church",
+              "name": "Sea Breeze Archipelago Church",
+              "region": "Sea Breeze Archipelago"
+            },
+            {
+              "type": "location",
+              "id": "bridge-of-the-twin-knights",
+              "name": "Bridge of the Twin Knights",
+              "region": "Windswept Hills"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Chain hunts of **Foxparks, Fuack, Rushoar, Melpaca, Vixy, Eikthyrdeer, and Direhowl**—each yields 1–3 Leather, especially when you counter their elements with water and electric pals.",
+          "citations": [
+            "shockbyte-leather-sources",
+            "eikthyrdeer-drops"
+          ],
+          "links": [
+            {
+              "type": "pal",
+              "id": "foxparks",
+              "name": "Foxparks"
+            },
+            {
+              "type": "pal",
+              "id": "eikthyrdeer",
+              "name": "Eikthyrdeer"
+            },
+            {
+              "type": "item",
+              "id": "leather",
+              "name": "Leather"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "If the loop stalls, buy Leather from the **Wandering Merchant** for about 150 Gold each before restocking spheres and returning to the hunt.",
+          "citations": [
+            "shockbyte-leather-merchant"
+          ],
+          "links": [
+            {
+              "type": "npc",
+              "id": "wandering-merchant",
+              "name": "Wandering Merchant"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "resource-paldium",
+      "title": "Paldium Fragment Mining Loop",
+      "source_heading": "Paldium Fragment Mining Loop",
+      "category": "Resources",
+      "category_group": "Resources & Crafting",
+      "shortage_menu": true,
+      "trigger": "Player is short on Paldium Fragments for Pal Spheres, tech unlocks, or crafting recipes.",
+      "keywords": [
+        "paldium fragment",
+        "mining",
+        "ore",
+        "primitive furnace"
+      ],
+      "steps": [
+        {
+          "order": 1,
+          "instruction": "Run the river south of the **Windswept Hills statue**, mining blue crystal nodes that respawn every few minutes for 2–4 fragments each.",
+          "citations": [
+            "palwiki-paldium"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "windswept-hills-river",
+              "name": "Windswept Hills River",
+              "region": "Windswept Hills"
+            }
+          ]
+        },
+        {
+          "order": 2,
+          "instruction": "Circle the northern cliffs and kick protruding Paldium crystals along the ridgeline to pull in another 30+ fragments per lap.",
+          "citations": [
+            "palwiki-paldium"
+          ],
+          "links": [
+            {
+              "type": "location",
+              "id": "windswept-hills-ridge",
+              "name": "Windswept Hills Ridge",
+              "region": "Windswept Hills"
+            }
+          ]
+        },
+        {
+          "order": 3,
+          "instruction": "Back at base, smelt Ore in the **Primitive Furnace** and crush leftovers so each batch refunds extra fragments before the next run.",
+          "citations": [
+            "palwiki-paldium"
+          ],
+          "links": [
+            {
+              "type": "structure",
+              "id": "primitive-furnace",
+              "name": "Primitive Furnace"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "resource-broncherry-meat",
       "title": "Broncherry Meat Caravan Loop",
       "source_heading": "Broncherry Meat Caravan Loop",

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -2,7 +2,7 @@
   "metadata": {
     "schema_version": 2,
     "game_version": "v0.6.7 (build 1.079.736)",
-    "verified_at_utc": "2025-11-13T00:00:00Z",
+    "verified_at_utc": "2025-11-18T00:00:00Z",
     "world_map_reference": "Palworld uses a two‑dimensional coordinate system where the X axis runs east–west and the Y axis runs north–south.  Coordinates may be positive or negative.  (0,0) lies near the initial spawn area on the main island.",
     "difficulty_modes": [
       "normal",
@@ -24779,7 +24779,7 @@
   },
   "guideCatalog": {
     "path": "data/guide_catalog.json",
-    "guide_count": 199,
+    "guide_count": 203,
     "fields": [
       "id",
       "title",
@@ -30753,6 +30753,288 @@
                   "type": "structure",
                   "id": "statue-of-power",
                   "name": "Statue of Power"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-coal",
+          "title": "Coal Run & Smelter Prep",
+          "source_heading": "Coal Run & Smelter Prep",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player can’t craft Refined Ingots, gunpowder, or ammo because Coal reserves are empty.",
+          "keywords": [
+            "coal",
+            "hillside cavern",
+            "desiccated desert",
+            "refined ingot"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Clear **Hillside Cavern (147,-397)** northeast of the Rayne Syndicate Tower, mining every Coal vein before exiting to reset the nodes.",
+              "citations": [
+                "pcgamesn-coal"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "hillside-cavern",
+                  "name": "Hillside Cavern",
+                  "region": "Windswept Hills"
+                }
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Rotate through the **Desiccated Desert** ridges and **Astral Mountain** foothills for faster-respawning Coal veins once you have higher-level gear.",
+              "citations": [
+                "pcgamesn-coal"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "desiccated-desert",
+                  "name": "Desiccated Desert",
+                  "region": "Desiccated Desert"
+                },
+                {
+                  "type": "location",
+                  "id": "astral-mountain",
+                  "name": "Astral Mountain",
+                  "region": "Astral Mountain"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Feed the haul into the **Improved Furnace or Crusher** at base to turn Coal and Ore into Refined Ingots before the next combat push.",
+              "citations": [
+                "palwiki-coal"
+              ],
+              "links": [
+                {
+                  "type": "structure",
+                  "id": "improved-furnace",
+                  "name": "Improved Furnace"
+                },
+                {
+                  "type": "structure",
+                  "id": "crusher",
+                  "name": "Crusher"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-honey",
+          "title": "Honey Harvest Network",
+          "source_heading": "Honey Harvest Network",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player needs Honey for Cake, Strange Juice, or other cooking lines and lacks a steady stock.",
+          "keywords": [
+            "honey",
+            "cinnamoth",
+            "beegarde",
+            "ranch"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Teleport to **Cinnamoth Forest (-74,-279)** and capture the roaming Cinnamoth packs so each catch drops 6–8 Honey.",
+              "citations": [
+                "pcgamesn-honey"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "cinnamoth-forest",
+                  "name": "Cinnamoth Forest",
+                  "region": "Sea Breeze Archipelago"
+                },
+                {
+                  "type": "pal",
+                  "id": "cinnamoth",
+                  "name": "Cinnamoth"
+                }
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Push into **Mossanda Forest (234,-118)** to capture or defeat Beegarde squads and bank another dozen Honey plus workers for automation.",
+              "citations": [
+                "pcgamesn-honey"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "mossanda-forest",
+                  "name": "Mossanda Forest",
+                  "region": "Forest of Oblivion"
+                },
+                {
+                  "type": "pal",
+                  "id": "beegarde",
+                  "name": "Beegarde"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Assign captured **Beegarde** to a Ranch so Honey trickles in passively between breeding batches and cake crafts.",
+              "citations": [
+                "pcgamesn-honey",
+                "palwiki-honey"
+              ],
+              "links": [
+                {
+                  "type": "structure",
+                  "id": "ranch",
+                  "name": "Ranch"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-leather-early",
+          "title": "Leather Farming Loop (Early)",
+          "source_heading": "Leather Farming Loop (Early)",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player needs Leather for early armor, saddles, or crafting upgrades and wants a fast refill loop.",
+          "keywords": [
+            "leather",
+            "foxparks",
+            "rushoar",
+            "merchant"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Fast travel to the **Sea Breeze Archipelago Church** or the **Bridge of the Twin Knights** and clear the dense Foxparks, Rushoar, and Fuack spawns for quick Leather drops.",
+              "citations": [
+                "shockbyte-leather-sources"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "sea-breeze-archipelago-church",
+                  "name": "Sea Breeze Archipelago Church",
+                  "region": "Sea Breeze Archipelago"
+                },
+                {
+                  "type": "location",
+                  "id": "bridge-of-the-twin-knights",
+                  "name": "Bridge of the Twin Knights",
+                  "region": "Windswept Hills"
+                }
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Chain hunts of **Foxparks, Fuack, Rushoar, Melpaca, Vixy, Eikthyrdeer, and Direhowl**—each yields 1–3 Leather, especially when you counter their elements with water and electric pals.",
+              "citations": [
+                "shockbyte-leather-sources",
+                "eikthyrdeer-drops"
+              ],
+              "links": [
+                {
+                  "type": "pal",
+                  "id": "foxparks",
+                  "name": "Foxparks"
+                },
+                {
+                  "type": "pal",
+                  "id": "eikthyrdeer",
+                  "name": "Eikthyrdeer"
+                },
+                {
+                  "type": "item",
+                  "id": "leather",
+                  "name": "Leather"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "If the loop stalls, buy Leather from the **Wandering Merchant** for about 150 Gold each before restocking spheres and returning to the hunt.",
+              "citations": [
+                "shockbyte-leather-merchant"
+              ],
+              "links": [
+                {
+                  "type": "npc",
+                  "id": "wandering-merchant",
+                  "name": "Wandering Merchant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "resource-paldium",
+          "title": "Paldium Fragment Mining Loop",
+          "source_heading": "Paldium Fragment Mining Loop",
+          "category": "Resources",
+          "category_group": "Resources & Crafting",
+          "shortage_menu": true,
+          "trigger": "Player is short on Paldium Fragments for Pal Spheres, tech unlocks, or crafting recipes.",
+          "keywords": [
+            "paldium fragment",
+            "mining",
+            "ore",
+            "primitive furnace"
+          ],
+          "steps": [
+            {
+              "order": 1,
+              "instruction": "Run the river south of the **Windswept Hills statue**, mining blue crystal nodes that respawn every few minutes for 2–4 fragments each.",
+              "citations": [
+                "palwiki-paldium"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "windswept-hills-river",
+                  "name": "Windswept Hills River",
+                  "region": "Windswept Hills"
+                }
+              ]
+            },
+            {
+              "order": 2,
+              "instruction": "Circle the northern cliffs and kick protruding Paldium crystals along the ridgeline to pull in another 30+ fragments per lap.",
+              "citations": [
+                "palwiki-paldium"
+              ],
+              "links": [
+                {
+                  "type": "location",
+                  "id": "windswept-hills-ridge",
+                  "name": "Windswept Hills Ridge",
+                  "region": "Windswept Hills"
+                }
+              ]
+            },
+            {
+              "order": 3,
+              "instruction": "Back at base, smelt Ore in the **Primitive Furnace** and crush leftovers so each batch refunds extra fragments before the next run.",
+              "citations": [
+                "palwiki-paldium"
+              ],
+              "links": [
+                {
+                  "type": "structure",
+                  "id": "primitive-furnace",
+                  "name": "Primitive Furnace"
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- add shortage menu cards for the leather, paldium, honey, and coal resource loops to the catalog and bundle
- refresh bundle metadata to reflect the new catalog count and verification timestamp
- update the resource coverage report to read both legacy sectioned catalogs and the current flat guide list, and record progress in agent notes

## Testing
- python scripts/resource_coverage_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e05ab2ab408331894da82c7865c753