### PR TITLE
Fix item chip navigation and add related guides

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -38,6 +38,12 @@ background-size:140% auto,120% auto,cover,cover;background-position:var(--guide-
 .chip__thumb{width:42px;height:42px;border-radius:14px;overflow:hidden;flex:0 0 42px;background:rgba(148,210,189,0.15);box-shadow:0 14px 26px rgba(4,14,28,0.45);display:grid;place-items:center}
 .chip__thumb img{width:100%;height:100%;object-fit:cover;display:block}
 .chip.link.link--with-thumb{padding:10px 20px}
+.item-detail-guides{display:flex;flex-direction:column;gap:12px}
+.item-guide-chip-list{display:flex;flex-wrap:wrap;gap:10px}
+.item-guide-chip{cursor:pointer;background:rgba(148,210,189,0.14);border-color:rgba(148,210,189,0.38);padding:10px 16px;transition:transform .2s ease,box-shadow .25s ease,border-color .25s ease}
+.item-guide-chip:hover{border-color:rgba(148,210,189,0.65);box-shadow:0 16px 28px rgba(148,210,189,0.2);transform:translateY(-1px)}
+.item-guide-chip:focus-visible{outline:2px solid rgba(148,210,189,0.7);outline-offset:2px;box-shadow:0 16px 28px rgba(148,210,189,0.2);border-color:rgba(148,210,189,0.65)}
+.item-guide-chip .chip__meta{font-size:.7rem;letter-spacing:.05em;text-transform:uppercase;color:rgba(224,225,221,0.65)}
 .chip__body{display:flex;flex-direction:column;align-items:flex-start;gap:2px;min-width:0}
 .chip__label{font-weight:600;font-size:.9rem;line-height:1.2;color:var(--text,#f0f4f8)}
 .chip__meta{font-size:.7rem;letter-spacing:.04em;text-transform:uppercase;color:rgba(224,225,221,0.7);line-height:1.2}

--- a/data/item_details.json
+++ b/data/item_details.json
@@ -350,9 +350,9 @@
     ],
     "stats": {},
     "recipe": [],
-    "image": "https://static.wikia.nocookie.net/palworld/images/4/4a/Flour_icon.png/revision/latest?cb=20240124060459",
-    "fromPalworld": false,
-    "source": "Palworld Fandom"
+    "image": "https://palworld.gg/_ipx/q_80&s_60x60/images/items/T_itemicon_Material_Flour.png",
+    "fromPalworld": true,
+    "source": "Palworld.gg"
   },
   "flame_organ": {
     "name": "Flame Organ",

--- a/data/item_details_fallback.js
+++ b/data/item_details_fallback.js
@@ -351,9 +351,9 @@ window.__PALMATE_ITEM_DETAILS__ = {
     ],
     "stats": {},
     "recipe": [],
-    "image": "https://static.wikia.nocookie.net/palworld/images/4/4a/Flour_icon.png/revision/latest?cb=20240124060459",
-    "fromPalworld": false,
-    "source": "Palworld Fandom"
+    "image": "https://palworld.gg/_ipx/q_80&s_60x60/images/items/T_itemicon_Material_Flour.png",
+    "fromPalworld": true,
+    "source": "Palworld.gg"
   },
   "flame_organ": {
     "name": "Flame Organ",

--- a/index.html
+++ b/index.html
@@ -4456,6 +4456,7 @@
     let PASSIVE_DETAILS = {};
     let ITEM_DETAILS = {};
     let PARTNER_SKILLS = [];
+    let ITEM_KEY_LOOKUP = new Map();
     // Map of items to pals that drop them.  Populated after data load.
     let DROPS_MAP = {};
     // Map pal names to IDs for quick lookup when clicking breeding
@@ -6204,6 +6205,97 @@
         .filter(Boolean)
         .map(part => part.charAt(0).toUpperCase() + part.slice(1))
         .join(' ');
+    }
+
+    function normalizeItemLookupKey(value) {
+      if (value == null) return '';
+      return String(value).trim().toLowerCase();
+    }
+
+    function registerItemAlias(alias, key) {
+      const normalized = normalizeItemLookupKey(alias);
+      if (!normalized || !key) return;
+      const variants = new Set([normalized]);
+      const collapsed = normalized.replace(/[\s_-]+/g, ' ').trim();
+      if (collapsed) {
+        variants.add(collapsed);
+        variants.add(collapsed.replace(/\s+/g, '-'));
+        variants.add(collapsed.replace(/\s+/g, '_'));
+      }
+      variants.forEach(variant => {
+        if (!variant) return;
+        if (!ITEM_KEY_LOOKUP.has(variant)) {
+          ITEM_KEY_LOOKUP.set(variant, key);
+        }
+      });
+    }
+
+    function rebuildItemLookup() {
+      ITEM_KEY_LOOKUP = new Map();
+      const keys = new Set([
+        ...Object.keys(ITEMS || {}),
+        ...Object.keys(ITEM_DETAILS || {})
+      ]);
+      keys.forEach(key => {
+        if (!key) return;
+        registerItemAlias(key, key);
+        const friendly = humaniseItemKey(key);
+        registerItemAlias(friendly, key);
+        const slug = slugifyForPalworld(friendly);
+        if (slug) registerItemAlias(slug, key);
+        const item = ITEMS?.[key];
+        if (item?.name) registerItemAlias(item.name, key);
+        const detail = ITEM_DETAILS?.[key];
+        if (detail?.name) registerItemAlias(detail.name, key);
+        if (Array.isArray(detail?.aliases)) {
+          detail.aliases.forEach(alias => registerItemAlias(alias, key));
+        }
+      });
+    }
+
+    function lookupItemKey(value) {
+      if (!value) return null;
+      const normalized = normalizeItemLookupKey(value);
+      if (!normalized) return null;
+      if (ITEM_KEY_LOOKUP.has(normalized)) {
+        return ITEM_KEY_LOOKUP.get(normalized);
+      }
+      const collapsed = normalized.replace(/[\s_-]+/g, ' ').trim();
+      if (collapsed) {
+        if (ITEM_KEY_LOOKUP.has(collapsed)) {
+          return ITEM_KEY_LOOKUP.get(collapsed);
+        }
+        const hyphenated = collapsed.replace(/\s+/g, '-');
+        if (ITEM_KEY_LOOKUP.has(hyphenated)) {
+          return ITEM_KEY_LOOKUP.get(hyphenated);
+        }
+        const underscored = collapsed.replace(/\s+/g, '_');
+        if (ITEM_KEY_LOOKUP.has(underscored)) {
+          return ITEM_KEY_LOOKUP.get(underscored);
+        }
+      }
+      const slug = slugifyForPalworld(value);
+      if (slug) {
+        const slugKey = normalizeItemLookupKey(slug);
+        if (ITEM_KEY_LOOKUP.has(slugKey)) {
+          return ITEM_KEY_LOOKUP.get(slugKey);
+        }
+      }
+      return null;
+    }
+
+    function resolveItemKeyFromLink(link) {
+      if (!link || typeof link !== 'object') return null;
+      const candidates = [];
+      if (link.id != null) candidates.push(link.id);
+      if (link.slug != null) candidates.push(link.slug);
+      if (link.name != null) candidates.push(link.name);
+      if (link.title != null) candidates.push(link.title);
+      for (const candidate of candidates) {
+        const resolved = lookupItemKey(candidate);
+        if (resolved) return resolved;
+      }
+      return null;
     }
     function normalizeRanchAssignment(raw) {
       if (!raw || typeof raw !== 'object') return null;
@@ -8252,6 +8344,7 @@
         SKILL_DETAILS = payload.skillsDetails || {};
         PASSIVE_DETAILS = payload.passiveDetails || {};
         ITEM_DETAILS = await loadItemDetails();
+        rebuildItemLookup();
         PARTNER_SKILLS = await loadPartnerSkillDataset();
         // Build name‑to‑ID lookup map
         PAL_NAME_TO_ID = {};
@@ -17521,11 +17614,12 @@
           focusSearch(link.slug || link.id, { target: 'pals' });
         }
       } else if(link.type === 'item'){
-        const itemKey = link.id || link.slug;
-        if(itemKey && ITEMS[itemKey]){
+        const itemKey = resolveItemKeyFromLink(link);
+        if(itemKey && (ITEMS[itemKey] || ITEM_DETAILS[itemKey])){
           openItemDetail(itemKey);
         } else {
-          focusSearch(itemKey, { target: 'items' });
+          const fallbackTerm = link.name || niceName(link.id || link.slug || '');
+          focusSearch(fallbackTerm, { target: 'items' });
         }
       } else if(link.type === 'tech'){
         showTechDetail(link.id);
@@ -19570,6 +19664,68 @@
       const card = document.createElement('article');
       card.className = 'item-detail-card';
 
+      let dropSection = null;
+      let guidesRendered = false;
+      const renderGuideChips = (data) => {
+        if (guidesRendered || !data) return;
+        const entries = Array.isArray(data?.resourceGuides?.[itemKey]) ? data.resourceGuides[itemKey] : [];
+        if (!entries.length) return;
+        const guideSection = document.createElement('section');
+        guideSection.className = 'item-detail-section item-detail-guides';
+        const guideHeading = document.createElement('h4');
+        guideHeading.textContent = kidMode ? 'Guides to start' : 'Guide shortcuts';
+        guideSection.appendChild(guideHeading);
+        const chipsWrap = document.createElement('div');
+        chipsWrap.className = 'item-guide-chip-list';
+        entries.forEach(entry => {
+          if (!entry || !entry.id) return;
+          const chip = document.createElement('button');
+          chip.type = 'button';
+          chip.className = 'chip item-guide-chip';
+          chip.dataset.routeId = entry.id;
+          const body = document.createElement('span');
+          body.className = 'chip__body';
+          const label = document.createElement('span');
+          label.className = 'chip__label';
+          label.textContent = entry.title || niceName(entry.id);
+          body.appendChild(label);
+          const metaParts = [];
+          if (entry.levelLabel) metaParts.push(entry.levelLabel);
+          if (entry.timeLabel) metaParts.push(entry.timeLabel);
+          if (metaParts.length) {
+            const meta = document.createElement('span');
+            meta.className = 'chip__meta';
+            meta.textContent = metaParts.join(' • ');
+            body.appendChild(meta);
+          }
+          chip.appendChild(body);
+          const tooltipParts = [];
+          if (entry.summary) tooltipParts.push(entry.summary);
+          if (Array.isArray(entry.shortageNotes) && entry.shortageNotes.length) {
+            tooltipParts.push(entry.shortageNotes[0]);
+          }
+          if (tooltipParts.length) {
+            chip.title = tooltipParts.join(' • ');
+          }
+          chip.addEventListener('click', () => {
+            openRoutePreviewById(entry.id);
+          });
+          chipsWrap.appendChild(chip);
+        });
+        if (!chipsWrap.children.length) return;
+        const count = chipsWrap.children.length;
+        guideHeading.textContent = kidMode
+          ? (count === 1 ? 'Guide to start' : 'Guides to start')
+          : (count === 1 ? 'Guide shortcut' : 'Guide shortcuts');
+        guideSection.appendChild(chipsWrap);
+        if (dropSection && dropSection.parentNode === card) {
+          card.insertBefore(guideSection, dropSection);
+        } else {
+          card.appendChild(guideSection);
+        }
+        guidesRendered = true;
+      };
+
       const header = document.createElement('div');
       header.className = 'item-detail-header';
       const headingWrap = document.createElement('div');
@@ -19714,7 +19870,13 @@
       }
       card.appendChild(summarySection);
 
-      const dropSection = document.createElement('section');
+      if (routeGuideData && routeGuideData.resourceGuides) {
+        renderGuideChips(routeGuideData);
+      } else {
+        ensureRouteGuide().then(renderGuideChips).catch(() => {});
+      }
+
+      dropSection = document.createElement('section');
       dropSection.className = 'item-detail-section';
       const dropHeading = document.createElement('h4');
       dropHeading.textContent = 'Dropped by';


### PR DESCRIPTION
## Summary
- normalize item key lookup so multi-word item chips resolve and open the correct details
- surface related guide shortcuts in the item detail modal with dedicated styling
- restore Beautiful Flower to the Palworld.gg dataset and update Flour with a working Palworld.gg image

## Testing
- not run (static site changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e472e7be608331b751ac4248b85cf6