### PR TITLE
Resolve remaining under-cited resource steps

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -483,3 +483,14 @@ By adhering to these guidelines, the Palmate agent will produce reliable, compre
 1. Source corroborating location or merchant evidence for the remaining seven under-cited routes: Coal (:001/:002), Sulfur (:001), Chikipi Poultry (:001), Refined Ingot (:002), Venom Gland (:001), Katress Hair (:002), and Medium Pal Soul (:001/:002). Prioritise high-signal map exports or wiki raws with explicit coordinates.
 2. Re-run `scripts/resource_coverage_report.py` after each remediation batch and snapshot the Markdown diff so progress stays documented; once the backlog hits zero, add a regression test that locks in the fully cited state.
 3. Audit the regenerated bundle in downstream consumers—the `resource-beautiful-flower` duplicate route warnings persist during rebuilds, so schedule a follow-up to dedupe that route set before the next release.
+
+### 2025-12-17 Dual-citation remediation wave 2
+
+* Cleared the seven outstanding under-cited field steps by layering second sources across Coal, Sulfur, Chikipi Poultry, Refined Ingot, Venom Gland, Katress Hair, and Medium Pal Soul, updating step guidance to call out the corroborating evidence.【F:guides.md†L4163-L4295】【F:guides.md†L5863-L5913】【F:guides.md†L8801-L8874】【F:guides.md†L12239-L12319】【F:guides.md†L14720-L14766】【F:guides.md†L15172-L15199】【F:guides.md†L15493-L15639】
+* Registered new Fandom raw source entries for Chikipi, Helzephyr, and Sootseer to back the added citations and archived the raw pulls under `sources/` for auditability.【F:guides.md†L27823-L27828】【F:guides.md†L28597-L28602】【F:guides.md†L28489-L28494】【F:sources/palfandom-chikipi.txt†L1-L80】【F:sources/palfandom-helzephyr.txt†L1-L80】【F:sources/palfandom-sootseer.txt†L1-L48】
+* Re-ran the coverage report to confirm the under-cited section now reports zero debt, restoring the dual-citation gate to green.【b3aacc†L1-L9】
+
+**Continuation notes:**
+
+1. Fold the `PYTHONPATH=.` invocation into the pytest helper or documentation so coverage-report tests run cleanly without manual environment tweaks.
+2. Keep monitoring new or revised resource guides for dual-source coverage and expand the source registry in tandem to prevent the under-cited queue from resurfacing.

--- a/guides.md
+++ b/guides.md
@@ -4163,7 +4163,7 @@ Coal unlocks Refined Ingot fuel for improved furnaces and automation upgrades. T
       "step_id": "resource-coal:001",
       "type": "gather",
       "summary": "Mine Hillside Cavern nodes",
