### PR TITLE
Add regression tests for coverage CSV output

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -448,3 +448,14 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Source a second coordinate-grade citation for the overworld Astegon and Blazamut hunts (interactive atlas, annotated video, or GameWith scrape) so sanctuary loop steps carry dual evidence instead of leaning on a single Fandom table.
 2. Document reliable merchant or quest sinks that specifically consume Precious Pelts; once confirmed, add an optional trade/sales step and update the catalog trigger text to spotlight downstream uses beyond raw gold.
 3. Audit other sanctuary-only sale items (Precious Claw, Precious Entrails) and queue follow-up routes so late-game currency loops cover the full set of rare drops.
+
+### 2025-12-14 Coverage tooling regression tests
+
+* Added `tests/test_resource_coverage_report.py` with unit coverage for the CSV formatter to ensure catalog gaps, citation warnings, coordinate debt, and exemption rows retain their schema and ordering when future policies land.【F:tests/test_resource_coverage_report.py†L1-L107】
+* Introduced a CLI smoke test that shells out to `scripts/resource_coverage_report.py --format csv` and validates the header layout, preventing regressions when the report output is consumed by dashboards or automation.【F:tests/test_resource_coverage_report.py†L59-L96】
+
+**Continuation notes:**
+
+1. Extend the regression suite to snapshot the Markdown output once the outstanding dual-source citations are in place; we can then gate text-mode changes behind explicit approvals.
+2. Wire the CSV tests into CI (GitHub Actions or the internal harness) so contributors receive fast feedback when changing `resource_coverage_report.py`.
+3. After securing second-source coordinates for Astral hunts, capture fixture data for those cases and broaden the CSV unit test to cover multi-step missing/exempt combinations drawn from real guide IDs.

--- a/tests/test_resource_coverage_report.py
+++ b/tests/test_resource_coverage_report.py
@@ -1,0 +1,158 @@
+import csv
+import io
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from scripts.resource_coverage_report import (
+    CatalogEntry,
+    ResourceRoute,
+    format_csv_report,
+)
+
+
+class FormatCsvReportTests(unittest.TestCase):
+    def test_format_csv_report_covers_all_sections(self) -> None:
+        missing_routes = [
+            CatalogEntry(
+                entry_id="resource-honey",
+                title="Honey Farming Loop",
+                shortage_menu=True,
+            )
+        ]
+        missing_catalog = [
+            ResourceRoute(
+                route_id="resource-pal-oil",
+                title="Oil Sweep",
+                citations=("palwiki-pal-oil",),
+                field_step_ids=("resource-pal-oil:001",),
+                missing_field_step_ids=(),
+                exempt_field_step_ids=(),
+            )
+        ]
+        citation_warnings = [
+            ResourceRoute(
+                route_id="resource-ore",
+                title="Ore Mining",
+                citations=(),
+                field_step_ids=("resource-ore:002",),
+                missing_field_step_ids=(),
+                exempt_field_step_ids=(),
+            )
+        ]
+        location_warnings = [
+            ResourceRoute(
+                route_id="resource-quartz",
+                title="Quartz Astral Ridge",
+                citations=("palwiki-quartz", "palfandom-quartz"),
+                field_step_ids=("resource-quartz:003", "resource-quartz:004"),
+                missing_field_step_ids=("resource-quartz:004",),
+                exempt_field_step_ids=(),
+            )
+        ]
+        location_exemptions = [
+            ResourceRoute(
+                route_id="resource-lifmunk-effigy",
+                title="Effigy Cleanup",
+                citations=("palwiki-effigy", "palfandom-effigy"),
+                field_step_ids=("resource-effigy:001",),
+                missing_field_step_ids=(),
+                exempt_field_step_ids=("resource-effigy:001",),
+            )
+        ]
+
+        csv_output = format_csv_report(
+            missing_routes,
+            missing_catalog,
+            citation_warnings,
+            location_warnings,
+            location_exemptions,
+        )
+
+        expected_rows = [
+            [
+                "type",
+                "id",
+                "title",
+                "shortage_menu",
+                "citation_count",
+                "missing_field_steps",
+            ],
+            [
+                "catalog_without_route",
+                "resource-honey",
+                "Honey Farming Loop",
+                "true",
+                "",
+                "",
+            ],
+            [
+                "route_without_catalog",
+                "resource-pal-oil",
+                "Oil Sweep",
+                "",
+                "1",
+                "",
+            ],
+            [
+                "route_citation_warning",
+                "resource-ore",
+                "Ore Mining",
+                "",
+                "0",
+                "",
+            ],
+            [
+                "route_missing_field_coords",
+                "resource-quartz",
+                "Quartz Astral Ridge",
+                "",
+                "2",
+                "resource-quartz:004",
+            ],
+            [
+                "route_field_coord_exempt",
+                "resource-lifmunk-effigy",
+                "Effigy Cleanup",
+                "",
+                "2",
+                "resource-effigy:001",
+            ],
+        ]
+
+        reader = csv.reader(io.StringIO(csv_output))
+        self.assertEqual(list(reader), expected_rows)
+
+
+class CliCsvOutputTests(unittest.TestCase):
+    def test_cli_emits_expected_header_and_shape(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        script_path = repo_root / "scripts" / "resource_coverage_report.py"
+        result = subprocess.run(
+            [sys.executable, str(script_path), "--format", "csv"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        output = result.stdout.strip()
+        reader = csv.reader(io.StringIO(output))
+        rows = list(reader)
+        self.assertGreaterEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0],
+            [
+                "type",
+                "id",
+                "title",
+                "shortage_menu",
+                "citation_count",
+                "missing_field_steps",
+            ],
+        )
+        for row in rows[1:]:
+            self.assertEqual(len(row), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression coverage for the CSV formatter so every row type retains its schema and ordering
- add a CLI smoke test that exercises `scripts/resource_coverage_report.py --format csv`
- log the new safeguards and next steps in `agent.md`

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e41717a7708331b5f66fc331d6276f