### PR TITLE
Refine resource picker styling and hide vendor-only shortages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -433,9 +433,9 @@ gba(119,141,169,0.45)}
 .route-context__resource-stat-label{font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:rgba(224,225,221,0.68)}
 .route-context__resource-hint{display:grid;gap:12px;padding:16px 18px;border-radius:18px;background:rgba(8,16,32,0.78);border:1px solid rgba(119,141,169,0.38);box-shadow:0 20px 36px rgba(0,0,0,0.48)}
 .route-resource-guides{display:grid;gap:12px}
-.route-resource-guides--empty{gap:10px}
+.route-resource-guides--empty{gap:10px;padding:18px 20px;border-radius:18px;background:rgba(8,16,32,0.82);border:1px dashed rgba(148,210,189,0.4);box-shadow:0 20px 38px rgba(0,0,0,0.5);text-align:center}
 .route-resource-guides__intro{margin:0;font-size:.95rem;font-weight:600;color:rgba(224,225,221,0.85)}
-.route-resource-guides__intro--empty{color:rgba(224,225,221,0.72)}
+.route-resource-guides__intro--empty{color:rgba(224,225,221,0.75)}
 .route-resource-guides__hint{margin:0;font-size:.85rem;color:rgba(224,225,221,0.7)}
 .route-resource-guides__more{margin:0;font-size:.8rem;letter-spacing:.05em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
 .route-resource-guide-list{list-style:none;display:grid;gap:12px;margin:0;padding:0}
@@ -458,14 +458,28 @@ gba(119,141,169,0.45)}
   .route-context__resource-stat{min-width:0}
 }
 .route-context__resource-add{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
-.route-context__resource-add select,.route-context__resource-add input{background:rgba(13,27,42,0.6);border:1px solid rgba(119,141,169,0.35);border-radius:10px;color:var(--text,#f0f4f8);padding:8px 12px;font-size:.95rem;min-width:160px;transition:border-color .2s ease,box-shadow .2s ease}
-.route-context__resource-add select{flex:2 1 220px}
-.route-context__resource-add input{flex:1 1 140px}
-.route-context__resource-add select:focus-visible,.route-context__resource-add input:focus-visible{outline:none;border-color:var(--accent,#778da9);box-shadow:0 0 0 2px rgba(119,141,169,0.35)}
+.route-context__resource-add input{background:rgba(13,27,42,0.6);border:1px solid rgba(119,141,169,0.35);border-radius:10px;color:var(--text,#f0f4f8);padding:8px 12px;font-size:.95rem;min-width:140px;transition:border-color .2s ease,box-shadow .2s ease;flex:1 1 140px}
+.route-context__resource-add input:focus-visible{outline:none;border-color:var(--accent,#778da9);box-shadow:0 0 0 2px rgba(119,141,169,0.35)}
 .route-context__resource-add-btn{flex:0 0 auto}
+.route-resource-picker{position:relative;display:flex;flex-direction:column;flex:2 1 260px;min-width:220px}
+.route-resource-picker__toggle{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 14px;border-radius:12px;border:1px solid rgba(119,141,169,0.38);background:rgba(13,27,42,0.7);color:var(--text,#f0f4f8);font:inherit;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease,transform .2s ease}
+.route-resource-picker__toggle:hover,.route-resource-picker__toggle:focus-visible{outline:none;border-color:rgba(148,210,189,0.45);box-shadow:0 12px 24px rgba(0,0,0,0.45);transform:translateY(-1px)}
+.route-resource-picker__toggle-label{font-size:.95rem;font-weight:600;letter-spacing:.03em}
+.route-resource-picker__toggle-icon{font-size:.85rem;color:rgba(224,225,221,0.75);transition:transform .2s ease}
+.route-resource-picker--open .route-resource-picker__toggle-icon{transform:rotate(180deg)}
+.route-resource-picker__panel{position:absolute;top:calc(100% + 8px);left:0;right:0;z-index:5;padding:12px;border-radius:16px;background:rgba(8,16,32,0.92);border:1px solid rgba(119,141,169,0.45);box-shadow:0 24px 48px rgba(0,0,0,0.58);max-height:320px;overflow:auto;backdrop-filter:blur(6px)}
+.route-resource-picker__list{display:grid;gap:8px}
+.route-resource-option{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 12px;border-radius:12px;border:1px solid rgba(148,210,189,0.32);background:linear-gradient(135deg,rgba(20,36,54,0.92),rgba(12,24,40,0.92));color:var(--text,#f0f4f8);font:inherit;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease,transform .2s ease}
+.route-resource-option:hover,.route-resource-option:focus-visible{outline:none;border-color:rgba(148,210,189,0.55);box-shadow:0 18px 34px rgba(148,210,189,0.18);transform:translateY(-1px)}
+.route-resource-option--active{border-color:rgba(224,255,244,0.6);box-shadow:0 18px 34px rgba(148,210,189,0.24)}
+.route-resource-option--queued{border-style:dashed;border-color:rgba(148,210,189,0.32);color:rgba(224,225,221,0.7)}
+.route-resource-option__label{font-size:.9rem;font-weight:600;letter-spacing:.02em}
+.route-resource-option__status{font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
+.route-resource-option__empty{margin:0;font-size:.85rem;color:rgba(224,225,221,0.68);text-align:center;padding:6px 0}
 @media (max-width:600px){
   .route-context__resource-add{flex-direction:column;align-items:stretch}
-  .route-context__resource-add select,.route-context__resource-add input{min-width:0;width:100%}
+  .route-resource-picker{width:100%}
+  .route-context__resource-add input{min-width:0;width:100%}
   .route-context__resource-add-btn{width:100%}
 }
 .route-context__resource-list{display:flex;flex-wrap:wrap;gap:8px}

--- a/index.html
+++ b/index.html
@@ -10612,6 +10612,21 @@
 
     const RESOURCE_ITEM_TYPE_WHITELIST = new Set(['material', 'materials', 'ingredient', 'ingredients', 'food']);
     const RESOURCE_ITEM_CATEGORY_WHITELIST = new Set(['material', 'food']);
+    const RESOURCE_SHORTAGE_MENU_EXCLUSIONS = new Set([
+      'diamond',
+      'ruby',
+      'sapphire',
+      'gumoss_leaf',
+      'penking_plume',
+      'mushroom',
+      'raw_dumud',
+      'raw_kelpsea',
+      'rushoar_pork',
+      'mammorest_meat',
+      'reindrix_venison',
+      'eikthyrdeer_venison',
+      'tocotoco_feather'
+    ]);
 
     function isResourceItemId(itemId){
       if(!itemId) return false;
@@ -10716,6 +10731,7 @@
         .sort((a, b) => itemDisplayName(a).localeCompare(itemDisplayName(b), undefined, { sensitivity: 'base' }));
       const resourceGuides = {};
       const missingResourceGuides = [];
+      const filteredResources = [];
       sortedResources.forEach(itemId => {
         const routesForItem = resourceRoutes.has(itemId)
           ? Array.from(resourceRoutes.get(itemId))
@@ -10741,7 +10757,11 @@
               .slice(0, 2)
           };
         });
+        if(!entries.length && RESOURCE_SHORTAGE_MENU_EXCLUSIONS.has(itemId)){
+          return;
+        }
         resourceGuides[itemId] = entries;
+        filteredResources.push(itemId);
         if(!entries.length){
           missingResourceGuides.push(itemId);
         }
@@ -10755,7 +10775,7 @@
         chapters,
         routeLookup,
         tags: Array.from(tagSet).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
-        keyResources: sortedResources,
+        keyResources: filteredResources,
         resourceGuides,
         resourceGuideGaps: missingResourceGuides,
         extras: parsed?.extras || [],
@@ -14159,13 +14179,28 @@
       const resourceChips = context.resourceGaps.length
         ? context.resourceGaps.map(entry => renderResourceGapChip(entry)).join('')
         : `<p class="route-context__empty">${escapeHTML(kidMode ? 'Add items you are missing.' : 'Add resource gaps to surface farming routes.')}</p>`;
-      const optionsHtml = resourceOptions.length
+      const resourcePickerLabel = kidMode ? 'Pick a resource' : 'Select a resource';
+      const resourceOptionButtons = resourceOptions.length
         ? resourceOptions.map(itemId => {
             const guides = Array.isArray(resourceGuideMap[itemId]) ? resourceGuideMap[itemId] : [];
-            const guideCountAttr = ` data-guide-count="${guides.length}"`;
-            return `<option value="${escapeHTML(itemId)}"${guideCountAttr}>${escapeHTML(itemDisplayName(itemId))}</option>`;
+            const guideCount = guides.length;
+            const classes = ['route-resource-option'];
+            if(guideCount === 0){
+              classes.push('route-resource-option--queued');
+            }
+            const status = guideCount
+              ? (kidMode
+                ? `${guideCount} plan${guideCount === 1 ? '' : 's'}`
+                : `${guideCount} guide${guideCount === 1 ? '' : 's'}`)
+              : (kidMode ? 'Queued' : 'Queued');
+            return `
+              <button type="button" class="${classes.join(' ')}" data-resource-option="${escapeHTML(itemId)}" data-guide-count="${guideCount}">
+                <span class="route-resource-option__label">${escapeHTML(itemDisplayName(itemId))}</span>
+                <span class="route-resource-option__status">${escapeHTML(status)}</span>
+              </button>
+            `;
           }).join('')
-        : '';
+        : `<p class="route-resource-option__empty">${escapeHTML(kidMode ? 'Resources load soon.' : 'Resources load shortly.')}</p>`;
       const levelSliderValue = levelValue === '' ? 1 : levelValue;
       const sliderEmptyAttr = levelValue === '' ? ' data-empty="true"' : '';
       return `
@@ -14215,10 +14250,19 @@
               </div>
               <div class="route-context__resources">
                 <div class="route-context__resource-add">
-                  <select id="routeResourceSelect">
-                    <option value="">${escapeHTML(kidMode ? 'Pick a resource' : 'Select a resource')}</option>
-                    ${optionsHtml}
-                  </select>
+                  <div class="route-resource-picker" data-resource-picker>
+                    <button type="button" class="route-resource-picker__toggle" data-resource-toggle aria-expanded="false">
+                      <span class="route-resource-picker__toggle-label" data-resource-toggle-label>${escapeHTML(resourcePickerLabel)}</span>
+                      <i class="fa-solid fa-chevron-down route-resource-picker__toggle-icon" data-resource-toggle-icon aria-hidden="true"></i>
+                      <span class="sr-only">${escapeHTML(kidMode ? 'Open resource menu' : 'Open resource menu')}</span>
+                    </button>
+                    <div class="route-resource-picker__panel" data-resource-panel hidden>
+                      <div class="route-resource-picker__list">
+                        ${resourceOptionButtons}
+                      </div>
+                    </div>
+                    <input type="hidden" id="routeResourceSelect" value="" />
+                  </div>
                   <input type="number" id="routeResourceQty" min="1" max="999" placeholder="${escapeHTML(kidMode ? 'Qty' : 'Qty')}" />
                   <button type="button" class="btn route-context__resource-add-btn" data-action="add-resource-gap">${escapeHTML(kidMode ? 'Add' : 'Add')}</button>
                 </div>
@@ -14961,11 +15005,74 @@
       const resourceQty = card.querySelector('#routeResourceQty');
       const resourceList = card.querySelector('#routeResourceList');
       const resourceHelp = card.querySelector('#routeResourceGuideHint');
+      const resourcePicker = card.querySelector('[data-resource-picker]');
+      const resourcePanel = resourcePicker?.querySelector('[data-resource-panel]');
+      const resourceToggle = resourcePicker?.querySelector('[data-resource-toggle]');
+      const resourceToggleIcon = resourcePicker?.querySelector('[data-resource-toggle-icon]');
+      const resourceToggleLabel = resourcePicker?.querySelector('[data-resource-toggle-label]');
+      const resourcePlaceholderLabel = kidMode ? 'Pick a resource' : 'Select a resource';
+      let resourcePickerOpen = false;
       const renderResourceHelp = itemId => {
         if(resourceHelp){
           resourceHelp.innerHTML = renderResourceGuideHelp(itemId);
         }
       };
+      const applyResourcePickerState = () => {
+        if(resourcePanel){
+          if(resourcePickerOpen){
+            resourcePanel.removeAttribute('hidden');
+          } else {
+            resourcePanel.setAttribute('hidden', '');
+          }
+        }
+        if(resourceToggle){
+          resourceToggle.setAttribute('aria-expanded', resourcePickerOpen ? 'true' : 'false');
+        }
+        if(resourceToggleIcon){
+          resourceToggleIcon.classList.toggle('fa-chevron-up', resourcePickerOpen);
+          resourceToggleIcon.classList.toggle('fa-chevron-down', !resourcePickerOpen);
+        }
+        if(resourcePicker){
+          resourcePicker.classList.toggle('route-resource-picker--open', resourcePickerOpen);
+        }
+      };
+      const updateResourceToggleLabel = itemId => {
+        if(!resourceToggleLabel) return;
+        if(itemId){
+          resourceToggleLabel.textContent = itemDisplayName(itemId);
+        } else {
+          resourceToggleLabel.textContent = resourcePlaceholderLabel;
+        }
+      };
+      const highlightResourceOption = itemId => {
+        if(!resourcePicker) return;
+        resourcePicker.querySelectorAll('[data-resource-option]').forEach(btn => {
+          const active = btn?.dataset?.resourceOption === itemId;
+          btn.classList.toggle('route-resource-option--active', active);
+        });
+      };
+      if(resourceToggle){
+        resourceToggle.addEventListener('click', () => {
+          resourcePickerOpen = !resourcePickerOpen;
+          applyResourcePickerState();
+        }, { signal });
+      }
+      if(resourcePicker){
+        resourcePicker.addEventListener('click', event => {
+          const option = event.target.closest('[data-resource-option]');
+          if(!option) return;
+          const itemId = option.dataset.resourceOption || '';
+          if(resourceSelect){
+            resourceSelect.value = itemId;
+            const changeEvent = new Event('change', { bubbles: false });
+            resourceSelect.dispatchEvent(changeEvent);
+          } else {
+            renderResourceHelp(itemId);
+          }
+          resourcePickerOpen = false;
+          applyResourcePickerState();
+        }, { signal });
+      }
       const addButton = card.querySelector('[data-action="add-resource-gap"]');
       if(addButton && resourceSelect){
         addButton.addEventListener('click', () => {
@@ -14984,7 +15091,10 @@
       }
       if(resourceSelect){
         resourceSelect.addEventListener('change', () => {
-          renderResourceHelp(resourceSelect.value);
+          const value = resourceSelect.value || '';
+          updateResourceToggleLabel(value);
+          highlightResourceOption(value);
+          renderResourceHelp(value);
         }, { signal });
       }
       if(resourceHelp){
@@ -14998,6 +15108,9 @@
           }
         }, { signal });
       }
+      updateResourceToggleLabel(resourceSelect ? resourceSelect.value : '');
+      highlightResourceOption(resourceSelect ? resourceSelect.value : '');
+      applyResourcePickerState();
       if(resourceList){
         resourceList.addEventListener('click', event => {
           const chip = event.target.closest('[data-resource-id]');


### PR DESCRIPTION
## Summary
- hide vendor-only sale items from the resource shortage picker so the backlog only shows farmable targets
- replace the resource dropdown with a styled picker that matches the goal drawer experience and highlights queued items
- refresh the empty-state styling so queued shortages present as an on-brand card

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45e682b3c83319a986d71d2739ad1