### PR TITLE
Refine resource shortage planner experience

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -289,3 +289,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Extend the coverage report with citation linting so resource routes missing two independent sources raise actionable warnings alongside the coverage diff.【F:scripts/resource_coverage_report.py†L114-L149】
 2. Consider serialising the new coordinate blocks into the bundle metadata for UI map overlays once design finalises the shortages tooltip layout.【F:guides.md†L25777-L25816】【F:data/guides.bundle.json†L107-L128】
 3. After the next data refresh, spot-check `--format markdown --output` exports to confirm automated Ops digests ingest without additional formatting fixes.【F:scripts/resource_coverage_report.py†L131-L149】
+
+### 2025-11-25 Resource shortages panel polish & coverage surfacing
+
+* Re-themed the route context “Resource shortages” block so it inherits the cosmic gradient, halo lighting, and stat chips used by Tonight’s Goals. The refreshed banner now spotlights total coverage, pending backlog, and the next queued resources while staying responsive on narrow layouts.【F:index.html†L14086-L14118】【F:css/styles.css†L401-L468】
+* Enriched the helper drawer with full guide cards that show level ranges, time estimates, and shortage notes pulled directly from adaptive guidance, replacing the old flat chip list. Each card opens the preview modal via existing interactions to keep the flow consistent.【F:index.html†L14326-L14474】【F:css/styles.css†L415-L447】
+* Wired chip badges and dropdown metadata into the coverage map so selected shortages show their matched guide counts, clarifying when a resource is fully supported versus queued for the backlog.【F:index.html†L14107-L14115】【F:index.html†L14480-L14492】【F:css/styles.css†L451-L462】
+
+**Continuation notes:**
+
+1. Plumb bundle metadata (e.g., recommended phases or art IDs) into the new helper cards so future revisions can render custom thumbnails without re-querying the main route lookup.
+2. Audit the `resourceGuideEntries` source once more routes adopt multi-step outputs; consider injecting explicit `primary_resource_id` metadata into the schema to avoid relying solely on output detection.
+3. Expand the backlog preview copy to surface more than two queued resources when the coverage debt grows, potentially with a tooltip that links back to the coverage report export.

--- a/css/styles.css
+++ b/css/styles.css
@@ -413,7 +413,50 @@ gba(119,141,169,0.45)}
 .route-goal-option__label{font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.92)}
 .route-goal-option--active{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 32px rgba(148,210,189,0.2);transform:translateY(-1px)}
 .route-goal-drawer--open .route-goal-drawer__surface{box-shadow:0 0 28px rgba(148,210,189,0.4);border-color:rgba(148,210,189,0.65)}
