### PR TITLE
Add safe patch workflow for guides bundle edits

### DIFF
--- a/data/guides.bundle.patch.sample.json
+++ b/data/guides.bundle.patch.sample.json
@@ -1,0 +1,93 @@
+{
+  "metadata": {
+    "verified_at_utc": "2025-12-01T00:00:00Z"
+  },
+  "routes": {
+    "merge": {
+      "resource-paldium": {
+        "estimated_time_minutes": { "solo": 20, "coop": 15 }
+      }
+    },
+    "add": [
+      {
+        "route_id": "example-new-route",
+        "title": "Example Route",
+        "category": "resource",
+        "tags": ["example", "template"],
+        "progression_role": "template",
+        "recommended_level": {
+          "normal": { "min": 1, "max": 3 },
+          "hardcore": { "min": 1, "max": 3 }
+        },
+        "modes": { "normal": true, "hardcore": true, "solo": true, "coop": true },
+        "prerequisites": { "routes": [], "tech": [], "items": [], "pals": [] },
+        "objectives": ["Replace with actual objectives for the new content."],
+        "estimated_time_minutes": { "solo": 10, "coop": 8 },
+        "estimated_xp_gain": { "min": 120, "max": 180 },
+        "risk_profile": "low",
+        "failure_penalties": { "normal": "Describe material losses", "hardcore": "Describe permadeath handling" },
+        "adaptive_guidance": { "default": "Document dynamic adjustments once known." },
+        "checkpoints": [
+          {
+            "id": "example-new-route:checkpoint-1",
+            "summary": "Replace with checkpoint summary.",
+            "related_steps": ["example-new-route:001"],
+            "benefits": ["Document the tangible benefit of reaching this checkpoint."]
+          }
+        ],
+        "supporting_routes": {},
+        "failure_recovery": { "default": "Explain how to recover if a step fails." },
+        "steps": [
+          {
+            "step_id": "example-new-route:001",
+            "type": "instruction",
+            "summary": "Replace with the first actionable step.",
+            "detail": "Provide the detailed instructions, coordinates, and sourcing.",
+            "citations": [],
+            "branching": []
+          }
+        ],
+        "completion_criteria": [
+          { "type": "custom", "description": "State the actual completion trigger." }
+        ],
+        "yields": {
+          "levels_estimate": "Replace with XP estimate",
+          "resources": ["List notable resource gains"],
+          "key_unlocks": []
+        },
+        "metrics": { "notes": "Track metrics or additional context." },
+        "next_routes": []
+      }
+    ]
+  },
+  "guideCatalog": {
+    "set": {
+      "source": "patch-workflow"
+    },
+    "guides": {
+      "merge": {
+        "resource-paldium": {
+          "trigger": "Updated trigger copy"
+        }
+      },
+      "add": [
+        {
+          "id": "example-new-route",
+          "title": "Example Route",
+          "source_heading": "Patch Workflow",
+          "category": "resource",
+          "category_group": "template",
+          "trigger": "Use this entry as a template for new guides.",
+          "keywords": ["example", "template"],
+          "steps": [
+            "Document the real instructions for your new content.",
+            "Run scripts/update_guides_bundle.py with your patch file.",
+            "Validate with scripts/check_guides_bundle.py."
+          ],
+          "shortage_menu": false
+        }
+      ]
+    },
+    "expected_final_count": 240
+  }
+}

--- a/docs/guides-bundle-truncation-postmortem.md
+++ b/docs/guides-bundle-truncation-postmortem.md
@@ -36,5 +36,5 @@ While adding shortage coverage to `data/guides.bundle.json`, we overwrote the en
 
 ## Follow-Up Tasks
 - Automate a `scripts/check_guides_bundle.py --strict` mode that also validates a handful of route entries to ensure nested data survives edits.
-- Create a small helper script (`scripts/update_guide_catalog.py`) that handles bundle mutations atomically and leaves the original untouched if validation fails.
+- ✅ Replaced the ad-hoc helper with `scripts/update_guides_bundle.py`, which applies structured patches against a temporary copy, reuses the validator’s loss guard, and only swaps the live bundle after all checks pass.
 - Add CI coverage to block commits where `data/guides.bundle.json` shrinks below an expected minimum size or fails the strict validator.

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,27 @@ Contributions are welcome!  To add or update a route:
 4. **Sane level ranges** – Choose recommended level ranges that match the difficulty of the content.  Ensure Hardcore adjustments are present for dangerous encounters and that Co‑Op steps divide roles logically.
 5. **Update metadata** – If a new patch changes game mechanics (e.g. recipe ingredients), update the global metadata and affected routes.  Note the new game version and update `verified_at_utc`.
 
