### PR TITLE
Enhance respawn rotation guidance and coverage report exports

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -277,3 +277,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Layer in precise overworld coordinates for the recommended alpha and sealed realm rotations once sourced so Step :004 gains location-grade guidance.【F:guides.md†L25783-L25807】
 2. Gather empirical respawn timing data for desert ore and late-game biomes to see if additional banded advice is warranted in the route’s adaptive guidance.【F:guides.md†L25568-L25596】
 3. Smoke-test the shortages UI after the next bundle promotion to ensure the new mechanics card appears in the Stats & Mechanics filter with correct keywords and trigger text.【F:data/guides.bundle.json†L85-L140】
+
+### 2025-11-24 Respawn rotation detailing & reporting exports
+
+* Plotted Alpha Broncherry, Anubis, Bushi, and Penking coordinates plus respawn cadence notes directly inside Step :004 so planners can anchor daily and hourly loops without leaving the route.【F:guides.md†L25777-L25816】
+* Synced the shortage bundle and catalog instructions to the new coordinate guidance, updating citations so shortages mirror the route’s precise rotation advice.【F:data/guides.bundle.json†L107-L128】【F:data/guide_catalog.json†L7346-L7370】
+* Added `--format` and `--output` options to `resource_coverage_report.py`, enabling text, Markdown, or CSV exports for ops threads while preserving the default console summary.【F:scripts/resource_coverage_report.py†L1-L164】
+
+**Continuation notes:**
+
+1. Extend the coverage report with citation linting so resource routes missing two independent sources raise actionable warnings alongside the coverage diff.【F:scripts/resource_coverage_report.py†L114-L149】
+2. Consider serialising the new coordinate blocks into the bundle metadata for UI map overlays once design finalises the shortages tooltip layout.【F:guides.md†L25777-L25816】【F:data/guides.bundle.json†L107-L128】
+3. After the next data refresh, spot-check `--format markdown --output` exports to confirm automated Ops digests ingest without additional formatting fixes.【F:scripts/resource_coverage_report.py†L131-L149】

--- a/data/guide_catalog.json
+++ b/data/guide_catalog.json
@@ -7371,10 +7371,12 @@
         },
         {
           "order": 3,
-          "instruction": "Schedule overworld Alpha hunts on an in-game day cadence and plan Sealed Realm re-clears one hour after completion to keep rare drops flowing.",
+          "instruction": "Chain daily overworld clears on Alpha Broncherry (-222,-669) and Anubis (-134,-94), then book Bushi (-117,-490) and Penking (113,-353) Sealed Realms for one-hour resets so rare drops stay stocked.",
           "citations": [
-            "palwiki-alpha-pals†L8-L8",
-            "palwiki-sealed-realms†L76-L76"
+            "palwiki-alpha-pals†L98-L110",
+            "palwiki-alpha-pals†L281-L287",
+            "palwiki-sealed-realms†L29-L33",
+            "palwiki-sealed-realms†L59-L62"
           ]
         }
       ]

--- a/data/guides.bundle.json
+++ b/data/guides.bundle.json
@@ -134,10 +134,12 @@
             },
             {
               "order": 3,
-              "instruction": "Schedule overworld Alpha re-clears on an in-game day cadence and plan Sealed Realm runs one hour after completion so rare drops stay in rotation.",
+              "instruction": "Chain daily overworld clears on Alpha Broncherry (-222,-669) and Anubis (-134,-94), then set Bushi (-117,-490) and Penking (113,-353) Sealed Realms for one-hour resets to keep rare drops in rotation.",
               "citations": [
-                "palwiki-alpha-pals†L8-L8",
-                "palwiki-sealed-realms†L76-L76"
+                "palwiki-alpha-pals†L98-L110",
+                "palwiki-alpha-pals†L281-L287",
+                "palwiki-sealed-realms†L29-L33",
+                "palwiki-sealed-realms†L59-L62"
               ]
             }
           ]

--- a/guides.md
+++ b/guides.md
@@ -25777,9 +25777,50 @@ Resource Respawn Timer Field Guide maps the default 30-minute node respawns, doc
       "step_id": "resource-respawn-timers:004",
       "type": "plan",
       "summary": "Schedule dungeon and alpha resets",
-      "detail": "Add overworld alpha routes to your calendar on an in-game day cadence and pencil Sealed Realm re-clears for one hour after completion so rare drop farming stays on schedule.【palwiki-alpha-pals†L8-L8】【palwiki-sealed-realms†L76-L76】",
+      "detail": "Block daily overworld clears on Alpha Broncherry (-222,-669) and Anubis (-134,-94), then queue Bushi (-117,-490) and Penking (113,-353) Sealed Realms for their one-hour resets so rare drop rotations stay on schedule.【palwiki-alpha-pals†L98-L110】【palwiki-alpha-pals†L281-L287】【palwiki-sealed-realms†L29-L33】【palwiki-sealed-realms†L59-L62】",
       "targets": [],
-      "locations": [],
+      "locations": [
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            -222,
+            -669
+          ],
+          "time": "any",
+          "weather": "any",
+          "notes": "Alpha Broncherry respawns every in-game day."
+        },
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            -134,
+            -94
+          ],
+          "time": "any",
+          "weather": "any",
+          "notes": "Alpha Anubis respawns every in-game day."
+        },
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            -117,
+            -490
+          ],
+          "time": "any",
+          "weather": "any",
+          "notes": "Sealed Realm of the Swordmaster refreshes one hour after completion."
+        },
+        {
+          "region_id": "palpagos-overworld",
+          "coords": [
+            113,
+            -353
+          ],
+          "time": "any",
+          "weather": "any",
+          "notes": "Sealed Realm of the Frozen Wings refreshes one hour after completion."
+        }
+      ],
       "mode_adjustments": {},
       "recommended_loadout": {
         "gear": [],


### PR DESCRIPTION
## Summary
- add coordinate-rich guidance and locations to the resource respawn timers route and mirror the updates in the bundle and catalog
- extend the resource coverage report script with CLI output format selection and optional file export support
- record the new work and follow-up actions in the agent log for continuity

## Testing
- python scripts/resource_coverage_report.py
- python scripts/resource_coverage_report.py --format markdown
- python scripts/resource_coverage_report.py --format csv
- python scripts/resource_coverage_report.py --format markdown --output /tmp/coverage.md
- python scripts/resource_coverage_report.py --format csv --output /tmp/coverage.csv

------
https://chatgpt.com/codex/tasks/task_e_68e112aa048c833186a7062ecbcb7ebd