-.route-context__resources{display:grid;gap:10px}
+.route-context__field--resources{display:grid;gap:16px}
+.route-context__resources{display:grid;gap:12px}
+.route-context__resource-banner{display:flex;flex-wrap:wrap;align-items:center;gap:clamp(16px,2.6vw,24px);padding:18px 22px;border-radius:20px;background:linear-gradient(135deg,rgba(30,52,76,0.88),rgba(14,28,48,0.92));border:1px solid rgba(148,210,189,0.32);box-shadow:0 26px 48px rgba(0,0,0,0.55);position:relative;overflow:hidden}
+.route-context__resource-banner::before{content:"";position:absolute;inset:-45% auto auto -30%;width:220px;height:220px;background:radial-gradient(circle at center,rgba(148,210,189,0.35),transparent 72%);opacity:.35;pointer-events:none;animation:routeGlow 22s linear infinite}
+.route-context__resource-banner::after{content:"";position:absolute;inset:auto -30% -55% auto;width:200px;height:200px;background:radial-gradient(circle at center,rgba(119,141,169,0.28),transparent 70%);opacity:.3;pointer-events:none;animation:routeGlow 26s linear infinite reverse}
+.route-context__resource-banner>*{position:relative;z-index:1}
+.route-context__resource-icon{display:grid;place-items:center;width:58px;height:58px;border-radius:18px;background:rgba(148,210,189,0.2);color:rgba(224,255,244,0.92);box-shadow:0 18px 32px rgba(4,14,28,0.55);font-size:1.65rem}
+.route-context__resource-copy{display:flex;flex-direction:column;gap:6px;flex:1 1 240px;min-width:0}
+.route-context__resource-title{margin:0;font-size:1rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--light,#e0e1dd)}
+.route-context__resource-text{margin:0;font-size:.9rem;color:rgba(224,225,221,0.78)}
+.route-context__resource-next{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(148,210,189,0.18);border:1px solid rgba(148,210,189,0.35);font-size:.75rem;letter-spacing:.06em;text-transform:uppercase;color:rgba(224,255,244,0.85);width:max-content}
+.route-context__resource-stats{display:flex;flex-wrap:wrap;gap:12px;justify-content:flex-end}
+.route-context__resource-stat{display:flex;flex-direction:column;align-items:flex-end;gap:4px;padding:10px 16px;border-radius:16px;background:rgba(148,210,189,0.22);border:1px solid rgba(148,210,189,0.42);box-shadow:0 16px 28px rgba(0,0,0,0.45);min-width:120px}
+.route-context__resource-stat--pending{background:rgba(231,111,81,0.22);border-color:rgba(231,111,81,0.45)}
+.route-context__resource-stat--success{background:rgba(42,157,143,0.24);border-color:rgba(42,157,143,0.52)}
+.route-context__resource-stat-value{font-size:1.3rem;font-weight:700;color:var(--text,#f0f4f8);display:inline-flex;align-items:center;gap:6px}
+.route-context__resource-stat-value i{font-size:1.1rem;color:rgba(224,255,244,0.9)}
+.route-context__resource-stat-label{font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
+.route-context__resource-hint{display:grid;gap:12px;padding:16px 18px;border-radius:18px;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.38);box-shadow:0 20px 36px rgba(0,0,0,0.48)}
+.route-resource-guides{display:grid;gap:12px}
+.route-resource-guides--empty{gap:10px}
+.route-resource-guides__intro{margin:0;font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.85)}
+.route-resource-guides__intro--empty{color:rgba(224,225,221,0.72)}
+.route-resource-guides__hint{margin:0;font-size:.85rem;color:rgba(224,225,221,0.7)}
+.route-resource-guides__more{margin:0;font-size:.8rem;letter-spacing:.05em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
+.route-resource-guide-list{list-style:none;display:grid;gap:12px;margin:0;padding:0}
+.route-resource-guide-card{display:grid;gap:8px;width:100%;padding:16px 18px;border-radius:18px;border:1px solid rgba(148,210,189,0.32);background:linear-gradient(135deg,rgba(13,27,42,0.88),rgba(10,20,34,0.9));color:var(--text,#f0f4f8);text-align:left;font:inherit;cursor:pointer;transition:transform .2s ease,border-color .2s ease,box-shadow .25s ease}
+.route-resource-guide-card:hover,.route-resource-guide-card:focus-visible{transform:translateY(-1px);border-color:rgba(148,210,189,0.55);box-shadow:0 20px 36px rgba(148,210,189,0.22);outline:none}
+.route-resource-guide-card__header{display:flex;flex-wrap:wrap;align-items:flex-start;gap:10px;justify-content:space-between}
+.route-resource-guide-card__title{font-size:1rem;font-weight:700;letter-spacing:.03em;color:var(--light,#e0e1dd)}
+.route-resource-guide-card__meta{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
+.route-resource-guide-card__summary{margin:0;font-size:.9rem;color:rgba(224,225,221,0.78)}
+.route-resource-guide-card__notes{display:flex;flex-wrap:wrap;gap:8px}
+.route-resource-guide-card__note{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(148,210,189,0.18);border:1px solid rgba(148,210,189,0.32);font-size:.75rem;color:rgba(224,255,244,0.85)}
+.route-resource-guide-card__footer{display:flex;align-items:center;justify-content:flex-start}
+.route-resource-guide-card__cta{font-size:.8rem;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:rgba(224,225,221,0.75);display:inline-flex;align-items:center;gap:8px}
+.route-resource-guide-card__cta i{font-size:.85rem}
+.route-resource-chip__badge{display:inline-flex;align-items:center;justify-content:center;min-width:26px;padding:2px 8px;border-radius:999px;background:rgba(148,210,189,0.22);border:1px solid rgba(148,210,189,0.38);font-size:.72rem;font-weight:700;color:rgba(224,255,244,0.9)}
+@media (max-width:720px){
+  .route-context__resource-banner{flex-direction:column;align-items:flex-start;padding:18px 18px}
+  .route-context__resource-icon{width:52px;height:52px;font-size:1.4rem}
+  .route-context__resource-stats{width:100%;justify-content:flex-start}
+  .route-context__resource-stat{min-width:0}
+}
 .route-context__resource-add{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
 .route-context__resource-add select,.route-context__resource-add input{background:rgba(13,27,42,0.6);border:1px solid rgba(119,141,169,0.35);border-radius:10px;color:var(--text,#f0f4f8);padding:8px 12px;font-size:.95rem;min-width:160px;transition:border-color .2s ease,box-shadow .2s ease}
 .route-context__resource-add select{flex:2 1 220px}
@@ -425,16 +468,8 @@ gba(119,141,169,0.45)}
   .route-context__resource-add select,.route-context__resource-add input{min-width:0;width:100%}
   .route-context__resource-add-btn{width:100%}
 }
-.route-context__resource-hint{display:grid;gap:6px;font-size:.85rem;color:rgba(224,225,221,0.72)}
-.route-context__resource-hint-body{display:grid;gap:6px}
-.route-context__resource-hint-text{margin:0;font-size:.85rem;color:rgba(224,225,221,0.72)}
-.route-context__resource-hint-text--empty{color:rgba(224,225,221,0.55)}
-.route-context__resource-hint-list{display:flex;flex-wrap:wrap;gap:8px}
-.route-context__resource-hint-extra{align-self:center;font-size:.8rem;color:rgba(224,225,221,0.6)}
-.route-resource-guide-link{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;border:1px solid rgba(119,141,169,0.35);background:rgba(8,16,32,0.6);color:var(--text,#f0f4f8);font-size:.8rem;font-weight:600;cursor:pointer;transition:background .2s ease,border-color .2s ease}
-.route-resource-guide-link:hover,.route-resource-guide-link:focus-visible{background:rgba(119,141,169,0.25);border-color:rgba(119,141,169,0.55);outline:none}
 .route-context__resource-list{display:flex;flex-wrap:wrap;gap:8px}
-.route-resource-chip{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:999px;background:rgba(119,141,169,0.2);border:1px solid rgba(119,141,169,0.35);font-size:.85rem;font-weight:600;cursor:pointer}
+.route-resource-chip{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:999px;background:rgba(119,141,169,0.2);border:1px solid rgba(119,141,169,0.35);font-size:.85rem;font-weight:600;cursor:pointer;position:relative;overflow:hidden}
 .route-resource-chip__remove{font-weight:700;font-size:1rem}
 .route-resource-chip:hover{background:rgba(119,141,169,0.32)}
 .route-context__empty{margin:0;font-size:.9rem;color:rgba(224,225,221,0.68)}

--- a/index.html
+++ b/index.html
@@ -10721,10 +10721,26 @@
           ? Array.from(resourceRoutes.get(itemId))
           : [];
         const orderedRoutes = sortResourceGuideRoutes(routesForItem, routeLookup);
-        const entries = orderedRoutes.map(routeId => ({
-          id: routeId,
-          title: routeLookup?.[routeId]?.title || niceName(routeId)
-        }));
+        const entries = orderedRoutes.map(routeId => {
+          const routeEntry = routeLookup?.[routeId];
+          const objectives = Array.isArray(routeEntry?.objectives) ? routeEntry.objectives : [];
+          const shortages = Array.isArray(routeEntry?.adaptive_guidance?.resource_shortages)
+            ? routeEntry.adaptive_guidance.resource_shortages.filter(shortage => shortage && (shortage.solution || shortage.note))
+            : [];
+          return {
+            id: routeId,
+            title: routeEntry?.title || niceName(routeId),
+            level: routeEntry?.recommended_level || null,
+            levelLabel: formatLevelRangeLabel(routeEntry?.recommended_level) || '',
+            time: routeEntry?.estimated_time_minutes || null,
+            timeLabel: formatTimeLabel(routeEntry?.estimated_time_minutes) || '',
+            summary: objectives.length ? objectives[0] : '',
+            shortageNotes: shortages
+              .map(shortage => cleanGuideText(shortage.solution || shortage.note || ''))
+              .filter(Boolean)
+              .slice(0, 2)
+          };
+        });
         resourceGuides[itemId] = entries;
         if(!entries.length){
           missingResourceGuides.push(itemId);
@@ -14101,6 +14117,42 @@
       }
       const resourceOptions = Array.isArray(guide?.keyResources) ? guide.keyResources : [];
       const resourceGuideMap = guide?.resourceGuides || {};
+      const resourceGuideGaps = Array.isArray(guide?.resourceGuideGaps) ? guide.resourceGuideGaps : [];
+      const totalResources = resourceOptions.length;
+      let coveredResources = 0;
+      resourceOptions.forEach(itemId => {
+        const guides = Array.isArray(resourceGuideMap[itemId]) ? resourceGuideMap[itemId] : [];
+        if(guides.length){
+          coveredResources += 1;
+        }
+      });
+      const missingResources = Math.max(0, totalResources - coveredResources);
+      const backlogClass = missingResources
+        ? ' route-context__resource-stat--pending'
+        : ' route-context__resource-stat--success';
+      const backlogLabel = missingResources
+        ? (kidMode ? 'Coming soon' : 'Queued next')
+        : (kidMode ? 'All covered' : 'Backlog clear');
+      const backlogValueHtml = missingResources
+        ? escapeHTML(String(missingResources))
+        : '<i class="fa-solid fa-check" aria-hidden="true"></i>';
+      const coverageSummary = missingResources
+        ? (kidMode
+          ? `${coveredResources} guides ready · ${missingResources} coming soon`
+          : `${coveredResources} of ${totalResources} shortages wired · ${missingResources} queued next`)
+        : (kidMode
+          ? 'Guides ready for every tracked resource.'
+          : `Coverage complete for all ${coveredResources} tracked resources.`);
+      const backlogPreview = missingResources
+        ? resourceGuideGaps
+            .filter(itemId => resourceOptions.includes(itemId))
+            .slice(0, 2)
+            .map(itemId => itemDisplayName(itemId))
+            .filter(Boolean)
+        : [];
+      const backlogPreviewHtml = backlogPreview.length
+        ? `<span class="route-context__resource-next">${escapeHTML(kidMode ? `Next: ${backlogPreview.join(', ')}` : `Queued: ${backlogPreview.join(', ')}`)}</span>`
+        : '';
       const goalTiles = tags.length
         ? renderGoalDrawer(tags, context.goals)
         : `<p class="route-context__empty">${escapeHTML(kidMode ? 'Goals load soon.' : 'No goals available yet.')}</p>`;
@@ -14141,8 +14193,26 @@
               <label class="route-context__label">${escapeHTML(kidMode ? 'Goals' : 'Focus goals')}</label>
               <div class="route-context__goals">${goalTiles}</div>
             </div>
-            <div class="route-context__field">
+            <div class="route-context__field route-context__field--resources">
               <label class="route-context__label">${escapeHTML(kidMode ? 'Resource gaps' : 'Resource shortages')}</label>
+              <div class="route-context__resource-banner">
+                <div class="route-context__resource-icon" aria-hidden="true"><i class="fa-solid fa-seedling"></i></div>
+                <div class="route-context__resource-copy">
+                  <p class="route-context__resource-title">${escapeHTML(kidMode ? 'Match a farming route' : 'Match a farming route')}</p>
+                  <p class="route-context__resource-text">${escapeHTML(coverageSummary)}</p>
+                  ${backlogPreviewHtml}
+                </div>
+                <div class="route-context__resource-stats">
+                  <div class="route-context__resource-stat">
+                    <span class="route-context__resource-stat-value">${escapeHTML(String(coveredResources))}</span>
+                    <span class="route-context__resource-stat-label">${escapeHTML(kidMode ? 'Guides ready' : 'Guides ready')}</span>
+                  </div>
+                  <div class="route-context__resource-stat${backlogClass}">
+                    <span class="route-context__resource-stat-value">${backlogValueHtml}</span>
+                    <span class="route-context__resource-stat-label">${escapeHTML(backlogLabel)}</span>
+                  </div>
+                </div>
+              </div>
               <div class="route-context__resources">
                 <div class="route-context__resource-add">
                   <select id="routeResourceSelect">
@@ -14312,23 +14382,97 @@
 
     function renderResourceGuideHelp(itemId){
       const entries = resourceGuideEntries(itemId);
+      const guideGaps = new Set(Array.isArray(routeGuideData?.resourceGuideGaps) ? routeGuideData.resourceGuideGaps : []);
+      const allResources = Array.isArray(routeGuideData?.keyResources) ? routeGuideData.keyResources : [];
+      const totalTracked = allResources.length;
+      const coveredCount = Object.values(routeGuideData?.resourceGuides || {}).reduce((acc, list) => {
+        if(Array.isArray(list) && list.length){
+          return acc + 1;
+        }
+        return acc;
+      }, 0);
+      const missingCount = guideGaps.size;
       if(!itemId){
-        return `<p class="route-context__resource-hint-text">${escapeHTML(kidMode ? 'Pick a resource to see farming guides.' : 'Select a resource to see gathering guides.')}</p>`;
+        const intro = missingCount
+          ? (kidMode
+            ? `${coveredCount} guides ready · ${missingCount} on the way.`
+            : `${coveredCount} of ${totalTracked} shortages wired · ${missingCount} queued next.`)
+          : (kidMode
+            ? 'Every tracked shortage has a matching adventure.'
+            : `Every tracked shortage now has a matching plan. Pick one to dive in.`);
+        const prompt = kidMode
+          ? 'Choose a resource from the list above to see its guides.'
+          : 'Pick a resource from the list above to preview the matching farming plans.';
+        return `
+          <div class="route-resource-guides route-resource-guides--empty">
+            <p class="route-resource-guides__intro">${escapeHTML(intro)}</p>
+            <p class="route-resource-guides__hint">${escapeHTML(prompt)}</p>
+          </div>
+        `;
       }
       if(!entries.length){
-        return `<p class="route-context__resource-hint-text route-context__resource-hint-text--empty">${escapeHTML(kidMode ? 'No guide yet — more coming soon.' : 'No dedicated guide yet. Flag this for the next update!')}</p>`;
+        const queued = guideGaps.has(itemId);
+        const message = queued
+          ? (kidMode
+            ? 'This farming adventure is already on our to-do list. Check back after the next update!'
+            : 'This shortage is queued for the next coverage sprint. It will be published in the upcoming batch.')
+          : (kidMode
+            ? 'No guide yet — let a teammate know you need it!'
+            : 'No dedicated guide yet. Flag this shortage so the team can prioritise it.');
+        return `
+          <div class="route-resource-guides route-resource-guides--empty">
+            <p class="route-resource-guides__intro route-resource-guides__intro--empty">${escapeHTML(message)}</p>
+          </div>
+        `;
       }
-      const limited = entries.slice(0, 3);
-      const buttons = limited.map(entry => `<button type="button" class="chip route-resource-guide-link" data-resource-guide="${escapeHTML(entry.id)}">${escapeHTML(entry.title)}</button>`).join('');
+      const name = itemDisplayName(itemId);
+      const safeName = name ? escapeHTML(name) : escapeHTML('this resource');
+      const introLabel = kidMode ? 'Pick a guide to refill ' : 'Pick a plan to restock ';
+      const introHtml = `${escapeHTML(introLabel)}${safeName}.`;
+      const limited = entries.slice(0, 4);
+      const cards = limited.map(entry => {
+        const metaParts = [];
+        if(entry.levelLabel){
+          metaParts.push(entry.levelLabel);
+        }
+        if(entry.timeLabel){
+          metaParts.push(entry.timeLabel);
+        }
+        const meta = metaParts.length
+          ? `<span class="route-resource-guide-card__meta">${escapeHTML(metaParts.join(' • '))}</span>`
+          : '';
+        const summary = entry.summary
+          ? `<p class="route-resource-guide-card__summary">${escapeHTML(entry.summary)}</p>`
+          : '';
+        const notes = Array.isArray(entry.shortageNotes) && entry.shortageNotes.length
+          ? `<div class="route-resource-guide-card__notes">${entry.shortageNotes.map(note => `<span class="route-resource-guide-card__note">${escapeHTML(note)}</span>`).join('')}</div>`
+          : '';
+        const ctaLabel = kidMode ? 'Open plan' : 'Preview guide';
+        return `
+          <li>
+            <button type="button" class="route-resource-guide-card" data-resource-guide="${escapeHTML(entry.id)}">
+              <div class="route-resource-guide-card__header">
+                <span class="route-resource-guide-card__title">${escapeHTML(entry.title)}</span>
+                ${meta}
+              </div>
+              ${summary}
+              ${notes}
+              <div class="route-resource-guide-card__footer">
+                <span class="route-resource-guide-card__cta">${escapeHTML(ctaLabel)} <i class="fa-solid fa-arrow-right"></i></span>
+              </div>
+            </button>
+          </li>
+        `;
+      }).join('');
       const extra = entries.length - limited.length;
       const extraLabel = extra > 0
-        ? `<span class="route-context__resource-hint-extra">${escapeHTML(kidMode ? `+${extra} more guide${extra === 1 ? '' : 's'}` : `+${extra} more guide${extra === 1 ? '' : 's'}`)}</span>`
+        ? `<p class="route-resource-guides__more">${escapeHTML(kidMode ? `+${extra} more guide${extra === 1 ? '' : 's'} ready in the library.` : `+${extra} additional guide${extra === 1 ? '' : 's'} available in the library.`)}</p>`
         : '';
-      const intro = kidMode ? 'Guides that can help:' : 'Guides covering this resource:';
       return `
-        <div class="route-context__resource-hint-body">
-          <p class="route-context__resource-hint-text">${escapeHTML(intro)}</p>
-          <div class="route-context__resource-hint-list">${buttons}${extraLabel}</div>
+        <div class="route-resource-guides">
+          <p class="route-resource-guides__intro">${introHtml}</p>
+          <ul class="route-resource-guide-list">${cards}</ul>
+          ${extraLabel}
         </div>
       `;
     }
@@ -14338,11 +14482,15 @@
       if(!itemId) return '';
       const qty = entry?.qty != null ? Number(entry.qty) : null;
       const qtyLabel = qty != null && !Number.isNaN(qty) ? ` ×${qty}` : '';
-      const guideTitles = resourceGuideEntries(itemId).slice(0, 2).map(entry => entry.title);
+      const guidesForItem = resourceGuideEntries(itemId);
+      const guideTitles = guidesForItem.slice(0, 2).map(entry => entry.title);
       const titleAttr = guideTitles.length
         ? ` title="${escapeHTML((kidMode ? 'Guides: ' : 'Guides: ') + guideTitles.join(', '))}"`
         : '';
-      return `<button type="button" class="chip route-resource-chip" data-resource-id="${escapeHTML(itemId)}"${titleAttr}>${escapeHTML(itemDisplayName(itemId))}${escapeHTML(qtyLabel)}<span class="route-resource-chip__remove" aria-hidden="true">&times;</span></button>`;
+      const guideBadge = guidesForItem.length
+        ? `<span class="route-resource-chip__badge" aria-hidden="true">${escapeHTML(String(guidesForItem.length))}</span>`
+        : '';
+      return `<button type="button" class="chip route-resource-chip" data-resource-id="${escapeHTML(itemId)}"${titleAttr}>${escapeHTML(itemDisplayName(itemId))}${escapeHTML(qtyLabel)}${guideBadge}<span class="route-resource-chip__remove" aria-hidden="true">&times;</span></button>`;
     }
 
     let routeRecommendationsAbort = null;
@@ -14883,6 +15031,24 @@
         return steps.find(step => !routeState[step.id]) || null;
       }
       return null;
+    }
+
+    function formatLevelRangeLabel(level){
+      if(!level || typeof level !== 'object') return '';
+      const min = level.min != null ? Number(level.min) : null;
+      const max = level.max != null ? Number(level.max) : null;
+      const hasMin = Number.isFinite(min);
+      const hasMax = Number.isFinite(max);
+      if(hasMin && hasMax){
+        return `Lv ${min}-${max}`;
+      }
+      if(hasMin){
+        return `Lv ${min}+`;
+      }
+      if(hasMax){
+        return `Up to Lv ${max}`;
+      }
+      return '';
     }
 
     function formatTimeLabel(time){


### PR DESCRIPTION
## Summary
- Re-theme the resource shortages controls to match the cosmic card aesthetic and surface live coverage stats plus backlog previews
- Replace the flat helper chip list with rich guide cards that expose level ranges, time estimates, and shortage notes while keeping preview hooks intact
- Show guide coverage counts on selected shortage chips and document the UI polish plus follow-up tasks in `agent.md`

## Testing
- python scripts/resource_coverage_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e11c29bba08331a12ef4d765455d84