-      "detail": "Enter Hillside Cavern at 147,-397 northeast of Rayne Syndicate Tower. Clear the Coal, Sulfur, and Ore clusters with a Metal Pickaxe, exiting before weight caps you.【pcgamesn-coal†L135-L138】",
+      "detail": "Enter Hillside Cavern at 147,-397 northeast of Rayne Syndicate Tower. Clear the Coal, Sulfur, and Ore clusters with a Metal Pickaxe, exiting before weight caps you, matching the cave deposits highlighted by PCGamesN and the Fandom acquisition notes.【pcgamesn-coal†L135-L144】【palfandom-coal†L21-L34】",
       "targets": [
         {
           "kind": "item",
@@ -4216,14 +4216,15 @@ Coal unlocks Refined Ingot fuel for improved furnaces and automation upgrades. T
       },
       "branching": [],
       "citations": [
-        "pcgamesn-coal"
+        "pcgamesn-coal",
+        "palfandom-coal"
       ]
     },
     {
       "step_id": "resource-coal:002",
       "type": "gather",
       "summary": "Survey high-yield ridges",
-      "detail": "Once geared, push into the Desiccated Desert ridgeline (~340,-120) and Astral Mountain foothills (~40, 320) where Coal veins respawn quickly but enemies hit much harder.【pcgamesn-coal†L135-L138】",
+      "detail": "Once geared, push into the Desiccated Desert ridgeline (~340,-120) and Astral Mountain foothills (~40, 320) where Coal veins respawn quickly but enemies hit much harder, aligning with PCGamesN's desert sweep and the Fandom callout for Anubis desert deposits.【pcgamesn-coal†L142-L144】【palfandom-coal†L24-L34】",
       "targets": [
         {
           "kind": "item",
@@ -4289,7 +4290,8 @@ Coal unlocks Refined Ingot fuel for improved furnaces and automation upgrades. T
       },
       "branching": [],
       "citations": [
-        "pcgamesn-coal"
+        "pcgamesn-coal",
+        "palfandom-coal"
       ]
     },
     {
@@ -5863,7 +5865,7 @@ Sulfur powers gunpowder and every ballistic upgrade, so this loop opens with the
       "step_id": "resource-sulfur:001",
       "type": "gather",
       "summary": "Mine the Mossanda lava ravine",
-      "detail": "Head northeast of the Mossanda Forest fast travel statue (234,-118) to a lava ravine with early Sulfur nodes; clear the small clusters quickly before heat and encumbrance stack up.【pcgamesn-sulfur†L13-L19】",
+      "detail": "Head northeast of the Mossanda Forest fast travel statue (234,-118) to a lava ravine with early Sulfur nodes; clear the small clusters quickly before heat and encumbrance stack up, mirroring both PCGamesN's route and the Sulfur entry's dungeon-and-volcano guidance.【pcgamesn-sulfur†L13-L19】【palwiki-sulfur†L1-L16】",
       "targets": [
         {
           "kind": "item",
@@ -5906,7 +5908,8 @@ Sulfur powers gunpowder and every ballistic upgrade, so this loop opens with the
       },
       "branching": [],
       "citations": [
-        "pcgamesn-sulfur"
+        "pcgamesn-sulfur",
+        "palwiki-sulfur"
       ]
     },
     {
@@ -8799,7 +8802,7 @@ Chikipi Poultry Harvest Loop corrals the starter meadow flocks, adds a Meat Clea
       "step_id": "resource-chikipi-poultry:001",
       "type": "capture",
       "summary": "Sweep Palbox meadow for Chikipi",
-      "detail": "Teleport to the Windswept Hills statue (~-42,-498) and loop the grass flats, bolaing docile Chikipi before they flock. Scoop ground eggs while you net four prime layers for the ranch.【palwiki-chikipi†L29-L35】",
+      "detail": "Teleport to the Windswept Hills statue (~-42,-498) and loop the grass flats, bolaing docile Chikipi before they flock. Scoop ground eggs while you net four prime layers for the ranch, as both Palworld wiki and the Fandom entry note Windswept Hills as their natural spawn.【palwiki-chikipi†L29-L35】【palfandom-chikipi†L20-L36】",
       "targets": [
         {
           "kind": "pal",
@@ -8867,7 +8870,8 @@ Chikipi Poultry Harvest Loop corrals the starter meadow flocks, adds a Meat Clea
       },
       "branching": [],
       "citations": [
-        "palwiki-chikipi"
+        "palwiki-chikipi",
+        "palfandom-chikipi"
       ]
     },
     {
@@ -12235,7 +12239,7 @@ Refined Ingot Forge Cycle anchors an Improved Furnace hub on the Desiccated Dese
       "step_id": "resource-refined-ingot:002",
       "type": "gather",
       "summary": "Mine ore and coal from the ridge",
-      "detail": "Cycle mining pals through the (191,-36) plateau so coal nodes and ore boulders refill storage between furnace batches.【segmentnext-refined-ingot†L5-L5】",
+      "detail": "Cycle mining pals through the (191,-36) plateau so coal nodes and ore boulders refill storage between furnace batches, leaning on SegmentNext's furnace loop and PCGamesN's note that the Desiccated Desert ridges pack dense coal deposits.【segmentnext-refined-ingot†L5-L5】【pcgamesn-coal†L142-L144】",
       "targets": [
         {
           "kind": "item",
@@ -12310,7 +12314,8 @@ Refined Ingot Forge Cycle anchors an Improved Furnace hub on the Desiccated Dese
         }
       ],
       "citations": [
-        "segmentnext-refined-ingot"
+        "segmentnext-refined-ingot",
+        "pcgamesn-coal"
       ]
     },
     {
@@ -14715,7 +14720,7 @@ Harvest enough Venom Glands to sustain poison ammo, dark saddles, and antidote s
       "step_id": "resource-venom-gland:001",
       "type": "travel",
       "summary": "Stage Plateau south ridge camp",
-      "detail": "Fast travel to Plateau of Beginnings, glide to the southern peninsula, and drop a campfire, bed, and storage at roughly (230,-510) so you can reset night loops quickly.【progameguides-base-triangle†L1-L15】",
+      "detail": "Fast travel to Plateau of Beginnings, glide to the southern peninsula, and drop a campfire, bed, and storage at roughly (230,-510) so you can reset night loops quickly, taking advantage of the Windswept Hills base site the regional overview highlights.【progameguides-base-triangle†L1-L15】【palwiki-windswept-hills†L1-L18】",
       "targets": [],
       "locations": [
         {
@@ -14756,7 +14761,8 @@ Harvest enough Venom Glands to sustain poison ammo, dark saddles, and antidote s
       },
       "branching": [],
       "citations": [
-        "progameguides-base-triangle"
+        "progameguides-base-triangle",
+        "palwiki-windswept-hills"
       ]
     },
     {
@@ -15166,7 +15172,7 @@ Secure Katress Hair for witch gear and speed remedies by chaining Moonless Shore
       "step_id": "resource-katress-hair:002",
       "type": "combat",
       "summary": "Clear Sealed Realm of the Invincible",
-      "detail": "Tackle the level 23 Katress alpha at the Sealed Realm of the Invincible near (241,-330) to secure high-grade drops and a fast travel anchor.【segmentnext-katress†L7-L24】",
+      "detail": "Tackle the level 23 Katress alpha at the Sealed Realm of the Invincible near (241,-330) to secure high-grade drops and a fast travel anchor, lining up with SegmentNext's loop and the sealed realm roster confirming Katress as the encounter.【segmentnext-katress†L7-L24】【palwiki-sealed-realms-raw†L1-L42】",
       "targets": [
         {
           "kind": "pal",
@@ -15215,7 +15221,8 @@ Secure Katress Hair for witch gear and speed remedies by chaining Moonless Shore
       },
       "branching": [],
       "citations": [
-        "segmentnext-katress"
+        "segmentnext-katress",
+        "palwiki-sealed-realms-raw"
       ]
     },
     {
@@ -15487,7 +15494,7 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
       "step_id": "resource-medium-pal-soul:001",
       "type": "hunt",
       "summary": "Intercept Helzephyr above the twin bridges",
-      "detail": "Glide up from the Bridge of the Twin Knights waypoint (~113,-352) after dusk and tag the Helzephyr flock as it circles the northern mesas. Its Medium Pal Soul drop rate is low, so use chain bolas or rifles to secure repeated captures and harvest rare souls along with Venom Glands.【palwiki-helzephyr-raw†L65-L116】",
+      "detail": "Glide up from the Bridge of the Twin Knights waypoint (~113,-352) after dusk and tag the Helzephyr flock as it circles the northern mesas. Its Medium Pal Soul drop rate is low, so use chain bolas or rifles to secure repeated captures and harvest rare souls along with Venom Glands confirmed by both wiki sources.【palwiki-helzephyr-raw†L65-L116】【palfandom-helzephyr†L3-L64】",
       "targets": [
         {
           "kind": "item",
@@ -15554,14 +15561,15 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
       },
       "branching": [],
       "citations": [
-        "palwiki-helzephyr-raw"
+        "palwiki-helzephyr-raw",
+        "palfandom-helzephyr"
       ]
     },
     {
       "step_id": "resource-medium-pal-soul:002",
       "type": "hunt",
       "summary": "Purge Sakurajima Sootseer camps",
-      "detail": "Swoop into Sakurajima’s crater camps after midnight, luring Sootseer pairs out of the purple flame pits. Every takedown yields guaranteed Medium Pal Souls plus Bones and Crude Oil—kite them through open lava channels to avoid getting cornered.【palwiki-sootseer†L65-L114】",
+      "detail": "Swoop into Sakurajima’s crater camps after midnight, luring Sootseer pairs out of the purple flame pits. Every takedown yields guaranteed Medium Pal Souls plus Bones and Crude Oil—kite them through open lava channels to avoid getting cornered, as both wiki versions emphasize their night graveyard presence and drops.【palwiki-sootseer†L65-L114】【palfandom-sootseer†L1-L48】",
       "targets": [
         {
           "kind": "item",
@@ -15627,7 +15635,8 @@ Medium Pal Souls sit at the core of Statue of Power scaling, so this plan charts
       },
       "branching": [],
       "citations": [
-        "palwiki-sootseer"
+        "palwiki-sootseer",
+        "palfandom-sootseer"
       ]
     },
     {
@@ -27811,6 +27820,12 @@ updating guides, refresh these entries with new dates and pages.
       "access_date": "2025-10-01",
       "notes": "States that Chikipi roam the Windswept Hills, lay eggs on the ground, and their Egg Layer partner skill produces eggs at the ranch.【7b6ddf†L1-L27】【c48565†L1-L10】【cca570†L1-L2】"
     },
+    "palfandom-chikipi": {
+      "title": "Chikipi – Palworld Wiki (Fandom, raw)",
+      "url": "https://palworld.fandom.com/wiki/Chikipi?action=raw",
+      "access_date": "2025-12-17",
+      "notes": "Raw page lists Windswept Hills as Chikipi's wild spawn, outlines their docile behaviour, and confirms poultry drops when culled.【palfandom-chikipi†L20-L75】"
+    },
     "palwiki-egg-raw": {
       "title": "Egg – Palworld Wiki (raw)",
       "url": "https://palworld.wiki.gg/index.php?title=Egg&action=raw",
@@ -28471,6 +28486,12 @@ updating guides, refresh these entries with new dates and pages.
       "access_date": "2025-10-18",
       "notes": "Documents the Grave Robber partner skill digging bones at the ranch, guaranteed bone drops, and night spawns across Sakurajima.【palwiki-sootseer†L12-L116】"
     },
+    "palfandom-sootseer": {
+      "title": "Sootseer – Palworld Wiki (Fandom, raw)",
+      "url": "https://palworld.fandom.com/wiki/Sootseer?action=raw",
+      "access_date": "2025-12-17",
+      "notes": "Raw article cites Sakurajima night graveyard spawns and confirms Sootseer drops Medium Pal Souls alongside Bones and Crude Oil.【palfandom-sootseer†L1-L48】"
+    },
     "palwiki-rushoar": {
       "title": "Rushoar – Palworld Wiki",
       "url": "https://palworld.wiki.gg/wiki/Rushoar",
@@ -28572,6 +28593,12 @@ updating guides, refresh these entries with new dates and pages.
       "url": "https://palworld.wiki.gg/index.php?title=Helzephyr&action=raw",
       "access_date": "2025-10-24",
       "notes": "Lists Helzephyr Medium Pal Soul drop chances and describes its nocturnal patrols north of the Bridge of the Twin Knights and Islandhopper Coast waypoints.【palwiki-helzephyr-raw†L65-L116】"
+    },
+    "palfandom-helzephyr": {
+      "title": "Helzephyr – Palworld Wiki (Fandom, raw)",
+      "url": "https://palworld.fandom.com/wiki/Helzephyr?action=raw",
+      "access_date": "2025-12-17",
+      "notes": "Raw infobox lists Medium Pal Soul and Venom Gland drops and shows Helzephyr's nocturnal patrol habitat galleries.【palfandom-helzephyr†L3-L65】"
     },
     "palwiki-killamari": {
       "title": "Killamari – Palworld Wiki",

--- a/sources/palfandom-chikipi.txt
+++ b/sources/palfandom-chikipi.txt
@@ -1,0 +1,116 @@
+{{Pal Prev/Next | prevPal = Cattiva | prevNo = 002 | nextPal = Lifmunk | nextNo = 004}}
+{{Pal
+| name = Chikipi
+| alphatitle = Plump & Juicy
+| image = Chikipi.png
+| no = 003
+| ele1 = Neutral
+| drops = {{i|Egg}}<br/>{{i|Chikipi Poultry}}
+| food = 1
+| partnerskill = Egg Layer
+| psicon =Ranch 
+| psdesc = Sometimes lays an Egg when assigned to Ranch.
+| gathering = 1
+| farming = 1
+| breedpower = 1500
+|maps=<gallery>
+Chikipi Day Habitat.png|Day
+Chikipi Night Habitat.png|Night
+</gallery>}}
+'''Chikipi''' (Japanese: '''タマコッコ''' ''Tamakokko'') is a {{i|Neutral}} [[Elements|element]] [[Pals|Pal]].
+
+== Paldeck Entry==
+{{Paldeck|Extremely weak and far too delicious. It is one of the weakest Pals alongside [[Lamball]]. No matter how many are hunted, they just keep appearing.}}
+==Biology==
+===Appearance===
+Chikipi is a pal resembling a white chicken. Its body is vaguely egg-shaped and it has grey oval eyes. The beak of Chikipi is yellow and features a red wattle. The feet of Chikipi are orange with two clawed toes in the front and one toe at the back of the foot. The top of a Chikipi's head has a large comb that is red just like its waddle.
+
+===Behavior===
+Wild Chikipi may sporadically lay eggs on the ground, which can be picked up by the player. This Pal retaliates only when attacked, though neighboring Chikipi will become aggressive upon witnessing another Chikipi being harmed by the player.
+
+==Availability==
+===Wild Spawn===
+
+* [[Windswept Hills]]
+
+===[[Dungeons]]=== 
+*[[Dungeons#Grass Dungeons|Grass Dungeon Boss]]
+
+<div class="mw-collapsible mw-collapsed">
+=== [[Breeding]] ===
+<div class="mw-collapsible-content">
+{{Cols|2|{{Breeding|Chikipi}}}}
+</div></div>
+
+==Stats==
+{{Pal Table Stats
+|hp=60
+|attack=60
+|defense=60
+|min_hp=2425
+|max_hp=2920
+|min_attack=347
+|max_attack=421
+|max_defense=297
+|min_defense=371
+}}
+==Elemental Effectiveness==
+{{Pal Element Effect|type=neutral}}
+
+==Utility==
+'''Partner Skill:'''
+*Egg Layer - Sometimes lays eggs when assigned to Ranch.
+
+'''Work Suitability:'''
+* {{i|Gathering}} 1
+* {{i|Farming}} 1
+
+'''Possible Drops:''' 
+*Normal
+** {{i|Egg}}
+** {{i|Chikipi Poultry}}
+*Boss
+** {{i|Ancient Civilization Parts}}
+** {{i|Egg }}
+** {{i|Chikipi Poultry}}
+** {{i|Precious Plume}} 
+** {{i|Ring of Resistance}}
+'''Farming Produce''' 
+* {{i|Egg}}
+
+==Active Skills==
+{{PalSkillListStart}}
+{{PalSkillListEntry+|Chicken Rush|level=1}}
+{{PalSkillListEntry+|Air Cannon|level=7}}
+{{PalSkillListEntry+|Power Shot|level=15}}
+{{PalSkillListEntry+|Implode|level=22}}
+{{PalSkillListEntry+|Grass Tornado|level=30}}
+{{PalSkillListEntry+|Sand Tornado|level=40}}
+{{PalSkillListEntry+|Flare Storm|level=50}}
+{{PalSkillListEnd}}
+
+==Update History==
+*[[Early Access 0.1.2.0]]
+**Introduced.
+
+==Trivia== 
+*It was previously called '''Chickegg'''.
+*Chikipi's name may come from “chicken”, “chick”, and “chickpea” due to this Pal's small size.
+*Its Japanese name may come from 卵 ''tamago'' (egg) or simply 玉 ''tama'' (sphere/ball), and コッコ ''kokko'' (onomatopoeia for the sound a chicken makes).
+*Chikipi has:
+**The lowest stat total of all Pals, at 180.
+**The lowest HP of all Pals at 60, tied with [[Fuack]], [[Sparkit]], [[Killamari|Killamari,]] [[Tocotoco]], [[Swee]], and [[Flambelle]].
+*Chikipi was featured in Paldeck No.031 on PocketPair [https://x.com/Palworld_EN/status/1707726930106331431 X] and [https://www.youtube.com/watch?v=iJWqlcX855k youtube channel].
+
+==Gallery==
+<gallery>
+File:Paldeck - No.031 CHIKIPI - Palworld - Gameplay - Pocketpair-2
+File:Chieckegg2.png| A player petting a Chikipi
+File:Chickegg3.png| A player cooking a Chikipi
+File:Chikipi sleep.png|A Chikipi sleeping.
+File:Chikipi Lucky.png|The size difference between a [[Lucky Pals|Lucky]] Chikipi and a normal Chikipi.
+File:Chikipi1.png|Chikipi in Early logo
+</gallery>
+
+{{Navbox Pals}}
+[[Category:Pals with exclusive Skills]]

--- a/sources/palfandom-helzephyr.txt
+++ b/sources/palfandom-helzephyr.txt
@@ -1,0 +1,93 @@
+{{Pal Prev/Next | prevPal = Blazamut Ryu| prevNo = 096B | nextPal = Helzephyr Lux | nextNo = 097B}}
+{{Pal
+| name = Helzephyr
+| alphatitle = Wings of Death
+| image = Helzephyr.png
+| no = 097
+| ele1 = Dark
+| drops = {{i|Venom Gland}}<br/>{{i|Medium Pal Soul}}
+| food = 8
+| partnerskill = Wings of Death
+| psicon =Flying 
+| psdesc = Can be ridden as a flying mount. Applies Dark damage to the player's attacks while mounted.
+| transporting = 3
+| breedpower = 10
+|tech=Helzephyr Saddle|maps=<gallery>
+Helzephyr Day Habitat.png|Day
+Helzephyr Night Habitat.png|Night
+</gallery>}}'''Helzephyr''' (Japanese: '''ヘルガルダ''' ''Hellgaruda'') is a {{i|Dark}} [[Elements|element]] [[Pals|Pal]].
+
+== Paldeck Entry ==
+{{Paldeck|It calls forth lightning from the depths of hell. One who dies from Helzephyr's inferno is sure to be sent to the underworld.}}
+
+== Biology ==
+
+=== Appearance ===
+Helzephyr has mostly black feathers with light blue lightning bolt patterns on its wings and tail. Its face is a deeper shade of light blue, and a vivid purple flame rises from the top of its head.
+
+=== Behavior ===
+A hostile Pal that will attack  the player on sight.
+
+== Availability ==
+
+=== Wild Spawn ===
+
+<div class="mw-collapsible mw-collapsed">
+=== [[Breeding]] ===
+<div class="mw-collapsible-content">
+{{Cols|2|{{Breeding|Helzephyr}}}}
+</div></div>
+
+== Stats ==
+{{Pal Table Stats
+|hp = ???
+|attack = ???
+|defense = ???
+|min_hp = ???
+|max_hp = ???
+|min_attack = ???
+|max_attack = ???
+|min_defense = ???
+|max_defense = ???
+}}
+
+== Elemental Effectiveness ==
+{{Pal Element Effect|type=dark}}
+
+==Utility==
+'''Partner Skill:''' 
+*Wings of Death - Can be ridden as a flying mount. Applies Dark damage to the player's attacks while mounted. (Requires [[Helzephyr Saddle]]→ Unlocks at Lv. 33)
+'''Work Suitability:'''
+*{{i|Transporting}} 3
+'''Possible Drops:'''
+* {{i|Medium Pal Soul}}
+*{{i|Venom Gland}}
+
+==Active Skills==
+{{PalSkillListStart}}
+{{PalSkillListEntry+|Spirit Fire|level=1}}
+{{PalSkillListEntry+|Dark Ball|level=7}}
+{{PalSkillListEntry+|Shadow Burst|level=15}}
+{{PalSkillListEntry+|Flare Storm|level=22}}
+{{PalSkillListEntry+|Spirit Flame|level=30}}
+{{PalSkillListEntry+|Nightmare Ball|level=40}}
+{{PalSkillListEntry+|Dark Laser|level=50}}
+{{PalSkillListEnd}}
+
+==Update History==
+*[[Early Access 0.1.2.0]]
+**Introduced.
+==Trivia==
+
+* Etymology - ''Hel'' is the name of the Goddess of Death in Norse Mythology, and ''Zephyr'' is a Greek word meaning "of the west wind".
+* Its Japanese name may come from ''hell'' and ''Garuda'', which is a large mythical bird that appears in Hindu and Buddhist mythology.
+* Helzephyr was featured in Paldeck No.063 on PocketPair [https://x.com/Palworld_EN/status/1761360325843296659 X] and [https://www.youtube.com/watch?v=E-ElbMWYsaY youtube channel].
+
+==Gallery==
+<gallery>
+Paldeck - No.063 HELZEPHYR - Palworld - Gameplay - Pocketpair-2
+</gallery>
+
+{{Navbox Pals}}
+
+[[Category:Rideable Pals]]

--- a/sources/palfandom-sootseer.txt
+++ b/sources/palfandom-sootseer.txt
@@ -1,0 +1,81 @@
+{{Pal Prev/Next|prevPal=Kikit|prevNo=117|nextPal=Prixter|nextNo=119}}
+{{Pal
+| name = Sootseer
+| alphatitle = Flickering Flame
+| image = Sootseer.png
+| no = 118
+| ele1 = Dark
+| ele2 = Fire
+| drops = {{i|Medium Pal Soul}}<br/>{{i|Bone}}<br/>{{i|Crude Oil}}
+| food = 7
+| partnerskill = Grave Robber
+| psicon = 
+| psdesc = Sometimes digs up Bone when assigned to Ranch.
+| kindling = 3
+| handiwork = 3
+| gathering = 1
+| mining = 2
+| farming = 1
+|maps=Sootseer_Location.png}}'''Sootseer''' (Japanese:'''オドロクロ''' ''Odorokuro)'' is a {{i|Dark}} and {{i|Fire}} [[Pals|Pal]]. It was first shown in the Sakurajima Update trailer.
+
+== Paldeck Entry ==
+{{paldeck|It was once believed that as the world approached its end, the flame would weaken.
+Doomsayers would repeatedly rejoice when the flame began to weaken, but in the end, it turned out to be a prank by Sootseer.
+At least, for now.}}
+==Biology==
+===Appearance===
+Sootseer is a large, ghost-like Pal. It has a round head and body, and doesn't appear to have legs. On its head is a round, white skull with two horns that point up, and two blunt teeth that sit at the bottom. Its eyes are hollow black circles with line green circles inside of them. The rest of its head is ablaze with a lilac coloured flame. It has two arms, the arms long and thin. Its hands are circular, with three diamond shaped claws that point downward on each hand. On the back of the hands, the hands are ablaze with the same lilac flame that the head is. Its arms are a dark purple to black colour. Its torso is a pitch black colour that later turns into the same dark purple to black colour the arms are. Its body ends with a swirl, with no legs in sight.
+
+=== Behavior ===
+This Pal tends to be hostile towards the player.
+== Availability ==
+
+=== Wild Spawn ===
+* Found at night in the graveyard area of Sakurajima.
+
+=== [[Dungeons]] ===
+* Can be encountered in certain dungeons in Sakurajima as Alpha Boss.
+
+<div class="mw-collapsible mw-collapsed">
+===[[Breeding]]===
+<div class="mw-collapsible-content">
+{{Cols|2|{{Breeding|Sootseer}}}}
+</div>
+</div>
+==Stats==
+{{Pal Table Stats
+|hp = 105
+|attack = 125
+|defense = 90
+|min_hp = 4237
+|max_hp = 5261
+|min_attack = 709
+|max_attack = 892
+|min_defense = 488
+|max_defense = 620
+}}
+==Elemental Effectiveness==
+{{Pal Element Effect|type=dark/fire}}
+
+==Utility==
+'''[[Farming|Farming Produce]].'''
+
+* [[Bone]] x1
+
+==Active Skills==
+{{PalSkillListStart}}
+{{PalSkillListEnd}}
+Unknown information.
+
+==Update History==
+* [[Early Access 0.3.1]]
+** Introduced.
+
+==Trivia==
+* Sootseer's name is a corruption of the word "Soothsayer,"  a person who predicts the future by magical, intuitive, or more rational means.
+
+== Gallery ==
+<gallery>
+File:Sootseer flame.png|A Sootseer using its [[Kindling]] ability.
+</gallery>
+{{Navbox Pals}}

--- a/sources/palwiki-sulfur.txt
+++ b/sources/palwiki-sulfur.txt
@@ -1,0 +1,19 @@
+{{Infobox Item
+|name = Sulfur
+|image = Sulfur icon.png 
+|effects = Sulfur that can be found in volcanoes and such.<br/>Necessary for making [[Gunpowder]].
+|type = Material
+|source = [[Mining]]<br/>
+Sulfur rocks<br/>
+{{S|Sulfur Mine}}
+|weight = 3|gold_sell=6}}
+'''Sulfur''' is a [[material]] in {{PW}}.
+
+== Acquisition ==
+It's an advanced crafting component and can be found laying on the ground or by [[mining]] a  large, yellow rock. In the early game you can find them in [[dungeons]], in open world there are a lot of them in the Volcano and Desert regions. You can also receive it from  {{S|Sulfur Mine}} after crafting it.
+
+==Use==
+It's required to craft [[Gunpowder]] to create [[Ammo]].
+
+{{Navbox Materials}}
+[[Category:Materials]]


### PR DESCRIPTION
## Summary
- add dual citations to the remaining coal, sulfur, chikipi poultry, refined ingot, venom gland, katress hair, and medium pal soul field steps
- register new Fandom raw sources plus a sulfur entry to back the extra citations
- log the remediation wave and follow-up work in agent.md

## Testing
- python3 scripts/resource_coverage_report.py --format markdown
- PYTHONPATH=. pytest tests/test_resource_coverage_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e42b70bf088331a6fd9768d00b1c1c