+### Patch-Based Editing Workflow
+
+Updating `data/guides.bundle.json` directly is painful and risky because the
+file is large and highly structured.  Use the new helper to stage changes in a
+small patch file and let the script merge them safely:
+
+```bash
+python scripts/update_guides_bundle.py path/to/your_patch.json --dry-run
+```
+
+The script loads the existing bundle, applies your patch (add, merge, replace
+or remove operations) and runs the same structural and loss guards as the
+validator.  Use `--dry-run` to confirm the diff and counts before writing; omit
+it once you are satisfied and, if appropriate, follow up with
+`--update-backup` to refresh the baseline snapshot.
+
+Patch files accept partial updates—for example, merging new copy into an
+existing route or appending a fresh guide catalog entry.  See
+`data/guides.bundle.patch.sample.json` for a template that demonstrates the
+supported operations and expected schema fragments.
+
 ### Bundle Integrity Checklist
 
 The fallback bundle at `data/guides.bundle.json` must remain a complete, parseable snapshot of the guide library.  Before pushing changes, run the automated guardrail:

--- a/scripts/update_guides_bundle.py
+++ b/scripts/update_guides_bundle.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Apply structured patches to ``data/guides.bundle.json`` safely."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_BUNDLE_PATH = REPO_ROOT / "data" / "guides.bundle.json"
+DEFAULT_BACKUP_PATH = REPO_ROOT / "data" / "Guide.bundle.backup.JSON"
+
+# Make ``scripts`` importable so we can reuse the validator helpers.
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_guides_bundle  # type: ignore  # noqa: E402
+
+
+class PatchError(RuntimeError):
+    """Raised when a patch payload is malformed."""
+
+
+@dataclass
+class PatchSummary:
+    """Human-readable summary of the applied operations."""
+
+    lines: list[str]
+
+    def add(self, message: str) -> None:
+        self.lines.append(message)
+
+    def extend(self, messages: Iterable[str]) -> None:
+        self.lines.extend(messages)
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience only
+        return bool(self.lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Apply a structured patch to data/guides.bundle.json without risking "
+            "wholesale data loss."
+        )
+    )
+    parser.add_argument(
+        "patch",
+        type=Path,
+        help="Path to the JSON patch describing the desired bundle edits.",
+    )
+    parser.add_argument(
+        "--bundle",
+        type=Path,
+        default=DEFAULT_BUNDLE_PATH,
+        help="Path to the bundle file to update (defaults to data/guides.bundle.json).",
+    )
+    parser.add_argument(
+        "--backup",
+        type=Path,
+        default=DEFAULT_BACKUP_PATH,
+        help=(
+            "Baseline snapshot used for loss detection (defaults to "
+            "data/Guide.bundle.backup.JSON)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the computed changes without writing the bundle to disk.",
+    )
+    parser.add_argument(
+        "--skip-guard",
+        action="store_true",
+        help="Skip the baseline loss guard (not recommended).",
+    )
+    parser.add_argument(
+        "--allow-route-removals",
+        action="store_true",
+        help="Permit removing existing routes when intentionally deprecating them.",
+    )
+    parser.add_argument(
+        "--allow-step-removals",
+        action="store_true",
+        help="Permit removing existing route steps when intentionally pruning them.",
+    )
+    parser.add_argument(
+        "--allow-guide-removals",
+        action="store_true",
+        help="Permit removing existing guide catalog entries when pruning them.",
+    )
+    parser.add_argument(
+        "--update-backup",
+        action="store_true",
+        help="Refresh the baseline snapshot after a successful write.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_patch_payload(patch: Any) -> dict[str, Any]:
+    if not isinstance(patch, dict):
+        raise PatchError("Patch payload must be a JSON object at the top level.")
+    return patch
+
+
+def ensure_section(bundle: dict[str, Any], key: str, expected_type: type) -> Any:
+    value = bundle.get(key)
+    if value is None:
+        if expected_type is dict:
+            value = {}
+        elif expected_type is list:
+            value = []
+        else:
+            value = expected_type()
+        bundle[key] = value
+    if not isinstance(value, expected_type):
+        raise PatchError(
+            f"Bundle section '{key}' must be a {expected_type.__name__}, found {type(value).__name__}."
+        )
+    return value
+
+
+def deep_merge(target: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            deep_merge(target[key], value)
+        else:
+            target[key] = value
+    return target
+
+
+def apply_indexed_list_patch(
+    *,
+    items: list[dict[str, Any]],
+    id_field: str,
+    ops: dict[str, Any],
+    entity_label: str,
+) -> list[str]:
+    summary: list[str] = []
+    index = {item[id_field]: idx for idx, item in enumerate(items)}
+
+    def rebuild_index() -> None:
+        index.clear()
+        index.update({item[id_field]: idx for idx, item in enumerate(items)})
+
+    if "remove" in ops:
+        removals = ops["remove"]
+        if not isinstance(removals, list):
+            raise PatchError(f"'{entity_label}.remove' must be a list of identifiers.")
+        missing = [identifier for identifier in removals if identifier not in index]
+        if missing:
+            raise PatchError(
+                f"Cannot remove {entity_label} entries that do not exist: {', '.join(missing)}"
+            )
+        to_remove = set(removals)
+        items[:] = [item for item in items if item[id_field] not in to_remove]
+        summary.append(f"Removed {len(to_remove)} {entity_label} entries.")
+        rebuild_index()
+
+    if "merge" in ops:
+        merges = ops["merge"]
+        if not isinstance(merges, dict):
+            raise PatchError(f"'{entity_label}.merge' must be an object keyed by identifier.")
+        for identifier, fragment in merges.items():
+            if identifier not in index:
+                raise PatchError(
+                    f"Cannot merge into unknown {entity_label} entry '{identifier}'."
+                )
+            if not isinstance(fragment, dict):
+                raise PatchError(
+                    f"Merge fragment for {entity_label} '{identifier}' must be an object."
+                )
+            deep_merge(items[index[identifier]], fragment)
+        summary.append(f"Merged updates into {len(merges)} {entity_label} entries.")
+
+    if "replace" in ops:
+        replacements = ops["replace"]
+        if not isinstance(replacements, list):
+            raise PatchError(f"'{entity_label}.replace' must be a list of objects.")
+        replaced = 0
+        for entry in replacements:
+            if not isinstance(entry, dict):
+                raise PatchError(
+                    f"Every object in '{entity_label}.replace' must be a dictionary."
+                )
+            identifier = entry.get(id_field)
+            if not isinstance(identifier, str) or not identifier:
+                raise PatchError(
+                    f"Replacement entries must include a non-empty '{id_field}'."
+                )
+            if identifier not in index:
+                raise PatchError(
+                    f"Cannot replace unknown {entity_label} entry '{identifier}'."
+                )
+            items[index[identifier]] = entry
+            replaced += 1
+        if replaced:
+            summary.append(f"Replaced {replaced} {entity_label} entries.")
+        rebuild_index()
+
+    if "add" in ops:
+        additions = ops["add"]
+        if not isinstance(additions, list):
+            raise PatchError(f"'{entity_label}.add' must be a list of objects.")
+        added = 0
+        for entry in additions:
+            if not isinstance(entry, dict):
+                raise PatchError(
+                    f"Every object in '{entity_label}.add' must be a dictionary."
+                )
+            identifier = entry.get(id_field)
+            if not isinstance(identifier, str) or not identifier:
+                raise PatchError(
+                    f"Added entries must include a non-empty '{id_field}'."
+                )
+            if identifier in index:
+                raise PatchError(
+                    f"Cannot add duplicate {entity_label} entry '{identifier}'."
+                )
+            items.append(entry)
+            index[identifier] = len(items) - 1
+            added += 1
+        if added:
+            summary.append(f"Added {added} new {entity_label} entries.")
+
+    return summary
+
+
+def apply_routes_patch(bundle: dict[str, Any], ops: dict[str, Any]) -> list[str]:
+    routes = ensure_section(bundle, "routes", list)
+    return apply_indexed_list_patch(
+        items=routes,
+        id_field="route_id",
+        ops=ops,
+        entity_label="route",
+    )
+
+
+def apply_catalog_patch(bundle: dict[str, Any], patch: dict[str, Any]) -> list[str]:
+    guide_catalog = ensure_section(bundle, "guideCatalog", dict)
+    summary: list[str] = []
+
+    if "set" in patch:
+        set_payload = patch["set"]
+        if not isinstance(set_payload, dict):
+            raise PatchError("'guideCatalog.set' must be an object.")
+        deep_merge(guide_catalog, set_payload)
+        summary.append("Updated guideCatalog metadata fields via merge.")
+
+    guides_ops = patch.get("guides")
+    if guides_ops is not None:
+        if not isinstance(guides_ops, dict):
+            raise PatchError("'guideCatalog.guides' must be an object describing operations.")
+        data = ensure_section(guide_catalog, "data", dict)
+        guides = ensure_section(data, "guides", list)
+        summary.extend(
+            apply_indexed_list_patch(
+                items=guides,
+                id_field="id",
+                ops=guides_ops,
+                entity_label="guide catalog",
+            )
+        )
+
+    expected_count = patch.get("expected_final_count")
+    guides_list = guide_catalog.get("data", {}).get("guides")
+    if isinstance(guides_list, list):
+        actual_count = len(guides_list)
+        guide_catalog["guide_count"] = actual_count
+        if expected_count is not None and expected_count != actual_count:
+            raise PatchError(
+                "guideCatalog.expected_final_count does not match the resulting "
+                f"guide count ({expected_count} expected vs {actual_count} actual)."
+            )
+    elif expected_count is not None:
+        raise PatchError("guideCatalog.data.guides must exist when asserting a final count.")
+
+    return summary
+
+
+def apply_generic_section(
+    bundle: dict[str, Any], key: str, payload: Any, summary: PatchSummary
+) -> None:
+    current = bundle.get(key)
+    if isinstance(payload, dict) and isinstance(current, dict):
+        deep_merge(current, payload)
+        summary.add(f"Merged updates into existing '{key}' section.")
+    else:
+        bundle[key] = payload
+        action = "Replaced" if current is not None else "Set"
+        summary.add(f"{action} bundle section '{key}'.")
+
+
+def apply_patch(bundle: dict[str, Any], patch: dict[str, Any]) -> PatchSummary:
+    summary = PatchSummary(lines=[])
+    for key, value in patch.items():
+        if key == "routes":
+            if not isinstance(value, dict):
+                raise PatchError("'routes' patch must be an object of operations.")
+            summary.extend(apply_routes_patch(bundle, value))
+        elif key == "guideCatalog":
+            if not isinstance(value, dict):
+                raise PatchError("'guideCatalog' patch must be an object of operations.")
+            summary.extend(apply_catalog_patch(bundle, value))
+        else:
+            apply_generic_section(bundle, key, value, summary)
+    return summary
+
+
+def format_summary(summary: PatchSummary) -> str:
+    if not summary.lines:
+        return "No changes were applied."
+    return "\n".join(f"- {line}" for line in summary.lines)
+
+
+def write_bundle(path: Path, serialized: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=path.parent) as handle:
+        handle.write(serialized)
+        temp_path = Path(handle.name)
+    shutil.move(str(temp_path), path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    bundle_path = args.bundle.resolve()
+    backup_path = args.backup.resolve()
+
+    if not bundle_path.exists():
+        print(f"Bundle missing at {bundle_path}", file=sys.stderr)
+        return 1
+
+    try:
+        bundle = load_json(bundle_path)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        print(f"Failed to parse bundle JSON: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        patch_payload = validate_patch_payload(load_json(args.patch))
+    except (json.JSONDecodeError, PatchError) as exc:
+        print(f"Patch file invalid: {exc}", file=sys.stderr)
+        return 1
+
+    working_bundle = deepcopy(bundle)
+
+    try:
+        summary = apply_patch(working_bundle, patch_payload)
+    except PatchError as exc:
+        print(f"Patch application failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        (
+            route_count,
+            guide_count,
+            current_route_ids,
+            current_guide_ids,
+            current_step_ids,
+        ) = check_guides_bundle.check_structure(working_bundle)
+    except ValueError as exc:
+        print(f"Resulting bundle is invalid: {exc}", file=sys.stderr)
+        return 1
+
+    serialized_text = json.dumps(working_bundle, indent=2, ensure_ascii=False) + "\n"
+    bundle_size = len(serialized_text.encode("utf-8"))
+
+    if not args.skip_guard:
+        try:
+            check_guides_bundle.guard_against_data_loss(
+                route_count=route_count,
+                guide_count=guide_count,
+                bundle_size=bundle_size,
+                backup_path=backup_path,
+                current_route_ids=current_route_ids,
+                current_guide_ids=current_guide_ids,
+                current_step_ids=current_step_ids,
+                allow_route_removals=args.allow_route_removals,
+                allow_guide_removals=args.allow_guide_removals,
+                allow_step_removals=args.allow_step_removals,
+            )
+        except ValueError as exc:
+            print(f"Loss guard failed: {exc}", file=sys.stderr)
+            return 1
+
+    print("Patch applied successfully:")
+    print(format_summary(summary))
+    print(
+        f"Resulting bundle stats: {route_count} routes, {guide_count} catalog entries, "
+        f"{bundle_size} bytes."
+    )
+
+    if args.dry_run:
+        print("Dry run requested; bundle not written.")
+        return 0
+
+    write_bundle(bundle_path, serialized_text)
+    print(f"Wrote updated bundle to {bundle_path}.")
+
+    if args.update_backup:
+        check_guides_bundle.refresh_backup(bundle_path, backup_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a scripts/update_guides_bundle.py helper that applies structured patches to the fallback bundle with validation and loss guards
- document the safer workflow in the README and note the completed action item in the truncation postmortem
- provide a guides.bundle.patch.sample.json template that demonstrates supported operations for future edits

## Testing
- python scripts/update_guides_bundle.py data/guides.bundle.patch.sample.json --dry-run
- python scripts/check_guides_bundle.py

------
https://chatgpt.com/codex/tasks/task_e_68e28a38d6a88331bf96903ed8d82db2