### PR TITLE
Enhance resource coverage dual-citation checks

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -459,3 +459,15 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Extend the regression suite to snapshot the Markdown output once the outstanding dual-source citations are in place; we can then gate text-mode changes behind explicit approvals.
 2. Wire the CSV tests into CI (GitHub Actions or the internal harness) so contributors receive fast feedback when changing `resource_coverage_report.py`.
 3. After securing second-source coordinates for Astral hunts, capture fixture data for those cases and broaden the CSV unit test to cover multi-step missing/exempt combinations drawn from real guide IDs.
+
+### 2025-12-15 Field step dual-citation audit tooling
+
+* Enhanced `scripts/resource_coverage_report.py` so each field step now tracks whether it carries at least two unique citations; the text, Markdown, and CSV outputs surface a dedicated "under-cited" section alongside coordinate gaps.【F:scripts/resource_coverage_report.py†L65-L111】【F:scripts/resource_coverage_report.py†L272-L447】
+* Expanded the CSV formatter and regression tests to capture the new column, row type, and CLI header expectations, keeping the coverage pipeline contract stable.【F:scripts/resource_coverage_report.py†L452-L543】【F:tests/test_resource_coverage_report.py†L1-L193】
+* Ran the refreshed report and confirmed 13 resource routes currently have under-cited field steps, giving us a prioritized queue for sourcing secondary location references.【b99cd4†L14-L26】
+
+**Continuation notes:**
+
+1. Work through the flagged routes, sourcing a second citation for each under-cited step (start with Leather, Honey, Coal, and Wool loops where community map exports already exist) and update the relevant guide steps plus source registry.
+2. Add a Markdown snapshot test once dual-citation remediation lands so the textual report layout remains locked as we iterate on coverage rules.
+3. Consider integrating the new under-cited signal into dashboards/CI alerts so future guide submissions lacking dual sourcing are caught immediately.

--- a/tests/test_resource_coverage_report.py
+++ b/tests/test_resource_coverage_report.py
@@ -29,6 +29,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 field_step_ids=("resource-pal-oil:001",),
                 missing_field_step_ids=(),
                 exempt_field_step_ids=(),
+                under_cited_field_step_ids=("resource-pal-oil:001",),
             )
         ]
         citation_warnings = [
@@ -39,6 +40,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 field_step_ids=("resource-ore:002",),
                 missing_field_step_ids=(),
                 exempt_field_step_ids=(),
+                under_cited_field_step_ids=("resource-ore:002",),
             )
         ]
         location_warnings = [
@@ -49,6 +51,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 field_step_ids=("resource-quartz:003", "resource-quartz:004"),
                 missing_field_step_ids=("resource-quartz:004",),
                 exempt_field_step_ids=(),
+                under_cited_field_step_ids=("resource-quartz:004",),
             )
         ]
         location_exemptions = [
@@ -59,6 +62,18 @@ class FormatCsvReportTests(unittest.TestCase):
                 field_step_ids=("resource-effigy:001",),
                 missing_field_step_ids=(),
                 exempt_field_step_ids=("resource-effigy:001",),
+                under_cited_field_step_ids=(),
+            )
+        ]
+        step_citation_warnings = [
+            ResourceRoute(
+                route_id="resource-leather",
+                title="Leather Farms",
+                citations=("palwiki-leather", "palfandom-leather"),
+                field_step_ids=("resource-leather:001", "resource-leather:002"),
+                missing_field_step_ids=(),
+                exempt_field_step_ids=(),
+                under_cited_field_step_ids=("resource-leather:001",),
             )
         ]
 
@@ -68,6 +83,7 @@ class FormatCsvReportTests(unittest.TestCase):
             citation_warnings,
             location_warnings,
             location_exemptions,
+            step_citation_warnings,
         )
 
         expected_rows = [
@@ -78,12 +94,14 @@ class FormatCsvReportTests(unittest.TestCase):
                 "shortage_menu",
                 "citation_count",
                 "missing_field_steps",
+                "under_cited_field_steps",
             ],
             [
                 "catalog_without_route",
                 "resource-honey",
                 "Honey Farming Loop",
                 "true",
+                "",
                 "",
                 "",
             ],
@@ -94,6 +112,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 "",
                 "1",
                 "",
+                "resource-pal-oil:001",
             ],
             [
                 "route_citation_warning",
@@ -102,6 +121,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 "",
                 "0",
                 "",
+                "resource-ore:002",
             ],
             [
                 "route_missing_field_coords",
@@ -109,6 +129,7 @@ class FormatCsvReportTests(unittest.TestCase):
                 "Quartz Astral Ridge",
                 "",
                 "2",
+                "resource-quartz:004",
                 "resource-quartz:004",
             ],
             [
@@ -118,6 +139,16 @@ class FormatCsvReportTests(unittest.TestCase):
                 "",
                 "2",
                 "resource-effigy:001",
+                "",
+            ],
+            [
+                "route_under_cited_field_steps",
+                "resource-leather",
+                "Leather Farms",
+                "",
+                "2",
+                "",
+                "resource-leather:001",
             ],
         ]
 
@@ -148,10 +179,11 @@ class CliCsvOutputTests(unittest.TestCase):
                 "shortage_menu",
                 "citation_count",
                 "missing_field_steps",
+                "under_cited_field_steps",
             ],
         )
         for row in rows[1:]:
-            self.assertEqual(len(row), 6)
+            self.assertEqual(len(row), 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an under-cited field step audit to the resource coverage report with text, Markdown, and CSV surfacing
- extend the CSV formatter and regression tests to cover the new column, row type, and CLI expectations
- document the new tooling progress and outstanding follow-ups in agent.md

## Testing
- python -m unittest tests.test_resource_coverage_report
- python3 scripts/resource_coverage_report.py --format text


------
https://chatgpt.com/codex/tasks/task_e_68e41ae81dbc8331bb0ecf7be53bb76a